### PR TITLE
Use yarn add instead of install

### DIFF
--- a/v2/emailpassword/nextjs/init.mdx
+++ b/v2/emailpassword/nextjs/init.mdx
@@ -14,9 +14,9 @@ import CoreInjector from "/src/components/coreInjector"
 
 ## 1) Install supertokens package
 ```jsx
-yarn install supertokens-node
-yarn install supertokens-auth-react
-yarn install nextjs-cors
+yarn add supertokens-node
+yarn add supertokens-auth-react
+yarn add nextjs-cors
 ```
 
 ## 2) Create configuration files


### PR DESCRIPTION
## Summary of change
Use `yarn add` instead of `yarn install` for commands.

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?