### PR TITLE
changes to sql type of userId for email verification

### DIFF
--- a/v2/community/database-setup/mysql.mdx
+++ b/v2/community/database-setup/mysql.mdx
@@ -127,13 +127,13 @@ CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
 
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     token VARCHAR(128) NOT NULL UNIQUE,
     token_expiry BIGINT UNSIGNED NOT NULL,

--- a/v2/community/database-setup/postgresql.mdx
+++ b/v2/community/database-setup/postgresql.mdx
@@ -132,13 +132,13 @@ CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
 
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     token VARCHAR(128) NOT NULL UNIQUE,
     token_expiry BIGINT NOT NULL,

--- a/v2/emailpassword/quick-setup/database-setup/mysql.mdx
+++ b/v2/emailpassword/quick-setup/database-setup/mysql.mdx
@@ -127,13 +127,13 @@ CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
 
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     token VARCHAR(128) NOT NULL UNIQUE,
     token_expiry BIGINT UNSIGNED NOT NULL,

--- a/v2/emailpassword/quick-setup/database-setup/postgresql.mdx
+++ b/v2/emailpassword/quick-setup/database-setup/postgresql.mdx
@@ -132,13 +132,13 @@ CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
 
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     token VARCHAR(128) NOT NULL UNIQUE,
     token_expiry BIGINT NOT NULL,

--- a/v2/session/quick-setup/database-setup/mysql.mdx
+++ b/v2/session/quick-setup/database-setup/mysql.mdx
@@ -127,13 +127,13 @@ CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
 
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     token VARCHAR(128) NOT NULL UNIQUE,
     token_expiry BIGINT UNSIGNED NOT NULL,

--- a/v2/session/quick-setup/database-setup/postgresql.mdx
+++ b/v2/session/quick-setup/database-setup/postgresql.mdx
@@ -132,13 +132,13 @@ CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
 
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     token VARCHAR(128) NOT NULL UNIQUE,
     token_expiry BIGINT NOT NULL,

--- a/v2/thirdparty/quick-setup/database-setup/mysql.mdx
+++ b/v2/thirdparty/quick-setup/database-setup/mysql.mdx
@@ -127,13 +127,13 @@ CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
 
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     token VARCHAR(128) NOT NULL UNIQUE,
     token_expiry BIGINT UNSIGNED NOT NULL,

--- a/v2/thirdparty/quick-setup/database-setup/postgresql.mdx
+++ b/v2/thirdparty/quick-setup/database-setup/postgresql.mdx
@@ -132,13 +132,13 @@ CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
 
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     token VARCHAR(128) NOT NULL UNIQUE,
     token_expiry BIGINT NOT NULL,

--- a/v2/thirdpartyemailpassword/quick-setup/database-setup/mysql.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/database-setup/mysql.mdx
@@ -127,13 +127,13 @@ CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
 
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     token VARCHAR(128) NOT NULL UNIQUE,
     token_expiry BIGINT UNSIGNED NOT NULL,

--- a/v2/thirdpartyemailpassword/quick-setup/database-setup/postgresql.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/database-setup/postgresql.mdx
@@ -132,13 +132,13 @@ CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
 
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
-    user_id CHAR(36) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
     token VARCHAR(128) NOT NULL UNIQUE,
     token_expiry BIGINT NOT NULL,


### PR DESCRIPTION
## Summary of change
- Made `CHAR(36)` to `VARCHAR(128) for UserId type in non auth recipes.

## Related issues
- https://github.com/supertokens/supertokens-core/issues/258