### PR TITLE
Dev oauth keys node

### DIFF
--- a/v2/thirdparty/quick-setup/backend.mdx
+++ b/v2/thirdparty/quick-setup/backend.mdx
@@ -306,6 +306,23 @@ thirdparty.Init(&tpepmodels.TypeInput{
 </TabItem>
 </BackendSDKTabs>
 
+:::tip Using Development OAuth Keys
+To help users get started quickly, SuperTokens provides development OAuth credentials for setting up social providers.
+
+- Google:
+    - Client Id: 
+    - Client Secret: 
+- Github:
+    - Client Id:
+    - Client Secret:
+- Facebook:
+    - Client Id: 
+    - Client Secret:  
+
+** Note: The development keys are to be used for testing puroposes only, make sure to use valid credentials in production **
+:::
+
+
 Please refer to the corresponding documentations to get your client ids and client secrets for each of the below providers:
 - [Google](https://developers.google.com/identity/sign-in/web/sign-in#create_authorization_credentials) (Authorisation callback URL is `^{form_websiteDomain}/auth/callback/google`)
 - [Github](https://docs.github.com/en/developers/apps/creating-an-oauth-app) (Authorisation callback URL is `^{form_websiteDomain}/auth/callback/github`)

--- a/v2/thirdparty/quick-setup/backend.mdx
+++ b/v2/thirdparty/quick-setup/backend.mdx
@@ -309,16 +309,14 @@ thirdparty.Init(&tpepmodels.TypeInput{
 :::tip Using Development OAuth Keys
 To help users get started quickly, SuperTokens provides development OAuth credentials for setting up social providers.
 
-- Google:
-    - Client Id: 
+```
+Google:
+    - Client Id: 1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com
     - Client Secret: 
-- Github:
-    - Client Id:
+Github:
+    - Client Id: 467101b197249757c71f
     - Client Secret:
-- Facebook:
-    - Client Id: 
-    - Client Secret:  
-
+```
 ** Note: The development keys are to be used for testing puroposes only, make sure to use valid credentials in production **
 :::
 

--- a/v2/thirdpartyemailpassword/quick-setup/backend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/backend.mdx
@@ -308,6 +308,22 @@ thirdpartyemailpassword.Init(&tpepmodels.TypeInput{
 </TabItem>
 </BackendSDKTabs>
 
+:::tip Using Development OAuth Keys
+To help users get started quickly, SuperTokens provides development OAuth credentials for setting up social providers.
+
+- Google:
+    - Client Id: 
+    - Client Secret: 
+- Github:
+    - Client Id:
+    - Client Secret:
+- Facebook:
+    - Client Id: 
+    - Client Secret:  
+
+** Note: The development keys are to be used for testing puroposes only, make sure to use valid credentials in production **
+:::
+
 Please refer to the corresponding documentations to get your client ids and client secrets for each of the below providers:
 - [Google](https://developers.google.com/identity/sign-in/web/sign-in#create_authorization_credentials) (Authorisation callback URL is `^{form_websiteDomain}/auth/callback/google`)
 - [Github](https://docs.github.com/en/developers/apps/creating-an-oauth-app) (Authorisation callback URL is `^{form_websiteDomain}/auth/callback/github`)

--- a/v2/thirdpartyemailpassword/quick-setup/backend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/backend.mdx
@@ -311,16 +311,14 @@ thirdpartyemailpassword.Init(&tpepmodels.TypeInput{
 :::tip Using Development OAuth Keys
 To help users get started quickly, SuperTokens provides development OAuth credentials for setting up social providers.
 
-- Google:
-    - Client Id: 
+```
+Google:
+    - Client Id: 1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com
     - Client Secret: 
-- Github:
-    - Client Id:
+Github:
+    - Client Id: 467101b197249757c71f
     - Client Secret:
-- Facebook:
-    - Client Id: 
-    - Client Secret:  
-
+```
 ** Note: The development keys are to be used for testing puroposes only, make sure to use valid credentials in production **
 :::
 


### PR DESCRIPTION
## Summary of change
Adds docs for using OAuth development keys for Google and Github.
## Related issues
https://github.com/supertokens/docs/issues/134

## Remaining TODOs for this PR
- [ ] client secrets have to be added, in a way so that they do not get crawled