### PR TITLE
Updated nestjs guide to handle responses sent in verifySession

### DIFF
--- a/v2/emailpassword/nestjs/guide.mdx
+++ b/v2/emailpassword/nestjs/guide.mdx
@@ -346,8 +346,8 @@ export class AuthGuard implements CanActivate {
 
     if (resp.headersSent) {
       throw new STError({
-        message: "UNAUTHORISED",
-        type: "UNAUTHORISED",
+        message: "RESPONSE_SENT",
+        type: "RESPONSE_SENT",
       });
     }
 

--- a/v2/emailpassword/nestjs/guide.mdx
+++ b/v2/emailpassword/nestjs/guide.mdx
@@ -262,9 +262,9 @@ import { ExceptionFilter, Catch, ArgumentsHost } from '@nestjs/common';
 import { Request, Response, NextFunction, ErrorRequestHandler } from 'express';
 
 import { errorHandler } from 'supertokens-node/framework/express';
-import { Error } from 'supertokens-node';
+import { Error as STError } from 'supertokens-node';
 
-@Catch(Error)
+@Catch(STError)
 export class SupertokensExceptionFilter implements ExceptionFilter {
   handler: ErrorRequestHandler;
 
@@ -275,10 +275,15 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
   catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
 
+    const resp = ctx.getResponse<Response>();
+    if (resp.headersSent) {
+      return;
+    }
+
     this.handler(
       exception,
       ctx.getRequest<Request>(),
-      ctx.getResponse<Response>(),
+      resp,
       ctx.getNext<NextFunction>(),
     );
   }
@@ -320,6 +325,7 @@ Now that the library is set up, you can add a guard to protect your API. You can
 
 ```ts
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Error as STError } from "supertokens-node";
 
 import { verifySession } from 'supertokens-node/recipe/session/framework/express';
 
@@ -329,15 +335,23 @@ export class AuthGuard implements CanActivate {
     const ctx = context.switchToHttp();
 
     let err = undefined;
+    const resp = ctx.getResponse();
     await verifySession()(
       ctx.getRequest(),
-      ctx.getResponse(),
+      resp,
       (res) => {
         err = res;
       },
     );
 
-    if (err !== undefined) {
+    if (resp.headersSent) {
+      throw new STError({
+        message: "UNAUTHORISED",
+        type: "UNAUTHORISED",
+      });
+    }
+
+    if (err) {
       throw err;
     }
 

--- a/v2/session/nestjs/guide.mdx
+++ b/v2/session/nestjs/guide.mdx
@@ -344,8 +344,8 @@ export class AuthGuard implements CanActivate {
 
     if (resp.headersSent) {
       throw new STError({
-        message: "UNAUTHORISED",
-        type: "UNAUTHORISED",
+        message: "RESPONSE_SENT",
+        type: "RESPONSE_SENT",
       });
     }
 

--- a/v2/session/nestjs/guide.mdx
+++ b/v2/session/nestjs/guide.mdx
@@ -260,9 +260,9 @@ import { ExceptionFilter, Catch, ArgumentsHost } from '@nestjs/common';
 import { Request, Response, NextFunction, ErrorRequestHandler } from 'express';
 
 import { errorHandler } from 'supertokens-node/framework/express';
-import { Error } from 'supertokens-node';
+import { Error as STError } from 'supertokens-node';
 
-@Catch(Error)
+@Catch(STError)
 export class SupertokensExceptionFilter implements ExceptionFilter {
   handler: ErrorRequestHandler;
 
@@ -273,10 +273,15 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
   catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
 
+    const resp = ctx.getResponse<Response>();
+    if (resp.headersSent) {
+      return;
+    }
+
     this.handler(
       exception,
       ctx.getRequest<Request>(),
-      ctx.getResponse<Response>(),
+      resp,
       ctx.getNext<NextFunction>(),
     );
   }
@@ -318,6 +323,7 @@ Now that the library is set up, you can add a guard to protect your API. You can
 
 ```ts
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Error as STError } from "supertokens-node";
 
 import { verifySession } from 'supertokens-node/recipe/session/framework/express';
 
@@ -327,15 +333,23 @@ export class AuthGuard implements CanActivate {
     const ctx = context.switchToHttp();
 
     let err = undefined;
+    const resp = ctx.getResponse();
     await verifySession()(
       ctx.getRequest(),
-      ctx.getResponse(),
+      resp,
       (res) => {
         err = res;
       },
     );
 
-    if (err !== undefined) {
+    if (resp.headersSent) {
+      throw new STError({
+        message: "UNAUTHORISED",
+        type: "UNAUTHORISED",
+      });
+    }
+
+    if (err) {
       throw err;
     }
 

--- a/v2/thirdparty/nestjs/guide.mdx
+++ b/v2/thirdparty/nestjs/guide.mdx
@@ -310,9 +310,9 @@ import { ExceptionFilter, Catch, ArgumentsHost } from '@nestjs/common';
 import { Request, Response, NextFunction, ErrorRequestHandler } from 'express';
 
 import { errorHandler } from 'supertokens-node/framework/express';
-import { Error } from 'supertokens-node';
+import { Error as STError } from 'supertokens-node';
 
-@Catch(Error)
+@Catch(STError)
 export class SupertokensExceptionFilter implements ExceptionFilter {
   handler: ErrorRequestHandler;
 
@@ -323,10 +323,15 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
   catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
 
+    const resp = ctx.getResponse<Response>();
+    if (resp.headersSent) {
+      return;
+    }
+
     this.handler(
       exception,
       ctx.getRequest<Request>(),
-      ctx.getResponse<Response>(),
+      resp,
       ctx.getNext<NextFunction>(),
     );
   }
@@ -368,6 +373,7 @@ Now that the library is set up, you can add a guard to protect your API. You can
 
 ```ts
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Error as STError } from "supertokens-node";
 
 import { verifySession } from 'supertokens-node/recipe/session/framework/express';
 
@@ -377,15 +383,23 @@ export class AuthGuard implements CanActivate {
     const ctx = context.switchToHttp();
 
     let err = undefined;
+    const resp = ctx.getResponse();
     await verifySession()(
       ctx.getRequest(),
-      ctx.getResponse(),
+      resp,
       (res) => {
         err = res;
       },
     );
 
-    if (err !== undefined) {
+    if (resp.headersSent) {
+      throw new STError({
+        message: "UNAUTHORISED",
+        type: "UNAUTHORISED",
+      });
+    }
+
+    if (err) {
       throw err;
     }
 

--- a/v2/thirdparty/nestjs/guide.mdx
+++ b/v2/thirdparty/nestjs/guide.mdx
@@ -394,8 +394,8 @@ export class AuthGuard implements CanActivate {
 
     if (resp.headersSent) {
       throw new STError({
-        message: "UNAUTHORISED",
-        type: "UNAUTHORISED",
+        message: "RESPONSE_SENT",
+        type: "RESPONSE_SENT",
       });
     }
 

--- a/v2/thirdpartyemailpassword/nestjs/guide.mdx
+++ b/v2/thirdpartyemailpassword/nestjs/guide.mdx
@@ -392,8 +392,8 @@ export class AuthGuard implements CanActivate {
 
     if (resp.headersSent) {
       throw new STError({
-        message: "UNAUTHORISED",
-        type: "UNAUTHORISED",
+        message: "RESPONSE_SENT",
+        type: "RESPONSE_SENT",
       });
     }
 

--- a/v2/thirdpartyemailpassword/nestjs/guide.mdx
+++ b/v2/thirdpartyemailpassword/nestjs/guide.mdx
@@ -308,9 +308,9 @@ import { ExceptionFilter, Catch, ArgumentsHost } from '@nestjs/common';
 import { Request, Response, NextFunction, ErrorRequestHandler } from 'express';
 
 import { errorHandler } from 'supertokens-node/framework/express';
-import { Error } from 'supertokens-node';
+import { Error as STError } from 'supertokens-node';
 
-@Catch(Error)
+@Catch(STError)
 export class SupertokensExceptionFilter implements ExceptionFilter {
   handler: ErrorRequestHandler;
 
@@ -321,10 +321,15 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
   catch(exception: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
 
+    const resp = ctx.getResponse<Response>();
+    if (resp.headersSent) {
+      return;
+    }
+
     this.handler(
       exception,
       ctx.getRequest<Request>(),
-      ctx.getResponse<Response>(),
+      resp,
       ctx.getNext<NextFunction>(),
     );
   }
@@ -366,6 +371,7 @@ Now that the library is set up, you can add a guard to protect your API. You can
 
 ```ts
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Error as STError } from "supertokens-node";
 
 import { verifySession } from 'supertokens-node/recipe/session/framework/express';
 
@@ -375,15 +381,23 @@ export class AuthGuard implements CanActivate {
     const ctx = context.switchToHttp();
 
     let err = undefined;
+    const resp = ctx.getResponse();
     await verifySession()(
       ctx.getRequest(),
-      ctx.getResponse(),
+      resp,
       (res) => {
         err = res;
       },
     );
 
-    if (err !== undefined) {
+    if (resp.headersSent) {
+      throw new STError({
+        message: "UNAUTHORISED",
+        type: "UNAUTHORISED",
+      });
+    }
+
+    if (err) {
       throw err;
     }
 


### PR DESCRIPTION
## Summary of change
In case of errors, we are sending responses inside verifySession instead of calling the next function. 
The NestJS guide needed to be updated to handle this correctly as it expected the next call and tried to send the response again and allowed some wrong calls through the guard.

## Related issues
- Problem reported by email.

## Checklist
- [x] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [x] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [x] Changes required to the demo apps corresponding to the docs?
