### PR TITLE
Moved SDK init into a service in NestJS guide

### DIFF
--- a/v2/emailpassword/nestjs/guide.mdx
+++ b/v2/emailpassword/nestjs/guide.mdx
@@ -9,7 +9,8 @@ hide_title: true
 ## Overview
 
 Integrating SuperTokens into a NestJS backend is a bit different than the quick setup guide shows. We will add a few things:
-- A module to initialize the SDK
+- A module to house all authorization related code
+- A service to initialize the SDK
 - A middleware to add the authorization endpoints
 - A global error handler to pass SuperTokens related errors to the SDK
 - A guard to protect your API endpoints
@@ -25,53 +26,67 @@ Please look [here](https://docs.nestjs.com/first-steps) to see how to get starte
 npm i -s supertokens-node
 ```
 
-## 2) Adding a new module and initializing SuperTokens
-
-:::important
-- Please make sure to replace all the `appInfo` configurations values with yours.
-- To learn more about filling in `appInfo`, please visit [the appInfo page](../appinfo)
-- If you would like to configure a specific path for you APIs, you can do so by setting the `apiBasePath` value in the config. For example, if your API path is `www.example.com/api` then you can set the value of `apiBasePath` to `/api`.
-:::
+## 2) Adding a new module
 
 You can scaffold a module using the nest CLI by running this in the root folder of the application:
 ```bash
 nest g module auth
 ```
-The result should be a new `auth` folder with `auth.module.ts` in it. We should convert this into a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) to make sure that we only initialize SuperTokens once. As a bonus, you can set parts of the SuperTokens configuration in the App module. Centralizing settings like this can be helpful for things like setting separate connection URI for testing.
+The result should be a new `auth` folder with `auth.module.ts` in it. We should convert this into a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can set parts of the SuperTokens configuration in the App module. Centralizing settings like this can be helpful for things like using a separate connection URI for testing.
+
+### Add config type and injection token
+
+Add a `config.ts` file next into the `auth` folder. We will put the type and injection token for the SuperTokens config here.
 
 ```ts
-import { DynamicModule, Module } from "@nestjs/common";
+import { AppInfo } from "supertokens-node/lib/build/types";
 
-import supertokens from 'supertokens-node';
-import Session from 'supertokens-node/recipe/session';
-import EmailPassword from 'supertokens-node/recipe/emailpassword';
+export const ConfigInjectionToken = "ConfigInjectionToken";
+
+export type AuthModuleConfig = {
+  appInfo: AppInfo;
+  connectionURI: string;
+  apiKey?: string;
+}
+```
+
+### Convert to a dynamic module
+
+We want to configure this module in the App module, so we add a static `forRoot` method and convert it into a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules).
+
+```ts
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  DynamicModule,
+} from '@nestjs/common';
+
+import { AuthMiddleware } from './auth.middleware';
+import { ConfigProviderToken, AuthModuleConfig } from './config.interface';
 
 @Module({
   providers: [],
   exports: [],
   controllers: [],
 })
-export class AuthModule {
-  static forRoot({ connectionURI, apiKey }): DynamicModule {
-    supertokens.init({
-      supertokens: {
-        connectionURI,
-        apiKey,
-      },
-      appInfo: {
-        // learn more about this on https://supertokens.io/docs/emailpassword/appinfo
-        appName: "YOUR APP NAME", // Example: "SuperTokens",
-        apiDomain: "YOUR API DOMAIN", // Example: "https://api.supertokens.io",
-        websiteDomain: "YOUR WEBSITE DOMAIN" // Example: "https://supertokens.io"
-      },
-      recipeList: [
-        EmailPassword.init(),
-        Session.init(),
-      ],
-    });
+export class AuthModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
 
+  static forRoot({ connectionURI, apiKey, appInfo }: AuthModuleConfig): DynamicModule {
     return {
-      providers: [],
+      providers: [
+        {
+          useValue: {
+            appInfo,
+            connectionURI,
+            apiKey,
+          },
+          provide: ConfigProviderToken,
+        },
+      ],
       exports: [],
       imports: [],
       module: AuthModule,
@@ -81,6 +96,12 @@ export class AuthModule {
 ```
 
 ### Adding the module to the application
+
+:::important
+- Please make sure to replace all the `appInfo` configurations values with yours.
+- To learn more about filling in `appInfo`, please visit [the appInfo page](../appinfo)
+- If you would like to configure a specific path for you APIs, you can do so by setting the `apiBasePath` value in the config. For example, if your API path is `www.example.com/api` then you can set the value of `apiBasePath` to `/api`.
+:::
 
 You need to update the `App` module to use the new dynamic module by importing the result of `forRoot` instead of the class itself.
 
@@ -93,7 +114,13 @@ import { AuthModule } from './auth/auth.module';
     //highlight-start
     AuthModule.forRoot({
       connectionURI: "https://try.supertokens.io",
-      apiKey: "<REQUIRED FOR MANAGED SERVICE, ELSE YOU CAN REMOVE THIS FIELD>"
+      apiKey: "<REQUIRED FOR MANAGED SERVICE, ELSE YOU CAN REMOVE THIS FIELD>",
+      appInfo: {
+        // Learn more about this on https://supertokens.io/docs/session/appinfo
+        appName: "YOUR APP NAME", // Example: "SuperTokens",
+        apiDomain: "YOUR API DOMAIN", // Example: "https://api.supertokens.io",
+        websiteDomain: "YOUR WEBSITE DOMAIN" // Example: "https://supertokens.io"
+      },
     }),
     //highlight-end
   ],
@@ -103,7 +130,45 @@ import { AuthModule } from './auth/auth.module';
 export class AppModule {}
 ```
 
-## 3) Setting up the middleware
+## 3) Adding a service
+
+You can scaffold this service using the nest CLI by running this in the root folder of the application:
+```bash
+nest g service supertokens auth
+```
+:::important
+The nest CLI will add this service to the normal module providers, which you should move to the `providers` prop of the module returned in `forRoot`.
+:::
+
+We initialize the SDK in a service so that you can have access to injected services in event handlers. Edit the `supertokens.service.ts` to match:
+
+```ts
+import { Inject, Injectable } from '@nestjs/common';
+import supertokens from "supertokens-node";
+import Session from 'supertokens-node/recipe/session';
+import EmailPassword from 'supertokens-node/recipe/emailpassword';
+
+import { ConfigInjectionToken, AuthModuleConfig } from "../config.interface";
+
+@Injectable()
+export class SupertokensService {
+    constructor(@Inject(ConfigInjectionToken) private config: AuthModuleConfig) {
+        supertokens.init({
+            appInfo: config.appInfo,
+            supertokens: {
+                connectionURI: config.connectionURI,
+                apiKey: config.apiKey,
+            },
+            recipeList: [
+              EmailPassword.init(),
+              Session.init(),
+            ],
+        });
+    }
+}
+```
+
+## 4) Setting up the middleware
 
 ### The middleware file
 
@@ -145,7 +210,7 @@ export class AuthModule implements NestModule {
 }
 ```
 
-## 4) Update CORS settings
+## 5) Update CORS settings
 
 You should enable and update your CORS settings in `main.ts`:
 
@@ -169,7 +234,7 @@ async function bootstrap() {
 bootstrap()
 ```
 
-## 5) Add the SuperTokens error handler
+## 6) Add the SuperTokens error handler
 
 We add the SuperTokens error handler through a NestJS exception filter.
 
@@ -233,7 +298,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-## 5) Add session verification guard
+## 7) Add session verification guard
 
 Now that the library is set up, you can add a guard to protect your API. You can scaffold this `nest g guard auth auth`. This results in `auth.guard.ts` that we can edit to implement session verification.
 
@@ -265,7 +330,7 @@ export class AuthGuard implements CanActivate {
 }
 ```
 
-## 6) Add a parameter decorator
+## 8) Add a parameter decorator
 
 Now you can add a parameter decorator to access the already verified session in your APIs. You can generate an empty decorator by running `nest g decorator session auth`. Edit `session.decorator.ts` to return the session attached to the request:
 
@@ -280,7 +345,7 @@ export const Session = createParamDecorator(
 );
 ```
 
-## 7) Combine the decorator and the guard to authenticate users
+## 9) Combine the decorator and the guard to authenticate users
 
 You can add a protected method into a controller (e.g.: `App.controller.ts`) that receives the verified session as a parameter by:
 

--- a/v2/session/nestjs/guide.mdx
+++ b/v2/session/nestjs/guide.mdx
@@ -9,7 +9,8 @@ hide_title: true
 ## Overview
 
 Integrating SuperTokens into a NestJS backend is a bit different than the quick setup guide shows. We will add a few things:
-- A module to initialize the SDK
+- A module to house all authorization related code
+- A service to initialize the SDK
 - A middleware to add the authorization endpoints
 - A global error handler to pass SuperTokens related errors to the SDK
 - A guard to protect your API endpoints
@@ -25,52 +26,67 @@ Please look [here](https://docs.nestjs.com/first-steps) to see how to get starte
 npm i -s supertokens-node
 ```
 
-## 2) Adding a new module and initializing SuperTokens
-
-:::important
-- Please make sure to replace all the `appInfo` configurations values with yours.
-- To learn more about filling in `appInfo`, please visit [the appInfo page](../appinfo)
-- If you would like to configure a specific path for you APIs, you can do so by setting the `apiBasePath` value in the config. For example, if your API path is `www.example.com/api` then you can set the value of `apiBasePath` to `/api`.
-:::
+## 2) Adding a new module
 
 You can scaffold a module using the nest CLI by running this in the root folder of the application:
 ```bash
 nest g module auth
 ```
-The result should be a new `auth` folder with `auth.module.ts` in it. We should convert this into a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) to make sure that we only initialize SuperTokens once. As a bonus, you can set parts of the SuperTokens configuration in the App module. Centralizing settings like this can be helpful for things like setting separate connection URI for testing.
+The result should be a new `auth` folder with `auth.module.ts` in it. We should convert this into a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can set parts of the SuperTokens configuration in the App module. Centralizing settings like this can be helpful for things like using a separate connection URI for testing.
+
+### Add config type and injection token
+
+Add a `config.ts` file next into the `auth` folder. We will put the type and injection token for the SuperTokens config here.
 
 ```ts
-import { DynamicModule, Module } from "@nestjs/common";
+import { AppInfo } from "supertokens-node/lib/build/types";
 
-import supertokens from 'supertokens-node';
-import Session from 'supertokens-node/recipe/session';
-import EmailPassword from 'supertokens-node/recipe/emailpassword';
+export const ConfigInjectionToken = "ConfigInjectionToken";
+
+export type AuthModuleConfig = {
+  appInfo: AppInfo;
+  connectionURI: string;
+  apiKey?: string;
+}
+```
+
+### Convert to a dynamic module
+
+We want to configure this module in the App module, so we add a static `forRoot` method and convert it into a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules).
+
+```ts
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  DynamicModule,
+} from '@nestjs/common';
+
+import { AuthMiddleware } from './auth.middleware';
+import { ConfigProviderToken, AuthModuleConfig } from './config.interface';
 
 @Module({
   providers: [],
   exports: [],
   controllers: [],
 })
-export class AuthModule {
-  static forRoot({ connectionURI, apiKey }): DynamicModule {
-    supertokens.init({
-      supertokens: {
-        connectionURI,
-        apiKey,
-      },
-      appInfo: {
-        // learn more about this on https://supertokens.io/docs/session/appinfo
-        appName: "YOUR APP NAME", // Example: "SuperTokens",
-        apiDomain: "YOUR API DOMAIN", // Example: "https://api.supertokens.io",
-        websiteDomain: "YOUR WEBSITE DOMAIN" // Example: "https://supertokens.io"
-      },
-      recipeList: [
-        Session.init(),
-      ],
-    });
+export class AuthModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
 
+  static forRoot({ connectionURI, apiKey, appInfo }: AuthModuleConfig): DynamicModule {
     return {
-      providers: [],
+      providers: [
+        {
+          useValue: {
+            appInfo,
+            connectionURI,
+            apiKey,
+          },
+          provide: ConfigProviderToken,
+        },
+      ],
       exports: [],
       imports: [],
       module: AuthModule,
@@ -80,6 +96,12 @@ export class AuthModule {
 ```
 
 ### Adding the module to the application
+
+:::important
+- Please make sure to replace all the `appInfo` configurations values with yours.
+- To learn more about filling in `appInfo`, please visit [the appInfo page](../appinfo)
+- If you would like to configure a specific path for you APIs, you can do so by setting the `apiBasePath` value in the config. For example, if your API path is `www.example.com/api` then you can set the value of `apiBasePath` to `/api`.
+:::
 
 You need to update the `App` module to use the new dynamic module by importing the result of `forRoot` instead of the class itself.
 
@@ -92,7 +114,13 @@ import { AuthModule } from './auth/auth.module';
     //highlight-start
     AuthModule.forRoot({
       connectionURI: "https://try.supertokens.io",
-      apiKey: "<REQUIRED FOR MANAGED SERVICE, ELSE YOU CAN REMOVE THIS FIELD>"
+      apiKey: "<REQUIRED FOR MANAGED SERVICE, ELSE YOU CAN REMOVE THIS FIELD>",
+      appInfo: {
+        // Learn more about this on https://supertokens.io/docs/session/appinfo
+        appName: "YOUR APP NAME", // Example: "SuperTokens",
+        apiDomain: "YOUR API DOMAIN", // Example: "https://api.supertokens.io",
+        websiteDomain: "YOUR WEBSITE DOMAIN" // Example: "https://supertokens.io"
+      },
     }),
     //highlight-end
   ],
@@ -102,7 +130,43 @@ import { AuthModule } from './auth/auth.module';
 export class AppModule {}
 ```
 
-## 3) Setting up the middleware
+## 3) Adding a service
+
+You can scaffold this service using the nest CLI by running this in the root folder of the application:
+```bash
+nest g service supertokens auth
+```
+:::important
+The nest CLI will add this service to the normal module providers, which you should move to the `providers` prop of the module returned in `forRoot`.
+:::
+
+We initialize the SDK in a service so that you can have access to injected services in event handlers. Edit the `supertokens.service.ts` to match:
+
+```ts
+import { Inject, Injectable } from '@nestjs/common';
+import supertokens from "supertokens-node";
+import Session from 'supertokens-node/recipe/session';
+
+import { ConfigInjectionToken, AuthModuleConfig } from "../config.interface";
+
+@Injectable()
+export class SupertokensService {
+    constructor(@Inject(ConfigInjectionToken) private config: AuthModuleConfig) {
+        supertokens.init({
+            appInfo: config.appInfo,
+            supertokens: {
+                connectionURI: config.connectionURI,
+                apiKey: config.apiKey,
+            },
+            recipeList: [
+                Session.init(),
+            ]
+        });
+    }
+}
+```
+
+## 4) Setting up the middleware
 
 ### The middleware file
 
@@ -144,7 +208,7 @@ export class AuthModule implements NestModule {
 }
 ```
 
-## 4) Update CORS settings
+## 5) Update CORS settings
 
 You should enable and update your CORS settings in `main.ts`:
 
@@ -168,7 +232,7 @@ async function bootstrap() {
 bootstrap()
 ```
 
-## 5) Add the SuperTokens error handler
+## 6) Add the SuperTokens error handler
 
 We add the SuperTokens error handler through a NestJS exception filter.
 
@@ -232,7 +296,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-## 5) Add session verification guard
+## 7) Add session verification guard
 
 Now that the library is set up, you can add a guard to protect your API. You can scaffold this `nest g guard auth auth`. This results in `auth.guard.ts` that we can edit to implement session verification.
 
@@ -264,7 +328,7 @@ export class AuthGuard implements CanActivate {
 }
 ```
 
-## 6) Add a parameter decorator
+## 8) Add a parameter decorator
 
 Now you can add a parameter decorator to access the already verified session in your APIs. You can generate an empty decorator by running `nest g decorator session auth`. Edit `session.decorator.ts` to return the session attached to the request:
 
@@ -279,7 +343,7 @@ export const Session = createParamDecorator(
 );
 ```
 
-## 7) Combine the decorator and the guard to authenticate users
+## 9) Combine the decorator and the guard to authenticate users
 
 You can add a protected method into a controller (e.g.: `App.controller.ts`) that receives the verified session as a parameter by:
 

--- a/v2/thirdparty/nestjs/guide.mdx
+++ b/v2/thirdparty/nestjs/guide.mdx
@@ -146,7 +146,7 @@ We initialize the SDK in a service so that you can have access to injected servi
 import { Inject, Injectable } from '@nestjs/common';
 import supertokens from "supertokens-node";
 import Session from 'supertokens-node/recipe/session';
-import EmailPassword from 'supertokens-node/recipe/emailpassword';
+import ThirdParty from 'supertokens-node/recipe/thirdparty';
 
 import { ConfigInjectionToken, AuthModuleConfig } from "../config.interface";
 

--- a/v2/thirdparty/nestjs/guide.mdx
+++ b/v2/thirdparty/nestjs/guide.mdx
@@ -9,7 +9,8 @@ hide_title: true
 ## Overview
 
 Integrating SuperTokens into a NestJS backend is a bit different than the quick setup guide shows. We will add a few things:
-- A module to initialize the SDK
+- A module to house all authorization related code
+- A service to initialize the SDK
 - A middleware to add the authorization endpoints
 - A global error handler to pass SuperTokens related errors to the SDK
 - A guard to protect your API endpoints
@@ -25,68 +26,67 @@ Please look [here](https://docs.nestjs.com/first-steps) to see how to get starte
 npm i -s supertokens-node
 ```
 
-## 2) Adding a new module and initializing SuperTokens
-
-:::important
-- Please make sure to replace all the `appInfo` configurations values with yours.
-- To learn more about filling in `appInfo`, please visit [the appInfo page](../appinfo)
-- If you would like to configure a specific path for you APIs, you can do so by setting the `apiBasePath` value in the config. For example, if your API path is `www.example.com/api` then you can set the value of `apiBasePath` to `/api`.
-:::
+## 2) Adding a new module
 
 You can scaffold a module using the nest CLI by running this in the root folder of the application:
 ```bash
 nest g module auth
 ```
-The result should be a new `auth` folder with `auth.module.ts` in it. We should convert this into a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) to make sure that we only initialize SuperTokens once. As a bonus, you can set parts of the SuperTokens configuration in the App module. Centralizing settings like this can be helpful for things like setting separate connection URI for testing.
+The result should be a new `auth` folder with `auth.module.ts` in it. We should convert this into a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can set parts of the SuperTokens configuration in the App module. Centralizing settings like this can be helpful for things like using a separate connection URI for testing.
+
+### Add config type and injection token
+
+Add a `config.ts` file next into the `auth` folder. We will put the type and injection token for the SuperTokens config here.
 
 ```ts
-import { DynamicModule, Module } from "@nestjs/common";
+import { AppInfo } from "supertokens-node/lib/build/types";
 
-import supertokens from 'supertokens-node';
-import Session from 'supertokens-node/recipe/session';
-import EmailPassword from 'supertokens-node/recipe/emailpassword';
+export const ConfigInjectionToken = "ConfigInjectionToken";
+
+export type AuthModuleConfig = {
+  appInfo: AppInfo;
+  connectionURI: string;
+  apiKey?: string;
+}
+```
+
+### Convert to a dynamic module
+
+We want to configure this module in the App module, so we add a static `forRoot` method and convert it into a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules).
+
+```ts
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  DynamicModule,
+} from '@nestjs/common';
+
+import { AuthMiddleware } from './auth.middleware';
+import { ConfigProviderToken, AuthModuleConfig } from './config.interface';
 
 @Module({
   providers: [],
   exports: [],
   controllers: [],
 })
-export class AuthModule {
-  static forRoot({ connectionURI, apiKey }): DynamicModule {
-    supertokens.init({
-      supertokens: {
-        connectionURI,
-        apiKey,
-      },
-      appInfo: {
-        // learn more about this on https://supertokens.io/docs/thirdparty/appinfo
-        appName: "YOUR APP NAME", // Example: "SuperTokens",
-        apiDomain: "YOUR API DOMAIN", // Example: "https://api.supertokens.io",
-        websiteDomain: "YOUR WEBSITE DOMAIN" // Example: "https://supertokens.io"
-      },
-      recipeList: [
-        ThirdParty.init({
-            providers: [
-                Google({
-                    clientSecret: "GOOGLE_CLIENT_SECRET",
-                    clientId: "GOOGLE_CLIENT_ID"
-                }),
-                Github({
-                    clientSecret: "GITHUB_CLIENT_SECRET",
-                    clientId: "GITHUB_CLIENT_ID"
-                }),
-                Facebook({
-                    clientSecret: "FACEBOOK_CLIENT_SECRET",
-                    clientId: "FACEBOOK_CLIENT_ID"
-                })
-            ]
-        }),
-        Session.init(),
-      ],
-    });
+export class AuthModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
 
+  static forRoot({ connectionURI, apiKey, appInfo }: AuthModuleConfig): DynamicModule {
     return {
-      providers: [],
+      providers: [
+        {
+          useValue: {
+            appInfo,
+            connectionURI,
+            apiKey,
+          },
+          provide: ConfigProviderToken,
+        },
+      ],
       exports: [],
       imports: [],
       module: AuthModule,
@@ -96,6 +96,12 @@ export class AuthModule {
 ```
 
 ### Adding the module to the application
+
+:::important
+- Please make sure to replace all the `appInfo` configurations values with yours.
+- To learn more about filling in `appInfo`, please visit [the appInfo page](../appinfo)
+- If you would like to configure a specific path for you APIs, you can do so by setting the `apiBasePath` value in the config. For example, if your API path is `www.example.com/api` then you can set the value of `apiBasePath` to `/api`.
+:::
 
 You need to update the `App` module to use the new dynamic module by importing the result of `forRoot` instead of the class itself.
 
@@ -108,7 +114,13 @@ import { AuthModule } from './auth/auth.module';
     //highlight-start
     AuthModule.forRoot({
       connectionURI: "https://try.supertokens.io",
-      apiKey: "<REQUIRED FOR MANAGED SERVICE, ELSE YOU CAN REMOVE THIS FIELD>"
+      apiKey: "<REQUIRED FOR MANAGED SERVICE, ELSE YOU CAN REMOVE THIS FIELD>",
+      appInfo: {
+        // Learn more about this on https://supertokens.io/docs/session/appinfo
+        appName: "YOUR APP NAME", // Example: "SuperTokens",
+        apiDomain: "YOUR API DOMAIN", // Example: "https://api.supertokens.io",
+        websiteDomain: "YOUR WEBSITE DOMAIN" // Example: "https://supertokens.io"
+      },
     }),
     //highlight-end
   ],
@@ -118,7 +130,60 @@ import { AuthModule } from './auth/auth.module';
 export class AppModule {}
 ```
 
-## 3) Setting up the middleware
+## 3) Adding a service
+
+You can scaffold this service using the nest CLI by running this in the root folder of the application:
+```bash
+nest g service supertokens auth
+```
+:::important
+The nest CLI will add this service to the normal module providers, which you should move to the `providers` prop of the module returned in `forRoot`.
+:::
+
+We initialize the SDK in a service so that you can have access to injected services in event handlers. Edit the `supertokens.service.ts` to match:
+
+```ts
+import { Inject, Injectable } from '@nestjs/common';
+import supertokens from "supertokens-node";
+import Session from 'supertokens-node/recipe/session';
+import EmailPassword from 'supertokens-node/recipe/emailpassword';
+
+import { ConfigInjectionToken, AuthModuleConfig } from "../config.interface";
+
+@Injectable()
+export class SupertokensService {
+    constructor(@Inject(ConfigInjectionToken) private config: AuthModuleConfig) {
+        supertokens.init({
+            appInfo: config.appInfo,
+            supertokens: {
+                connectionURI: config.connectionURI,
+                apiKey: config.apiKey,
+            },
+            recipeList: [
+              ThirdParty.init({
+                providers: [
+                  Google({
+                    clientSecret: "GOOGLE_CLIENT_SECRET",
+                    clientId: "GOOGLE_CLIENT_ID"
+                  }),
+                  Github({
+                    clientSecret: "GITHUB_CLIENT_SECRET",
+                    clientId: "GITHUB_CLIENT_ID"
+                  }),
+                  Facebook({
+                    clientSecret: "FACEBOOK_CLIENT_SECRET",
+                    clientId: "FACEBOOK_CLIENT_ID"
+                  })
+                ]
+              }),
+              Session.init(),
+            ]
+        });
+    }
+}
+```
+
+## 4) Setting up the middleware
 
 ### The middleware file
 
@@ -160,7 +225,7 @@ export class AuthModule implements NestModule {
 }
 ```
 
-## 4) Update CORS settings
+## 5) Update CORS settings
 
 You should enable and update your CORS settings in `main.ts`:
 
@@ -184,7 +249,7 @@ async function bootstrap() {
 bootstrap()
 ```
 
-## 5) Add the SuperTokens error handler
+## 6) Add the SuperTokens error handler
 
 We add the SuperTokens error handler through a NestJS exception filter.
 
@@ -248,7 +313,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-## 5) Add session verification guard
+## 7) Add session verification guard
 
 Now that the library is set up, you can add a guard to protect your API. You can scaffold this `nest g guard auth auth`. This results in `auth.guard.ts` that we can edit to implement session verification.
 
@@ -280,7 +345,7 @@ export class AuthGuard implements CanActivate {
 }
 ```
 
-## 6) Add a parameter decorator
+## 8) Add a parameter decorator
 
 Now you can add a parameter decorator to access the already verified session in your APIs. You can generate an empty decorator by running `nest g decorator session auth`. Edit `session.decorator.ts` to return the session attached to the request:
 
@@ -295,7 +360,7 @@ export const Session = createParamDecorator(
 );
 ```
 
-## 7) Combine the decorator and the guard to authenticate users
+## 9) Combine the decorator and the guard to authenticate users
 
 You can add a protected method into a controller (e.g.: `App.controller.ts`) that receives the verified session as a parameter by:
 

--- a/v2/thirdpartyemailpassword/nestjs/guide.mdx
+++ b/v2/thirdpartyemailpassword/nestjs/guide.mdx
@@ -9,7 +9,8 @@ hide_title: true
 ## Overview
 
 Integrating SuperTokens into a NestJS backend is a bit different than the quick setup guide shows. We will add a few things:
-- A module to initialize the SDK
+- A module to house all authorization related code
+- A service to initialize the SDK
 - A middleware to add the authorization endpoints
 - A global error handler to pass SuperTokens related errors to the SDK
 - A guard to protect your API endpoints
@@ -25,68 +26,67 @@ Please look [here](https://docs.nestjs.com/first-steps) to see how to get starte
 npm i -s supertokens-node
 ```
 
-## 2) Adding a new module and initializing SuperTokens
-
-:::important
-- Please make sure to replace all the `appInfo` configurations values with yours.
-- To learn more about filling in `appInfo`, please visit [the appInfo page](../appinfo)
-- If you would like to configure a specific path for you APIs, you can do so by setting the `apiBasePath` value in the config. For example, if your API path is `www.example.com/api` then you can set the value of `apiBasePath` to `/api`.
-:::
+## 2) Adding a new module
 
 You can scaffold a module using the nest CLI by running this in the root folder of the application:
 ```bash
 nest g module auth
 ```
-The result should be a new `auth` folder with `auth.module.ts` in it. We should convert this into a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) to make sure that we only initialize SuperTokens once. As a bonus, you can set parts of the SuperTokens configuration in the App module. Centralizing settings like this can be helpful for things like setting separate connection URI for testing.
+The result should be a new `auth` folder with `auth.module.ts` in it. We should convert this into a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can set parts of the SuperTokens configuration in the App module. Centralizing settings like this can be helpful for things like using a separate connection URI for testing.
+
+### Add config type and injection token
+
+Add a `config.ts` file next into the `auth` folder. We will put the type and injection token for the SuperTokens config here.
 
 ```ts
-import { DynamicModule, Module } from "@nestjs/common";
+import { AppInfo } from "supertokens-node/lib/build/types";
 
-import supertokens from 'supertokens-node';
-import Session from 'supertokens-node/recipe/session';
-import EmailPassword from 'supertokens-node/recipe/emailpassword';
+export const ConfigInjectionToken = "ConfigInjectionToken";
+
+export type AuthModuleConfig = {
+  appInfo: AppInfo;
+  connectionURI: string;
+  apiKey?: string;
+}
+```
+
+### Convert to a dynamic module
+
+We want to configure this module in the App module, so we add a static `forRoot` method and convert it into a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules).
+
+```ts
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  DynamicModule,
+} from '@nestjs/common';
+
+import { AuthMiddleware } from './auth.middleware';
+import { ConfigProviderToken, AuthModuleConfig } from './config.interface';
 
 @Module({
   providers: [],
   exports: [],
   controllers: [],
 })
-export class AuthModule {
-  static forRoot({ connectionURI, apiKey }): DynamicModule {
-    supertokens.init({
-      supertokens: {
-        connectionURI,
-        apiKey,
-      },
-      appInfo: {
-        // learn more about this on https://supertokens.io/docs/thirdpartyemailpassword/appinfo
-        appName: "YOUR APP NAME", // Example: "SuperTokens",
-        apiDomain: "YOUR API DOMAIN", // Example: "https://api.supertokens.io",
-        websiteDomain: "YOUR WEBSITE DOMAIN" // Example: "https://supertokens.io"
-      },
-      recipeList: [
-        ThirdPartyEmailPassword.init({
-            providers: [
-                Google({
-                    clientSecret: "GOOGLE_CLIENT_SECRET",
-                    clientId: "GOOGLE_CLIENT_ID"
-                }),
-                Github({
-                    clientSecret: "GITHUB_CLIENT_SECRET",
-                    clientId: "GITHUB_CLIENT_ID"
-                }),
-                Facebook({
-                    clientSecret: "FACEBOOK_CLIENT_SECRET",
-                    clientId: "FACEBOOK_CLIENT_ID"
-                })
-            ]
-        }),
-        Session.init(),
-      ],
-    });
+export class AuthModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
 
+  static forRoot({ connectionURI, apiKey, appInfo }: AuthModuleConfig): DynamicModule {
     return {
-      providers: [],
+      providers: [
+        {
+          useValue: {
+            appInfo,
+            connectionURI,
+            apiKey,
+          },
+          provide: ConfigProviderToken,
+        },
+      ],
       exports: [],
       imports: [],
       module: AuthModule,
@@ -96,6 +96,12 @@ export class AuthModule {
 ```
 
 ### Adding the module to the application
+
+:::important
+- Please make sure to replace all the `appInfo` configurations values with yours.
+- To learn more about filling in `appInfo`, please visit [the appInfo page](../appinfo)
+- If you would like to configure a specific path for you APIs, you can do so by setting the `apiBasePath` value in the config. For example, if your API path is `www.example.com/api` then you can set the value of `apiBasePath` to `/api`.
+:::
 
 You need to update the `App` module to use the new dynamic module by importing the result of `forRoot` instead of the class itself.
 
@@ -108,7 +114,13 @@ import { AuthModule } from './auth/auth.module';
     //highlight-start
     AuthModule.forRoot({
       connectionURI: "https://try.supertokens.io",
-      apiKey: "<REQUIRED FOR MANAGED SERVICE, ELSE YOU CAN REMOVE THIS FIELD>"
+      apiKey: "<REQUIRED FOR MANAGED SERVICE, ELSE YOU CAN REMOVE THIS FIELD>",
+      appInfo: {
+        // Learn more about this on https://supertokens.io/docs/session/appinfo
+        appName: "YOUR APP NAME", // Example: "SuperTokens",
+        apiDomain: "YOUR API DOMAIN", // Example: "https://api.supertokens.io",
+        websiteDomain: "YOUR WEBSITE DOMAIN" // Example: "https://supertokens.io"
+      },
     }),
     //highlight-end
   ],
@@ -118,7 +130,60 @@ import { AuthModule } from './auth/auth.module';
 export class AppModule {}
 ```
 
-## 3) Setting up the middleware
+## 3) Adding a service
+
+You can scaffold this service using the nest CLI by running this in the root folder of the application:
+```bash
+nest g service supertokens auth
+```
+:::important
+The nest CLI will add this service to the normal module providers, which you should move to the `providers` prop of the module returned in `forRoot`.
+:::
+
+We initialize the SDK in a service so that you can have access to injected services in event handlers. Edit the `supertokens.service.ts` to match:
+
+```ts
+import { Inject, Injectable } from '@nestjs/common';
+import supertokens from "supertokens-node";
+import Session from 'supertokens-node/recipe/session';
+import ThirdPartyEmailPassword from 'supertokens-node/recipe/thirdpartyemailpassword';
+
+import { ConfigInjectionToken, AuthModuleConfig } from "../config.interface";
+
+@Injectable()
+export class SupertokensService {
+    constructor(@Inject(ConfigInjectionToken) private config: AuthModuleConfig) {
+        supertokens.init({
+            appInfo: config.appInfo,
+            supertokens: {
+                connectionURI: config.connectionURI,
+                apiKey: config.apiKey,
+            },
+            recipeList: [
+              ThirdPartyEmailPassword.init({
+                  providers: [
+                      Google({
+                          clientSecret: "GOOGLE_CLIENT_SECRET",
+                          clientId: "GOOGLE_CLIENT_ID"
+                      }),
+                      Github({
+                          clientSecret: "GITHUB_CLIENT_SECRET",
+                          clientId: "GITHUB_CLIENT_ID"
+                      }),
+                      Facebook({
+                          clientSecret: "FACEBOOK_CLIENT_SECRET",
+                          clientId: "FACEBOOK_CLIENT_ID"
+                      })
+                  ]
+              }),
+              Session.init(),
+            ]
+        });
+    }
+}
+```
+
+## 4) Setting up the middleware
 
 ### The middleware file
 
@@ -160,7 +225,7 @@ export class AuthModule implements NestModule {
 }
 ```
 
-## 4) Update CORS settings
+## 5) Update CORS settings
 
 You should enable and update your CORS settings in `main.ts`:
 
@@ -184,7 +249,7 @@ async function bootstrap() {
 bootstrap()
 ```
 
-## 5) Add the SuperTokens error handler
+## 6) Add the SuperTokens error handler
 
 We add the SuperTokens error handler through a NestJS exception filter.
 
@@ -248,7 +313,7 @@ async function bootstrap() {
 bootstrap();
 ```
 
-## 5) Add session verification guard
+## 7) Add session verification guard
 
 Now that the library is set up, you can add a guard to protect your API. You can scaffold this `nest g guard auth auth`. This results in `auth.guard.ts` that we can edit to implement session verification.
 
@@ -280,7 +345,7 @@ export class AuthGuard implements CanActivate {
 }
 ```
 
-## 6) Add a parameter decorator
+## 8) Add a parameter decorator
 
 Now you can add a parameter decorator to access the already verified session in your APIs. You can generate an empty decorator by running `nest g decorator session auth`. Edit `session.decorator.ts` to return the session attached to the request:
 
@@ -295,7 +360,7 @@ export const Session = createParamDecorator(
 );
 ```
 
-## 7) Combine the decorator and the guard to authenticate users
+## 9) Combine the decorator and the guard to authenticate users
 
 You can add a protected method into a controller (e.g.: `App.controller.ts`) that receives the verified session as a parameter by:
 


### PR DESCRIPTION
## Summary of change
Moved SDK initialization into a service so that that event handlers can use injected services.

## Related issues
- #130 
