### PR TITLE
Add JWT docs to NodeJS SDK reference

### DIFF
--- a/v2/nodejs/jwt/createJWT.mdx
+++ b/v2/nodejs/jwt/createJWT.mdx
@@ -7,7 +7,7 @@ hide_title: true
 ## `createJWT(payload, validitySeconds)`
 
 ### Parameters
-- `payload`
+- `payload` (Optional)
   - type: `any`
   - Must be a valid JSON
 

--- a/v2/nodejs/jwt/createJWT.mdx
+++ b/v2/nodejs/jwt/createJWT.mdx
@@ -1,0 +1,26 @@
+---
+id: createJWT
+title: createJWT
+hide_title: true
+---
+
+## `createJWT(payload, validity)`
+
+### Parameters
+- `payload`
+  - type: `any`
+  - Must be a valid JSON
+
+- `validity` (Optional)
+  - type: `number`
+  - Must be greater than 0
+
+### Returns
+```ts
+Promise<{
+    status: "OK",
+    jwt: string,
+} | {
+    status: "UNSUPPORTED_ALGORITHM_ERROR",
+}>
+```

--- a/v2/nodejs/jwt/createJWT.mdx
+++ b/v2/nodejs/jwt/createJWT.mdx
@@ -4,14 +4,14 @@ title: createJWT
 hide_title: true
 ---
 
-## `createJWT(payload, validity)`
+## `createJWT(payload, validitySeconds)`
 
 ### Parameters
 - `payload`
   - type: `any`
   - Must be a valid JSON
 
-- `validity` (Optional)
+- `validitySeconds` (Optional)
   - type: `number`
   - Must be greater than 0
 

--- a/v2/nodejs/jwt/getJWKS.mdx
+++ b/v2/nodejs/jwt/getJWKS.mdx
@@ -1,0 +1,24 @@
+---
+id: getJWKS
+title: getJWKS
+hide_title: true
+---
+
+## `getJWKS()`
+
+### Returns
+```ts
+type JsonWebKey = {
+    kty: string;
+    kid: string;
+    n: string;
+    e: string;
+    alg: string;
+    use: string;
+};
+
+Promise<{
+    status: "OK",
+    keys: JsonWebKey[],
+}>
+```

--- a/v2/nodejs/jwt/init.mdx
+++ b/v2/nodejs/jwt/init.mdx
@@ -5,7 +5,7 @@ hide_title: true
 ---
 
 ```jsx
-JWTRecipe.init({
+JWT.init({
     jwtValiditySeconds?: number,
     override?: {
         functions?: function,

--- a/v2/nodejs/jwt/init.mdx
+++ b/v2/nodejs/jwt/init.mdx
@@ -1,0 +1,25 @@
+---
+id: init
+title: init
+hide_title: true
+---
+
+```jsx
+JWTRecipe.init({
+    jwtValiditySeconds?: number,
+    override?: {
+        functions?: function,
+        apis?: function,
+    }
+})
+```
+
+## Parameters
+### `jwtValiditySeconds` (Optional)
+- The validity in seconds to use when creating JWTs.
+- Default: If this option is not provided and no validity is provided to the [createJWT](./createJWT) function, the validity used is `3153600000` (100 years in seconds)
+
+### `override` (Optional)
+- Use this feature to override how this recipe behaves.
+- Default: `undefined`
+

--- a/v2/nodejs/jwt/override/apis.mdx
+++ b/v2/nodejs/jwt/override/apis.mdx
@@ -1,0 +1,310 @@
+---
+id: apis
+title: Overriding APIs
+---
+
+import NodeJSFrameworkSubTabs from "/src/components/tabs/NodeJSFrameworkSubTabs"
+
+## Main interface
+
+```jsx
+    /*
+    * Called to return all JWKs that can be used for JWT verification
+    * 
+    * @method GET
+    * 
+    * @params: set it to undefined to disable the API.
+    *           - options: See APIOptions below
+    * 
+    * @returns "OK" and array of keys (refer to JsonWebKey below for typedef)
+    */
+    getJWKSGET:
+        | undefined
+        | ((input: { 
+                options: APIOptions 
+            }) => Promise<{ 
+                status: "OK"; 
+                keys: JsonWebKey[];
+            }>)
+```
+
+## Supporting Types
+
+<NodeJSFrameworkSubTabs>
+<TabItem value="express">
+
+```tsx
+interface BaseRequest {
+    original: Express.Request;
+    getKeyValueFromQuery: (key: string) => Promise<string | undefined>;
+    getJSONBody: () => Promise<any>;
+    getMethod: () => HTTPMethod;
+    getCookieValue: (key_: string) => string | undefined;
+    getHeaderValue: (key: string) => string | undefined;
+    getOriginalURL: () => string;
+}
+
+interface BaseResponse {
+    original: Express.Response;
+    setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    setCookie: (
+        key: string,
+        value: string,
+        domain: string | undefined,
+        secure: boolean,
+        httpOnly: boolean,
+        expires: number,
+        path: string,
+        sameSite: "strict" | "lax" | "none"
+    ) => void;
+    setStatusCode: (statusCode: number) => void;
+    sendJSONResponse: (content: any) => void;
+}
+```
+</TabItem>
+<TabItem value="hapi">
+
+```tsx
+interface BaseRequest {
+    original: Hapi.Request;
+    getKeyValueFromQuery: (key: string) => Promise<string | undefined>;
+    getJSONBody: () => Promise<any>;
+    getMethod: () => HTTPMethod;
+    getCookieValue: (key_: string) => string | undefined;
+    getHeaderValue: (key: string) => string | undefined;
+    getOriginalURL: () => string;
+}
+
+interface BaseResponse {
+    original: Hapi.ResponseToolkit;
+    setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    setCookie: (
+        key: string,
+        value: string,
+        domain: string | undefined,
+        secure: boolean,
+        httpOnly: boolean,
+        expires: number,
+        path: string,
+        sameSite: "strict" | "lax" | "none"
+    ) => void;
+    setStatusCode: (statusCode: number) => void;
+    sendJSONResponse: (content: any) => void;
+}
+```
+</TabItem>
+
+<TabItem value="fastify">
+
+```tsx
+interface BaseRequest {
+    original: Fastify.FastifyRequest;
+    getKeyValueFromQuery: (key: string) => Promise<string | undefined>;
+    getJSONBody: () => Promise<any>;
+    getMethod: () => HTTPMethod;
+    getCookieValue: (key_: string) => string | undefined;
+    getHeaderValue: (key: string) => string | undefined;
+    getOriginalURL: () => string;
+}
+
+interface BaseResponse {
+    original: Fastify.FastifyReply;
+    setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    setCookie: (
+        key: string,
+        value: string,
+        domain: string | undefined,
+        secure: boolean,
+        httpOnly: boolean,
+        expires: number,
+        path: string,
+        sameSite: "strict" | "lax" | "none"
+    ) => void;
+    setStatusCode: (statusCode: number) => void;
+    sendJSONResponse: (content: any) => void;
+}
+```
+</TabItem>
+
+<TabItem value="awsLambda">
+
+```tsx
+interface BaseRequest {
+    original: AWS.APIGatewayProxyEvent | AWS.APIGatewayProxyEventV2;
+    getKeyValueFromQuery: (key: string) => Promise<string | undefined>;
+    getJSONBody: () => Promise<any>;
+    getMethod: () => HTTPMethod;
+    getCookieValue: (key_: string) => string | undefined;
+    getHeaderValue: (key: string) => string | undefined;
+    getOriginalURL: () => string;
+}
+
+interface BaseResponse {
+    original: AWS.APIGatewayProxyEvent | AWS.APIGatewayProxyEventV2;
+    setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    setCookie: (
+        key: string,
+        value: string,
+        domain: string | undefined,
+        secure: boolean,
+        httpOnly: boolean,
+        expires: number,
+        path: string,
+        sameSite: "strict" | "lax" | "none"
+    ) => void;
+    setStatusCode: (statusCode: number) => void;
+    sendJSONResponse: (content: any) => void;
+}
+```
+</TabItem>
+
+<TabItem value="koa">
+
+```tsx
+interface BaseRequest {
+    original: Koa.Context;
+    getKeyValueFromQuery: (key: string) => Promise<string | undefined>;
+    getJSONBody: () => Promise<any>;
+    getMethod: () => HTTPMethod;
+    getCookieValue: (key_: string) => string | undefined;
+    getHeaderValue: (key: string) => string | undefined;
+    getOriginalURL: () => string;
+}
+
+interface BaseResponse {
+    original: Koa.Context;
+    setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    setCookie: (
+        key: string,
+        value: string,
+        domain: string | undefined,
+        secure: boolean,
+        httpOnly: boolean,
+        expires: number,
+        path: string,
+        sameSite: "strict" | "lax" | "none"
+    ) => void;
+    setStatusCode: (statusCode: number) => void;
+    sendJSONResponse: (content: any) => void;
+}
+```
+</TabItem>
+
+<TabItem value="loopback">
+
+```tsx
+interface BaseRequest {
+    original: Loopback.MiddlewareContext;
+    getKeyValueFromQuery: (key: string) => Promise<string | undefined>;
+    getJSONBody: () => Promise<any>;
+    getMethod: () => HTTPMethod;
+    getCookieValue: (key_: string) => string | undefined;
+    getHeaderValue: (key: string) => string | undefined;
+    getOriginalURL: () => string;
+}
+
+interface BaseResponse {
+    original: Loopback.MiddlewareContext;
+    setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    setCookie: (
+        key: string,
+        value: string,
+        domain: string | undefined,
+        secure: boolean,
+        httpOnly: boolean,
+        expires: number,
+        path: string,
+        sameSite: "strict" | "lax" | "none"
+    ) => void;
+    setStatusCode: (statusCode: number) => void;
+    sendJSONResponse: (content: any) => void;
+}
+```
+</TabItem>
+<TabItem value="nextjs">
+
+```tsx
+interface BaseRequest {
+    original: Next.NextApiRequest;
+    getKeyValueFromQuery: (key: string) => Promise<string | undefined>;
+    getJSONBody: () => Promise<any>;
+    getMethod: () => HTTPMethod;
+    getCookieValue: (key_: string) => string | undefined;
+    getHeaderValue: (key: string) => string | undefined;
+    getOriginalURL: () => string;
+}
+
+interface BaseResponse {
+    original: Next.NextApiResponse;
+    setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    setCookie: (
+        key: string,
+        value: string,
+        domain: string | undefined,
+        secure: boolean,
+        httpOnly: boolean,
+        expires: number,
+        path: string,
+        sameSite: "strict" | "lax" | "none"
+    ) => void;
+    setStatusCode: (statusCode: number) => void;
+    sendJSONResponse: (content: any) => void;
+}
+```
+</TabItem>
+<TabItem value="nestjs">
+
+```tsx
+interface BaseRequest {
+    // NestJS uses library-specific types for Request and Response
+    // You should use the one provided by your underlying framework (the default is Express)
+    original: Express.Request;
+    getKeyValueFromQuery: (key: string) => Promise<string | undefined>;
+    getJSONBody: () => Promise<any>;
+    getMethod: () => HTTPMethod;
+    getCookieValue: (key_: string) => string | undefined;
+    getHeaderValue: (key: string) => string | undefined;
+    getOriginalURL: () => string;
+}
+
+interface BaseResponse {
+    // NestJS uses library-specific types for Request and Response
+    // You should use the one provided by your underlying framework (the default is Express)
+    original: Express.Response;
+    setHeader: (key: string, value: string, allowDuplicateKey: boolean) => void;
+    setCookie: (
+        key: string,
+        value: string,
+        domain: string | undefined,
+        secure: boolean,
+        httpOnly: boolean,
+        expires: number,
+        path: string,
+        sameSite: "strict" | "lax" | "none"
+    ) => void;
+    setStatusCode: (statusCode: number) => void;
+    sendJSONResponse: (content: any) => void;
+}
+```
+</TabItem>
+</NodeJSFrameworkSubTabs>
+
+```tsx
+type APIOptions = {
+    recipeImplementation: RecipeInterface;
+    config: TypeNormalisedInput;
+    recipeId: string;
+    isInServerlessEnv: boolean;
+    req: BaseRequest;
+    res: BaseResponse;
+};
+
+type JsonWebKey = {
+    kty: string;
+    kid: string;
+    n: string;
+    e: string;
+    alg: string;
+    use: string;
+};
+```

--- a/v2/nodejs/jwt/override/functions.mdx
+++ b/v2/nodejs/jwt/override/functions.mdx
@@ -11,14 +11,14 @@ export interface RecipeInterface {
     * Called to create a signed JWT
     * 
     * @params: 
-    *   - payload: Object containing custom claims that shuld be included in the JWT payload
+    *   - payload: (Optional) Object containing custom claims that shuld be included in the JWT payload
     *   - validitySeconds: (Optional) Time in seconds for which the JWT should be considered valid.
     *                      if this is undefined, the validity provided to the init function is used
     * 
     * @returns "OK" and the JWT if succesfull. "UNSUPPORTED_ALGORITHM_ERROR" if an unsupported signing algorithm is used
     */
     createJWT(input: {
-        payload: any;
+        payload?: any;
         validitySeconds?: number;
     }): Promise<
         | {

--- a/v2/nodejs/jwt/override/functions.mdx
+++ b/v2/nodejs/jwt/override/functions.mdx
@@ -1,0 +1,56 @@
+---
+id: functions
+title: Overriding Functions
+---
+
+## Main interface
+
+```tsx
+export interface RecipeInterface {
+    /*
+    * Called to create a signed JWT
+    * 
+    * @params: 
+    *   - payload: Object containing custom claims that shuld be included in the JWT payload
+    *   - validitySeconds: (Optional) Time in seconds for which the JWT should be considered valid.
+    *                      if this is undefined, the validity provided to the init function is used
+    * 
+    * @returns "OK" and the JWT if succesfull. "UNSUPPORTED_ALGORITHM_ERROR" if an unsupported signing algorithm is used
+    */
+    createJWT(input: {
+        payload: any;
+        validitySeconds?: number;
+    }): Promise<
+        | {
+              status: "OK";
+              jwt: string;
+          }
+        | {
+              status: "UNSUPPORTED_ALGORITHM_ERROR";
+          }
+    >;
+
+    /*
+    * Called to retrieve a list of JWKs that can be used for JWT verification
+    * 
+    * @returns "OK" and an array of keys (refer to JsonWebKey below for typedef)
+    */
+    getJWKS(): Promise<{
+        status: "OK";
+        keys: JsonWebKey[];
+    }>;
+}
+```
+
+## Supporting Types
+
+```tsx
+export type JsonWebKey = {
+    kty: string;
+    kid: string;
+    n: string;
+    e: string;
+    alg: string;
+    use: string;
+};
+```

--- a/v2/nodejs/sidebars.js
+++ b/v2/nodejs/sidebars.js
@@ -147,6 +147,14 @@ module.exports = {
         "jwt/init",
         "jwt/createJWT",
         "jwt/getJWKS",
+        {
+          type: 'category',
+          label: 'Override',
+          items: [
+            "jwt/override/apis",
+            "jwt/override/functions"
+          ],
+        },
       ]
     }
   ],

--- a/v2/nodejs/sidebars.js
+++ b/v2/nodejs/sidebars.js
@@ -140,5 +140,14 @@ module.exports = {
         },
       ],
     },
+    {
+      type: 'category',
+      label: 'JWT',
+      items: [
+        "jwt/init",
+        "jwt/createJWT",
+        "jwt/getJWKS",
+      ]
+    }
   ],
 };


### PR DESCRIPTION
## Summary of change
Adds function docs for the JWT recipe to NodeJS SDK reference docs

## Related issues
- https://github.com/supertokens/for-zenhub/issues/16

## Related pull requests
- https://github.com/supertokens/supertokens-node/pull/181