### PR TITLE
Add create query for jwt_signing_keys table for MySQL and PostgresSQL

### DIFF
--- a/v2/community/database-setup/mysql.mdx
+++ b/v2/community/database-setup/mysql.mdx
@@ -159,6 +159,14 @@ CREATE TABLE IF NOT EXISTS thirdparty_users (
     time_joined BIGINT UNSIGNED NOT NULL,
     PRIMARY KEY (third_party_id, third_party_user_id)
 );
+
+CREATE TABLE IF NOT EXISTS jwt_signing_keys (
+    key_id VARCHAR(255) NOT NULL,
+    key_string TEXT NOT NULL,
+    algorithm VARCHAR(10) NOT NULL,
+    created_at BIGINT UNSIGNED,
+    PRIMARY KEY(key_id)
+);
 ```
 
 :::tip

--- a/v2/community/database-setup/postgresql.mdx
+++ b/v2/community/database-setup/postgresql.mdx
@@ -164,6 +164,14 @@ CREATE TABLE IF NOT EXISTS thirdparty_users (
     time_joined BIGINT NOT NULL,
     PRIMARY KEY (third_party_id, third_party_user_id)
 );
+
+CREATE TABLE IF NOT EXISTS jwt_signing_keys (
+    key_id VARCHAR(255) NOT NULL,
+    key_string TEXT NOT NULL,
+    algorithm VARCHAR(10) NOT NULL,
+    created_at BIGINT,
+    PRIMARY KEY(key_id)
+);
 ```
 
 :::tip

--- a/v2/emailpassword/quick-setup/database-setup/mysql.mdx
+++ b/v2/emailpassword/quick-setup/database-setup/mysql.mdx
@@ -159,6 +159,14 @@ CREATE TABLE IF NOT EXISTS thirdparty_users (
     time_joined BIGINT UNSIGNED NOT NULL,
     PRIMARY KEY (third_party_id, third_party_user_id)
 );
+
+CREATE TABLE IF NOT EXISTS jwt_signing_keys (
+    key_id VARCHAR(255) NOT NULL,
+    key_string TEXT NOT NULL,
+    algorithm VARCHAR(10) NOT NULL,
+    created_at BIGINT UNSIGNED,
+    PRIMARY KEY(key_id)
+);
 ```
 
 :::tip

--- a/v2/emailpassword/quick-setup/database-setup/postgresql.mdx
+++ b/v2/emailpassword/quick-setup/database-setup/postgresql.mdx
@@ -164,6 +164,14 @@ CREATE TABLE IF NOT EXISTS thirdparty_users (
     time_joined BIGINT NOT NULL,
     PRIMARY KEY (third_party_id, third_party_user_id)
 );
+
+CREATE TABLE IF NOT EXISTS jwt_signing_keys (
+    key_id VARCHAR(255) NOT NULL,
+    key_string TEXT NOT NULL,
+    algorithm VARCHAR(10) NOT NULL,
+    created_at BIGINT,
+    PRIMARY KEY(key_id)
+);
 ```
 
 :::tip

--- a/v2/session/quick-setup/database-setup/mysql.mdx
+++ b/v2/session/quick-setup/database-setup/mysql.mdx
@@ -159,6 +159,14 @@ CREATE TABLE IF NOT EXISTS thirdparty_users (
     time_joined BIGINT UNSIGNED NOT NULL,
     PRIMARY KEY (third_party_id, third_party_user_id)
 );
+
+CREATE TABLE IF NOT EXISTS jwt_signing_keys (
+    key_id VARCHAR(255) NOT NULL,
+    key_string TEXT NOT NULL,
+    algorithm VARCHAR(10) NOT NULL,
+    created_at BIGINT UNSIGNED,
+    PRIMARY KEY(key_id)
+);
 ```
 
 :::tip

--- a/v2/session/quick-setup/database-setup/postgresql.mdx
+++ b/v2/session/quick-setup/database-setup/postgresql.mdx
@@ -164,6 +164,14 @@ CREATE TABLE IF NOT EXISTS thirdparty_users (
     time_joined BIGINT NOT NULL,
     PRIMARY KEY (third_party_id, third_party_user_id)
 );
+
+CREATE TABLE IF NOT EXISTS jwt_signing_keys (
+    key_id VARCHAR(255) NOT NULL,
+    key_string TEXT NOT NULL,
+    algorithm VARCHAR(10) NOT NULL,
+    created_at BIGINT,
+    PRIMARY KEY(key_id)
+);
 ```
 
 :::tip

--- a/v2/thirdparty/quick-setup/database-setup/mysql.mdx
+++ b/v2/thirdparty/quick-setup/database-setup/mysql.mdx
@@ -159,6 +159,14 @@ CREATE TABLE IF NOT EXISTS thirdparty_users (
     time_joined BIGINT UNSIGNED NOT NULL,
     PRIMARY KEY (third_party_id, third_party_user_id)
 );
+
+CREATE TABLE IF NOT EXISTS jwt_signing_keys (
+    key_id VARCHAR(255) NOT NULL,
+    key_string TEXT NOT NULL,
+    algorithm VARCHAR(10) NOT NULL,
+    created_at BIGINT UNSIGNED,
+    PRIMARY KEY(key_id)
+);
 ```
 
 :::tip

--- a/v2/thirdparty/quick-setup/database-setup/postgresql.mdx
+++ b/v2/thirdparty/quick-setup/database-setup/postgresql.mdx
@@ -164,6 +164,14 @@ CREATE TABLE IF NOT EXISTS thirdparty_users (
     time_joined BIGINT NOT NULL,
     PRIMARY KEY (third_party_id, third_party_user_id)
 );
+
+CREATE TABLE IF NOT EXISTS jwt_signing_keys (
+    key_id VARCHAR(255) NOT NULL,
+    key_string TEXT NOT NULL,
+    algorithm VARCHAR(10) NOT NULL,
+    created_at BIGINT,
+    PRIMARY KEY(key_id)
+);
 ```
 
 :::tip

--- a/v2/thirdpartyemailpassword/quick-setup/database-setup/mysql.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/database-setup/mysql.mdx
@@ -159,6 +159,14 @@ CREATE TABLE IF NOT EXISTS thirdparty_users (
     time_joined BIGINT UNSIGNED NOT NULL,
     PRIMARY KEY (third_party_id, third_party_user_id)
 );
+
+CREATE TABLE IF NOT EXISTS jwt_signing_keys (
+    key_id VARCHAR(255) NOT NULL,
+    key_string TEXT NOT NULL,
+    algorithm VARCHAR(10) NOT NULL,
+    created_at BIGINT UNSIGNED,
+    PRIMARY KEY(key_id)
+);
 ```
 
 :::tip

--- a/v2/thirdpartyemailpassword/quick-setup/database-setup/postgresql.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/database-setup/postgresql.mdx
@@ -164,6 +164,14 @@ CREATE TABLE IF NOT EXISTS thirdparty_users (
     time_joined BIGINT NOT NULL,
     PRIMARY KEY (third_party_id, third_party_user_id)
 );
+
+CREATE TABLE IF NOT EXISTS jwt_signing_keys (
+    key_id VARCHAR(255) NOT NULL,
+    key_string TEXT NOT NULL,
+    algorithm VARCHAR(10) NOT NULL,
+    created_at BIGINT,
+    PRIMARY KEY(key_id)
+);
 ```
 
 :::tip


### PR DESCRIPTION
## Summary of change
Adds the `CREATE TABLE` queries for jwt_signing_keys for both MySQL and PostgresSQL to all recipe database setup docs (under the create tables section)

## Related issues
- https://github.com/supertokens/for-zenhub/issues/16