### PR TITLE
Explicitly naming constraints in PostgreSQL for more robust error handling

### DIFF
--- a/v2/community/database-setup/postgresql.mdx
+++ b/v2/community/database-setup/postgresql.mdx
@@ -100,21 +100,21 @@ CREATE TABLE IF NOT EXISTS key_value (
     name VARCHAR(128),
     value TEXT,
     created_at_time BIGINT,
-    PRIMARY KEY(name)
+    CONSTRAINT key_value_pkey PRIMARY KEY(name)
 );
 
 CREATE TABLE IF NOT EXISTS all_auth_recipe_users(
     user_id CHAR(36) NOT NULL,
     recipe_id VARCHAR(128) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (user_id)
+    CONSTRAINT all_auth_recipe_users_pkey PRIMARY KEY (user_id)
 );
 CREATE INDEX all_auth_recipe_users_pagination_index ON all_auth_recipe_users (time_joined DESC, user_id DESC);
 
 CREATE TABLE session_access_token_signing_keys (
     created_at_time BIGINT NOT NULL,
     value TEXT,
-    PRIMARY KEY (created_at_time)
+    CONSTRAINT session_access_token_signing_keys_pkey PRIMARY KEY (created_at_time)
 );
 
 CREATE TABLE IF NOT EXISTS session_info (
@@ -125,23 +125,23 @@ CREATE TABLE IF NOT EXISTS session_info (
     expires_at BIGINT NOT NULL,
     created_at_time BIGINT NOT NULL,
     jwt_user_payload TEXT,
-    PRIMARY KEY(session_handle)
+    CONSTRAINT session_info_pkey PRIMARY KEY(session_handle)
 );
 
 CREATE TABLE IF NOT EXISTS emailpassword_users (
     user_id CHAR(36) NOT NULL,
-    email VARCHAR(256) NOT NULL UNIQUE,
+    email VARCHAR(256) NOT NULL CONSTRAINT emailpassword_users_email_key UNIQUE,
     password_hash VARCHAR(128) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (user_id)
+    CONSTRAINT emailpassword_users_pkey PRIMARY KEY (user_id)
 );
 
 CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
     user_id CHAR(36) NOT NULL,
-    token VARCHAR(128) NOT NULL UNIQUE,
+    token VARCHAR(128) NOT NULL CONSTRAINT emailpassword_pswd_reset_tokens_token_key UNIQUE,
     token_expiry BIGINT NOT NULL,
-    PRIMARY KEY (user_id, token),
-    FOREIGN KEY (user_id) REFERENCES emailpassword_users (user_id) ON DELETE CASCADE ON UPDATE CASCADE
+    CONSTRAINT emailpassword_pswd_reset_tokens_pkey PRIMARY KEY (user_id, token),
+    CONSTRAINT emailpassword_pswd_reset_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES emailpassword_users (user_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
@@ -149,15 +149,15 @@ CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_ps
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
     user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
-    PRIMARY KEY (user_id, email)
+    CONSTRAINT emailverification_verified_emails_pkey PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
     user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
-    token VARCHAR(128) NOT NULL UNIQUE,
+    token VARCHAR(128) NOT NULL CONSTRAINT emailverification_tokens_token_key UNIQUE,
     token_expiry BIGINT NOT NULL,
-    PRIMARY KEY (user_id, email, token)
+    CONSTRAINT emailverification_tokens_pkey PRIMARY KEY (user_id, email, token)
 );
 
 CREATE INDEX emailverification_tokens_index ON emailverification_tokens(token_expiry);
@@ -165,10 +165,10 @@ CREATE INDEX emailverification_tokens_index ON emailverification_tokens(token_ex
 CREATE TABLE IF NOT EXISTS thirdparty_users (
     third_party_id VARCHAR(28) NOT NULL,
     third_party_user_id VARCHAR(128) NOT NULL,
-    user_id CHAR(36) NOT NULL,
+    user_id CHAR(36) NOT NULL CONSTRAINT thirdparty_users_user_id_key UNIQUE,
     email VARCHAR(256) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (third_party_id, third_party_user_id)
+    CONSTRAINT thirdparty_users_pkey PRIMARY KEY (third_party_id, third_party_user_id)
 );
 
 CREATE TABLE IF NOT EXISTS jwt_signing_keys (
@@ -176,7 +176,7 @@ CREATE TABLE IF NOT EXISTS jwt_signing_keys (
     key_string TEXT NOT NULL,
     algorithm VARCHAR(10) NOT NULL,
     created_at BIGINT,
-    PRIMARY KEY(key_id)
+    CONSTRAINT jwt_signing_keys_pkey PRIMARY KEY(key_id)
 );
 ```
 

--- a/v2/emailpassword/quick-setup/database-setup/postgresql.mdx
+++ b/v2/emailpassword/quick-setup/database-setup/postgresql.mdx
@@ -100,21 +100,21 @@ CREATE TABLE IF NOT EXISTS key_value (
     name VARCHAR(128),
     value TEXT,
     created_at_time BIGINT,
-    PRIMARY KEY(name)
+    CONSTRAINT key_value_pkey PRIMARY KEY(name)
 );
 
 CREATE TABLE IF NOT EXISTS all_auth_recipe_users(
     user_id CHAR(36) NOT NULL,
     recipe_id VARCHAR(128) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (user_id)
+    CONSTRAINT all_auth_recipe_users_pkey PRIMARY KEY (user_id)
 );
 CREATE INDEX all_auth_recipe_users_pagination_index ON all_auth_recipe_users (time_joined DESC, user_id DESC);
 
 CREATE TABLE session_access_token_signing_keys (
     created_at_time BIGINT NOT NULL,
     value TEXT,
-    PRIMARY KEY (created_at_time)
+    CONSTRAINT session_access_token_signing_keys_pkey PRIMARY KEY (created_at_time)
 );
 
 CREATE TABLE IF NOT EXISTS session_info (
@@ -125,23 +125,23 @@ CREATE TABLE IF NOT EXISTS session_info (
     expires_at BIGINT NOT NULL,
     created_at_time BIGINT NOT NULL,
     jwt_user_payload TEXT,
-    PRIMARY KEY(session_handle)
+    CONSTRAINT session_info_pkey PRIMARY KEY(session_handle)
 );
 
 CREATE TABLE IF NOT EXISTS emailpassword_users (
     user_id CHAR(36) NOT NULL,
-    email VARCHAR(256) NOT NULL UNIQUE,
+    email VARCHAR(256) NOT NULL CONSTRAINT emailpassword_users_email_key UNIQUE,
     password_hash VARCHAR(128) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (user_id)
+    CONSTRAINT emailpassword_users_pkey PRIMARY KEY (user_id)
 );
 
 CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
     user_id CHAR(36) NOT NULL,
-    token VARCHAR(128) NOT NULL UNIQUE,
+    token VARCHAR(128) NOT NULL CONSTRAINT emailpassword_pswd_reset_tokens_token_key UNIQUE,
     token_expiry BIGINT NOT NULL,
-    PRIMARY KEY (user_id, token),
-    FOREIGN KEY (user_id) REFERENCES emailpassword_users (user_id) ON DELETE CASCADE ON UPDATE CASCADE
+    CONSTRAINT emailpassword_pswd_reset_tokens_pkey PRIMARY KEY (user_id, token),
+    CONSTRAINT emailpassword_pswd_reset_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES emailpassword_users (user_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
@@ -149,15 +149,15 @@ CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_ps
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
     user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
-    PRIMARY KEY (user_id, email)
+    CONSTRAINT emailverification_verified_emails_pkey PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
     user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
-    token VARCHAR(128) NOT NULL UNIQUE,
+    token VARCHAR(128) NOT NULL CONSTRAINT emailverification_tokens_token_key UNIQUE,
     token_expiry BIGINT NOT NULL,
-    PRIMARY KEY (user_id, email, token)
+    CONSTRAINT emailverification_tokens_pkey PRIMARY KEY (user_id, email, token)
 );
 
 CREATE INDEX emailverification_tokens_index ON emailverification_tokens(token_expiry);
@@ -165,10 +165,10 @@ CREATE INDEX emailverification_tokens_index ON emailverification_tokens(token_ex
 CREATE TABLE IF NOT EXISTS thirdparty_users (
     third_party_id VARCHAR(28) NOT NULL,
     third_party_user_id VARCHAR(128) NOT NULL,
-    user_id CHAR(36) NOT NULL,
+    user_id CHAR(36) NOT NULL CONSTRAINT thirdparty_users_user_id_key UNIQUE,
     email VARCHAR(256) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (third_party_id, third_party_user_id)
+    CONSTRAINT thirdparty_users_pkey PRIMARY KEY (third_party_id, third_party_user_id)
 );
 
 CREATE TABLE IF NOT EXISTS jwt_signing_keys (
@@ -176,7 +176,7 @@ CREATE TABLE IF NOT EXISTS jwt_signing_keys (
     key_string TEXT NOT NULL,
     algorithm VARCHAR(10) NOT NULL,
     created_at BIGINT,
-    PRIMARY KEY(key_id)
+    CONSTRAINT jwt_signing_keys_pkey PRIMARY KEY(key_id)
 );
 ```
 

--- a/v2/session/quick-setup/database-setup/postgresql.mdx
+++ b/v2/session/quick-setup/database-setup/postgresql.mdx
@@ -100,21 +100,21 @@ CREATE TABLE IF NOT EXISTS key_value (
     name VARCHAR(128),
     value TEXT,
     created_at_time BIGINT,
-    PRIMARY KEY(name)
+    CONSTRAINT key_value_pkey PRIMARY KEY(name)
 );
 
 CREATE TABLE IF NOT EXISTS all_auth_recipe_users(
     user_id CHAR(36) NOT NULL,
     recipe_id VARCHAR(128) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (user_id)
+    CONSTRAINT all_auth_recipe_users_pkey PRIMARY KEY (user_id)
 );
 CREATE INDEX all_auth_recipe_users_pagination_index ON all_auth_recipe_users (time_joined DESC, user_id DESC);
 
 CREATE TABLE session_access_token_signing_keys (
     created_at_time BIGINT NOT NULL,
     value TEXT,
-    PRIMARY KEY (created_at_time)
+    CONSTRAINT session_access_token_signing_keys_pkey PRIMARY KEY (created_at_time)
 );
 
 CREATE TABLE IF NOT EXISTS session_info (
@@ -125,23 +125,23 @@ CREATE TABLE IF NOT EXISTS session_info (
     expires_at BIGINT NOT NULL,
     created_at_time BIGINT NOT NULL,
     jwt_user_payload TEXT,
-    PRIMARY KEY(session_handle)
+    CONSTRAINT session_info_pkey PRIMARY KEY(session_handle)
 );
 
 CREATE TABLE IF NOT EXISTS emailpassword_users (
     user_id CHAR(36) NOT NULL,
-    email VARCHAR(256) NOT NULL UNIQUE,
+    email VARCHAR(256) NOT NULL CONSTRAINT emailpassword_users_email_key UNIQUE,
     password_hash VARCHAR(128) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (user_id)
+    CONSTRAINT emailpassword_users_pkey PRIMARY KEY (user_id)
 );
 
 CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
     user_id CHAR(36) NOT NULL,
-    token VARCHAR(128) NOT NULL UNIQUE,
+    token VARCHAR(128) NOT NULL CONSTRAINT emailpassword_pswd_reset_tokens_token_key UNIQUE,
     token_expiry BIGINT NOT NULL,
-    PRIMARY KEY (user_id, token),
-    FOREIGN KEY (user_id) REFERENCES emailpassword_users (user_id) ON DELETE CASCADE ON UPDATE CASCADE
+    CONSTRAINT emailpassword_pswd_reset_tokens_pkey PRIMARY KEY (user_id, token),
+    CONSTRAINT emailpassword_pswd_reset_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES emailpassword_users (user_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
@@ -149,15 +149,15 @@ CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_ps
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
     user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
-    PRIMARY KEY (user_id, email)
+    CONSTRAINT emailverification_verified_emails_pkey PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
     user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
-    token VARCHAR(128) NOT NULL UNIQUE,
+    token VARCHAR(128) NOT NULL CONSTRAINT emailverification_tokens_token_key UNIQUE,
     token_expiry BIGINT NOT NULL,
-    PRIMARY KEY (user_id, email, token)
+    CONSTRAINT emailverification_tokens_pkey PRIMARY KEY (user_id, email, token)
 );
 
 CREATE INDEX emailverification_tokens_index ON emailverification_tokens(token_expiry);
@@ -165,10 +165,10 @@ CREATE INDEX emailverification_tokens_index ON emailverification_tokens(token_ex
 CREATE TABLE IF NOT EXISTS thirdparty_users (
     third_party_id VARCHAR(28) NOT NULL,
     third_party_user_id VARCHAR(128) NOT NULL,
-    user_id CHAR(36) NOT NULL,
+    user_id CHAR(36) NOT NULL CONSTRAINT thirdparty_users_user_id_key UNIQUE,
     email VARCHAR(256) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (third_party_id, third_party_user_id)
+    CONSTRAINT thirdparty_users_pkey PRIMARY KEY (third_party_id, third_party_user_id)
 );
 
 CREATE TABLE IF NOT EXISTS jwt_signing_keys (
@@ -176,7 +176,7 @@ CREATE TABLE IF NOT EXISTS jwt_signing_keys (
     key_string TEXT NOT NULL,
     algorithm VARCHAR(10) NOT NULL,
     created_at BIGINT,
-    PRIMARY KEY(key_id)
+    CONSTRAINT jwt_signing_keys_pkey PRIMARY KEY(key_id)
 );
 ```
 

--- a/v2/thirdparty/quick-setup/database-setup/postgresql.mdx
+++ b/v2/thirdparty/quick-setup/database-setup/postgresql.mdx
@@ -100,21 +100,21 @@ CREATE TABLE IF NOT EXISTS key_value (
     name VARCHAR(128),
     value TEXT,
     created_at_time BIGINT,
-    PRIMARY KEY(name)
+    CONSTRAINT key_value_pkey PRIMARY KEY(name)
 );
 
 CREATE TABLE IF NOT EXISTS all_auth_recipe_users(
     user_id CHAR(36) NOT NULL,
     recipe_id VARCHAR(128) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (user_id)
+    CONSTRAINT all_auth_recipe_users_pkey PRIMARY KEY (user_id)
 );
 CREATE INDEX all_auth_recipe_users_pagination_index ON all_auth_recipe_users (time_joined DESC, user_id DESC);
 
 CREATE TABLE session_access_token_signing_keys (
     created_at_time BIGINT NOT NULL,
     value TEXT,
-    PRIMARY KEY (created_at_time)
+    CONSTRAINT session_access_token_signing_keys_pkey PRIMARY KEY (created_at_time)
 );
 
 CREATE TABLE IF NOT EXISTS session_info (
@@ -125,23 +125,23 @@ CREATE TABLE IF NOT EXISTS session_info (
     expires_at BIGINT NOT NULL,
     created_at_time BIGINT NOT NULL,
     jwt_user_payload TEXT,
-    PRIMARY KEY(session_handle)
+    CONSTRAINT session_info_pkey PRIMARY KEY(session_handle)
 );
 
 CREATE TABLE IF NOT EXISTS emailpassword_users (
     user_id CHAR(36) NOT NULL,
-    email VARCHAR(256) NOT NULL UNIQUE,
+    email VARCHAR(256) NOT NULL CONSTRAINT emailpassword_users_email_key UNIQUE,
     password_hash VARCHAR(128) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (user_id)
+    CONSTRAINT emailpassword_users_pkey PRIMARY KEY (user_id)
 );
 
 CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
     user_id CHAR(36) NOT NULL,
-    token VARCHAR(128) NOT NULL UNIQUE,
+    token VARCHAR(128) NOT NULL CONSTRAINT emailpassword_pswd_reset_tokens_token_key UNIQUE,
     token_expiry BIGINT NOT NULL,
-    PRIMARY KEY (user_id, token),
-    FOREIGN KEY (user_id) REFERENCES emailpassword_users (user_id) ON DELETE CASCADE ON UPDATE CASCADE
+    CONSTRAINT emailpassword_pswd_reset_tokens_pkey PRIMARY KEY (user_id, token),
+    CONSTRAINT emailpassword_pswd_reset_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES emailpassword_users (user_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
@@ -149,15 +149,15 @@ CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_ps
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
     user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
-    PRIMARY KEY (user_id, email)
+    CONSTRAINT emailverification_verified_emails_pkey PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
     user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
-    token VARCHAR(128) NOT NULL UNIQUE,
+    token VARCHAR(128) NOT NULL CONSTRAINT emailverification_tokens_token_key UNIQUE,
     token_expiry BIGINT NOT NULL,
-    PRIMARY KEY (user_id, email, token)
+    CONSTRAINT emailverification_tokens_pkey PRIMARY KEY (user_id, email, token)
 );
 
 CREATE INDEX emailverification_tokens_index ON emailverification_tokens(token_expiry);
@@ -165,10 +165,10 @@ CREATE INDEX emailverification_tokens_index ON emailverification_tokens(token_ex
 CREATE TABLE IF NOT EXISTS thirdparty_users (
     third_party_id VARCHAR(28) NOT NULL,
     third_party_user_id VARCHAR(128) NOT NULL,
-    user_id CHAR(36) NOT NULL,
+    user_id CHAR(36) NOT NULL CONSTRAINT thirdparty_users_user_id_key UNIQUE,
     email VARCHAR(256) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (third_party_id, third_party_user_id)
+    CONSTRAINT thirdparty_users_pkey PRIMARY KEY (third_party_id, third_party_user_id)
 );
 
 CREATE TABLE IF NOT EXISTS jwt_signing_keys (
@@ -176,7 +176,7 @@ CREATE TABLE IF NOT EXISTS jwt_signing_keys (
     key_string TEXT NOT NULL,
     algorithm VARCHAR(10) NOT NULL,
     created_at BIGINT,
-    PRIMARY KEY(key_id)
+    CONSTRAINT jwt_signing_keys_pkey PRIMARY KEY(key_id)
 );
 ```
 

--- a/v2/thirdpartyemailpassword/quick-setup/database-setup/postgresql.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/database-setup/postgresql.mdx
@@ -100,21 +100,21 @@ CREATE TABLE IF NOT EXISTS key_value (
     name VARCHAR(128),
     value TEXT,
     created_at_time BIGINT,
-    PRIMARY KEY(name)
+    CONSTRAINT key_value_pkey PRIMARY KEY(name)
 );
 
 CREATE TABLE IF NOT EXISTS all_auth_recipe_users(
     user_id CHAR(36) NOT NULL,
     recipe_id VARCHAR(128) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (user_id)
+    CONSTRAINT all_auth_recipe_users_pkey PRIMARY KEY (user_id)
 );
 CREATE INDEX all_auth_recipe_users_pagination_index ON all_auth_recipe_users (time_joined DESC, user_id DESC);
 
 CREATE TABLE session_access_token_signing_keys (
     created_at_time BIGINT NOT NULL,
     value TEXT,
-    PRIMARY KEY (created_at_time)
+    CONSTRAINT session_access_token_signing_keys_pkey PRIMARY KEY (created_at_time)
 );
 
 CREATE TABLE IF NOT EXISTS session_info (
@@ -125,23 +125,23 @@ CREATE TABLE IF NOT EXISTS session_info (
     expires_at BIGINT NOT NULL,
     created_at_time BIGINT NOT NULL,
     jwt_user_payload TEXT,
-    PRIMARY KEY(session_handle)
+    CONSTRAINT session_info_pkey PRIMARY KEY(session_handle)
 );
 
 CREATE TABLE IF NOT EXISTS emailpassword_users (
     user_id CHAR(36) NOT NULL,
-    email VARCHAR(256) NOT NULL UNIQUE,
+    email VARCHAR(256) NOT NULL CONSTRAINT emailpassword_users_email_key UNIQUE,
     password_hash VARCHAR(128) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (user_id)
+    CONSTRAINT emailpassword_users_pkey PRIMARY KEY (user_id)
 );
 
 CREATE TABLE IF NOT EXISTS emailpassword_pswd_reset_tokens (
     user_id CHAR(36) NOT NULL,
-    token VARCHAR(128) NOT NULL UNIQUE,
+    token VARCHAR(128) NOT NULL CONSTRAINT emailpassword_pswd_reset_tokens_token_key UNIQUE,
     token_expiry BIGINT NOT NULL,
-    PRIMARY KEY (user_id, token),
-    FOREIGN KEY (user_id) REFERENCES emailpassword_users (user_id) ON DELETE CASCADE ON UPDATE CASCADE
+    CONSTRAINT emailpassword_pswd_reset_tokens_pkey PRIMARY KEY (user_id, token),
+    CONSTRAINT emailpassword_pswd_reset_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES emailpassword_users (user_id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_pswd_reset_tokens(token_expiry);
@@ -149,15 +149,15 @@ CREATE INDEX emailpassword_password_reset_token_expiry_index ON emailpassword_ps
 CREATE TABLE IF NOT EXISTS emailverification_verified_emails (
     user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
-    PRIMARY KEY (user_id, email)
+    CONSTRAINT emailverification_verified_emails_pkey PRIMARY KEY (user_id, email)
 );
 
 CREATE TABLE IF NOT EXISTS emailverification_tokens (
     user_id VARCHAR(128) NOT NULL,
     email VARCHAR(256),
-    token VARCHAR(128) NOT NULL UNIQUE,
+    token VARCHAR(128) NOT NULL CONSTRAINT emailverification_tokens_token_key UNIQUE,
     token_expiry BIGINT NOT NULL,
-    PRIMARY KEY (user_id, email, token)
+    CONSTRAINT emailverification_tokens_pkey PRIMARY KEY (user_id, email, token)
 );
 
 CREATE INDEX emailverification_tokens_index ON emailverification_tokens(token_expiry);
@@ -165,10 +165,10 @@ CREATE INDEX emailverification_tokens_index ON emailverification_tokens(token_ex
 CREATE TABLE IF NOT EXISTS thirdparty_users (
     third_party_id VARCHAR(28) NOT NULL,
     third_party_user_id VARCHAR(128) NOT NULL,
-    user_id CHAR(36) NOT NULL,
+    user_id CHAR(36) NOT NULL CONSTRAINT thirdparty_users_user_id_key UNIQUE,
     email VARCHAR(256) NOT NULL,
     time_joined BIGINT NOT NULL,
-    PRIMARY KEY (third_party_id, third_party_user_id)
+    CONSTRAINT thirdparty_users_pkey PRIMARY KEY (third_party_id, third_party_user_id)
 );
 
 CREATE TABLE IF NOT EXISTS jwt_signing_keys (
@@ -176,7 +176,7 @@ CREATE TABLE IF NOT EXISTS jwt_signing_keys (
     key_string TEXT NOT NULL,
     algorithm VARCHAR(10) NOT NULL,
     created_at BIGINT,
-    PRIMARY KEY(key_id)
+    CONSTRAINT jwt_signing_keys_pkey PRIMARY KEY(key_id)
 );
 ```
 


### PR DESCRIPTION
## Summary of change
Explicitly naming constraints in PostgreSQL for more robust error handling. We are using the default naming convention of PostgreSQL to be backwards compatible.
Improves compatibility with CockroachDB

## Related issues
- supertokens/supertokens-postgresql-plugin#22
