### PR TITLE
Update appinfo.mdx for the sessions only recipe

### DIFF
--- a/v2/session/appinfo.mdx
+++ b/v2/session/appinfo.mdx
@@ -18,15 +18,16 @@ This is the name of your application. It is used when sending password reset or 
 
 ## `websiteDomain` (compulsory)
 
-This is the domain part of your website. This is where the login UI will be shown. For example:
+This is the domain part of your website. For example:
 - For local development, you are likely using `localhost` with some port (ex `8080`). Then the value of this should be `"http://localhost:8080"`.
 - If your website is `https://www.example.com`, then the value of this should be `"https://www.example.com"`.
 - If your website is `https://example.com`, then the value of this should be `"https://example.com"`.
 - If you have multiple sub domains, and your users login via `https://auth.example.com`, then the value of this should be `"https://auth.example.com"`.
+- If you have multiple sub domains with their own login pages (ex `'https://staff.example.com/login'` and `'https://user.example.com/login'`), then the value of this should be the main domain `"https://example.com"` on the backend, and on each frontend, it should be the respective subdomain `"https://staff.example.com"` and `"https://user.example.com"`.
 
-By default, the login UI will be displayed on `{websiteDomain}/auth/*`. This can be changed by using the `websiteBasePath` config.
+On the frontend, we need the domain for routing purposes.
 
-On the frontend, we need the domain for routing purposes, and on the backend, we need it so that we can generate correct email verification and password reset links.
+Note: In case you are using multiple subdomains with their own login pages and only one backend, you should attach a variable to the session JWT when creating a session for a user (on login), which holds the identity of the frontend for which it is being issued for. This can be used in request routes after session verification to make sure that the session has permission to land on this route.
 
 ------------
 
@@ -37,21 +38,11 @@ This is the domain part of your API endpoint that the frontend talks to. For exa
 - If your frontend queries `https://api.example.com/*`, then the value of this should be `"https://api.example.com"`
 - If your API endpoint is reached via `/api/*`, then the value of this is the same as the `websiteDomain` - since `/api/*` is equal to querying `{websiteDomain}/api/*`.
 
-By default, our login widgets will query `{apiDomain}/auth/*`. This can be changed by using the `apiBasePath` config.
-
 ------------
 
 ## `websiteBasePath` (optional)
 
-By default, the login UI will be displayed on `{websiteDomain}/auth`. Other auth related UIs will be shown on `{websiteDomain}/auth/*`.
-
-If you want to change the `/auth` to something else, then you must set this value. For example:
-- If you want the login UI to show on `{websiteDomain}/user/*`, then the value of this should be `"/user"`.
-- If you are using a dedicated sub domain for auth, like `https://auth.example.com`, then you probably want the login UI to show up on `https://auth.example.com`. In this case, set this value to `"/"`.
-
-:::important
-Remember to set the same value for this param on the backend and the frontend.
-:::
+There is no need to define this for the `session only` recipe. This is used to display the login ui and handle the login system in other recipes.
 
 ------------
 


### PR DESCRIPTION
AppInfo page updated specifically for the sessions only recipe, since neither email/password reset links will be created and nor login ui will displayed by the supertokens library.

## Summary of change
Removed setup requirements which were solely for login system functioning.

## Related issues
- https://discord.com/channels/603466164219281420/644849840475602944/873090349277532171

## Remaining TODOs for this PR
- Make it more concise.