### PR TITLE
docs: clarity on axios interceptors

### DIFF
--- a/v2/emailpassword/quick-setup/frontend.mdx
+++ b/v2/emailpassword/quick-setup/frontend.mdx
@@ -239,8 +239,8 @@ class App extends React.Components {
 
 ## 5️) Add `axios` session interceptor
 :::important
-- This step is only applicable if you are using `axios`
-- You must call `addAxiosInterceptors` on all `axios` imports.
+- This step is only applicable if you are using `axios`.
+- You must call `addAxiosInterceptors` on all `axios` imports if you're using axios to make http calls directly or on each axios instance created.
 :::
 
 <FrontendSDKTabs>

--- a/v2/session/quick-setup/frontend.mdx
+++ b/v2/session/quick-setup/frontend.mdx
@@ -91,8 +91,8 @@ SuperTokens.init({
 ## 3️) Add `axios` session interceptor
 
 :::important
-- This step is only applicable if you are using `axios`
-- You must call `addAxiosInterceptors` on all `axios` imports.
+- This step is only applicable if you are using `axios`.
+- You must call `addAxiosInterceptors` on all `axios` imports if you're using the imported axios to make http calls directly or on each axios instance created.
 :::
 
 <FrontendSDKTabs>

--- a/v2/thirdparty/quick-setup/frontend.mdx
+++ b/v2/thirdparty/quick-setup/frontend.mdx
@@ -246,8 +246,8 @@ class App extends React.Components {
 
 ## 5️) Add `axios` session interceptor
 :::important
-- This step is only applicable if you are using `axios`
-- You must call the `addAxiosInterceptors` on all `axios` imports
+- This step is only applicable if you are using `axios`.
+- You must call `addAxiosInterceptors` on all `axios` imports if you're using axios to make http calls directly or on each axios instance created.
 :::
 
 

--- a/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
@@ -243,8 +243,8 @@ class App extends React.Components {
 
 ## 5️) Add `axios` session interceptor
 :::important
-- This step is only applicable if you are using `axios`
-- You must call `addAxiosInterceptors` on all `axios` imports.
+- This step is only applicable if you are using `axios`.
+- You must call `addAxiosInterceptors` on all `axios` imports if you're using axios to make http calls directly or on each axios instance created.
 :::
 
 <FrontendSDKTabs>


### PR DESCRIPTION
## Summary of change

Added clarity on the usage of the axios interceptors in the description.

Current description gives the wrong impression that it should always be set on the axios import but this doesn't work if we're not directly using the imported static axios object such as when [creating an axios instance](https://github.com/axios/axios#creating-an-instance) and using that instance throughout the codebase instead of importing axios everywhere. 