### PR TITLE
Replaced function async with async function

### DIFF
--- a/v2/emailpassword/common-customizations/redirect-to-auth.mdx
+++ b/v2/emailpassword/common-customizations/redirect-to-auth.mdx
@@ -19,7 +19,7 @@ Use the `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean}?)` 
 import { redirectToAuth } from "supertokens-auth-react/recipe/emailpassword";
 
 function NavBar () {
-  function async onLogin () {
+  async function onLogin () {
     // highlight-next-line
     redirectToAuth();
   }

--- a/v2/session/common-customizations/sign-out.mdx
+++ b/v2/session/common-customizations/sign-out.mdx
@@ -22,7 +22,7 @@ The [`signOut` method](/docs/auth-react/^{docsLinkRecipeName}/sign-out) revokes 
 import { signOut } from "supertokens-auth-react/recipe/^{codeImportRecipeName}";
 
 function NavBar () {
-  function async onLogout () {
+  async function onLogout () {
       // highlight-next-line
       await signOut();
       window.location.href = "/";
@@ -47,7 +47,7 @@ The [`signOut` method](/docs/website/usage/sign-out) revokes the session for the
 // highlight-next-line
 import SuperTokens from "supertokens-website";
 
-function async logout () {
+async function logout () {
   // highlight-next-line
   await SuperTokens.signOut(); 
   window.location.href = "/";

--- a/v2/thirdparty/common-customizations/redirect-to-auth.mdx
+++ b/v2/thirdparty/common-customizations/redirect-to-auth.mdx
@@ -19,7 +19,7 @@ Use the `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean}?)` 
 import { redirectToAuth } from "supertokens-auth-react/recipe/thirdparty";
 
 function NavBar () {
-  function async onLogin () {
+  async function onLogin () {
     // highlight-next-line
     redirectToAuth(); 
   }

--- a/v2/thirdparty/common-customizations/sign-out.mdx
+++ b/v2/thirdparty/common-customizations/sign-out.mdx
@@ -22,7 +22,7 @@ The [`signOut` method](/docs/auth-react/^{docsLinkRecipeName}/sign-out) revokes 
 import { signOut } from "supertokens-auth-react/recipe/^{codeImportRecipeName}";
 
 function NavBar () {
-  function async onLogout () {
+  async function onLogout () {
       // highlight-next-line
       await signOut();
       window.location.href = "/";
@@ -47,7 +47,7 @@ The [`signOut` method](/docs/website/usage/sign-out) revokes the session for the
 // highlight-next-line
 import SuperTokens from "supertokens-website";
 
-function async logout () {
+async function logout () {
   // highlight-next-line
   await SuperTokens.signOut(); 
   window.location.href = "/";

--- a/v2/thirdpartyemailpassword/common-customizations/redirect-to-auth.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/redirect-to-auth.mdx
@@ -19,7 +19,7 @@ Use the `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean}?)` 
 import { redirectToAuth } from "supertokens-auth-react/recipe/thirdpartyemailpassword";
 
 function NavBar () {
-  function async onLogin () {
+  async function onLogin () {
     // highlight-next-line
     redirectToAuth(); 
   }

--- a/v2/thirdpartyemailpassword/common-customizations/sign-out.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sign-out.mdx
@@ -22,7 +22,7 @@ The [`signOut` method](/docs/auth-react/^{docsLinkRecipeName}/sign-out) revokes 
 import { signOut } from "supertokens-auth-react/recipe/^{codeImportRecipeName}";
 
 function NavBar () {
-  function async onLogout () {
+  async function onLogout () {
       // highlight-next-line
       await signOut();
       window.location.href = "/";
@@ -47,7 +47,7 @@ The [`signOut` method](/docs/website/usage/sign-out) revokes the session for the
 // highlight-next-line
 import SuperTokens from "supertokens-website";
 
-function async logout () {
+async function logout () {
   // highlight-next-line
   await SuperTokens.signOut(); 
   window.location.href = "/";


### PR DESCRIPTION
## Summary of change
Replaced `function async` with `async function` as the latter is the syntactically correct one.

## Related issues

## Remaining TODOs for this PR
