### PR TITLE
added mode config for fastapi framework

### DIFF
--- a/v2/emailpassword/quick-setup/backend.mdx
+++ b/v2/emailpassword/quick-setup/backend.mdx
@@ -274,7 +274,8 @@ init(
         emailpassword.init(
            # TODO: See next step*/
         )
-    ]
+    ],
+    mode='asgi' # use wsgi if you are running using gunicorn
 })
 ```
 

--- a/v2/session/quick-setup/backend.mdx
+++ b/v2/session/quick-setup/backend.mdx
@@ -240,7 +240,8 @@ init(
     framework='fastapi',
     recipe_list=[
 	    session.init()
-    ]
+    ],
+    mode='asgi' # use wsgi if you are running using gunicorn
 })
 ```
 

--- a/v2/thirdparty/quick-setup/backend.mdx
+++ b/v2/thirdparty/quick-setup/backend.mdx
@@ -276,7 +276,8 @@ init(
         thirdparty.init(
            # TODO: See next step*/
         )
-    ]
+    ],
+    mode='asgi' # use wsgi if you are running using gunicorn
 })
 ```
 

--- a/v2/thirdpartyemailpassword/quick-setup/backend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/backend.mdx
@@ -279,7 +279,8 @@ init(
         thirdpartyemailpassword.init(
            # TODO: See next step*/
         )
-    ]
+    ],
+    mode='asgi' # use wsgi if you are running using gunicorn
 })
 ```
 


### PR DESCRIPTION
## Summary of change
`mode` config parameter is now supported for framework `fastapi` in supertokens-python sdk.

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
