### PR TITLE
Rectify typo in NodeJS docs

### DIFF
--- a/emailpassword/docs/serverless/with-aws-lambda/backend-config.md
+++ b/emailpassword/docs/serverless/with-aws-lambda/backend-config.md
@@ -31,7 +31,7 @@ In the API gateway, you will need to specify a [stage](https://docs.aws.amazon.c
 ```js
 
 let EmailPassword = require('supertokens-node/recipe/emailpassword');
-let Session = reqiure('supertokens-node/recipe/session')
+let Session = require('supertokens-node/recipe/session')
 
 function getBackendConfig() {
   return {

--- a/emailpassword/docs/serverless/with-netlify/backend-config.md
+++ b/emailpassword/docs/serverless/with-netlify/backend-config.md
@@ -29,7 +29,7 @@ This function will return the config object used to configure `supertokens-node`
 ```js
 
 let EmailPassword = require('supertokens-node/recipe/emailpassword');
-let Session = reqiure('supertokens-node/recipe/session')
+let Session = require('supertokens-node/recipe/session')
 
 function getBackendConfig() {
   return {

--- a/session/docs/serverless/with-aws-lambda/backend-config.md
+++ b/session/docs/serverless/with-aws-lambda/backend-config.md
@@ -26,7 +26,7 @@ This function will return the config object used to configure `supertokens-node`
 <!--config.js-->
 ```js
 
-let Session = reqiure('supertokens-node/recipe/session')
+let Session = require('supertokens-node/recipe/session')
 
 function getBackendConfig() {
   return {

--- a/session/docs/serverless/with-netlify/backend-config.md
+++ b/session/docs/serverless/with-netlify/backend-config.md
@@ -28,7 +28,7 @@ This function will return the config object used to configure `supertokens-node`
 <!--/config/supertokensConfig.js-->
 ```js
 
-let Session = reqiure('supertokens-node/recipe/session')
+let Session = require('supertokens-node/recipe/session')
 
 function getBackendConfig() {
   return {

--- a/thirdparty/docs/serverless/with-aws-lambda/backend-config.md
+++ b/thirdparty/docs/serverless/with-aws-lambda/backend-config.md
@@ -28,7 +28,7 @@ This function will return the config object used to configure `supertokens-node`
 ```js
 
 let ThirdParty = require('supertokens-node/recipe/thirdparty');
-let Session = reqiure('supertokens-node/recipe/session')
+let Session = require('supertokens-node/recipe/session')
 
 function getBackendConfig() {
   return {

--- a/thirdparty/docs/serverless/with-netlify/backend-config.md
+++ b/thirdparty/docs/serverless/with-netlify/backend-config.md
@@ -30,7 +30,7 @@ This function will return the config object used to configure `supertokens-node`
 ```js
 
 let ThirdParty = require('supertokens-node/recipe/thirdparty');
-let Session = reqiure('supertokens-node/recipe/session')
+let Session = require('supertokens-node/recipe/session')
 
 function getBackendConfig() {
   return {

--- a/thirdpartyemailpassword/docs/serverless/with-aws-lambda/backend-config.md
+++ b/thirdpartyemailpassword/docs/serverless/with-aws-lambda/backend-config.md
@@ -28,7 +28,7 @@ This function will return the config object used to configure `supertokens-node`
 ```js
 
 let ThirdPartyEmailPassword = require('supertokens-node/recipe/thirdpartyemailpassword');
-let Session = reqiure('supertokens-node/recipe/session')
+let Session = require('supertokens-node/recipe/session')
 
 function getBackendConfig() {
   return {

--- a/thirdpartyemailpassword/docs/serverless/with-netlify/backend-config.md
+++ b/thirdpartyemailpassword/docs/serverless/with-netlify/backend-config.md
@@ -30,7 +30,7 @@ This function will return the config object used to configure `supertokens-node`
 ```js
 
 let ThirdPartyEmailPassword = require('supertokens-node/recipe/thirdpartyemailpassword');
-let Session = reqiure('supertokens-node/recipe/session')
+let Session = require('supertokens-node/recipe/session')
 
 function getBackendConfig() {
   return {


### PR DESCRIPTION
There were several instances of `reqiure` which wouldn't have worked.

Small PR to rectify this