### PR TITLE
Reusing Guard from guide in nestjs docs

### DIFF
--- a/v2/emailpassword/common-customizations/get-user-info.mdx
+++ b/v2/emailpassword/common-customizations/get-user-info.mdx
@@ -250,20 +250,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let userId = req.session.getUserId();
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
+    let userId = session.getUserId();
     // You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki
     //highlight-next-line
     let userInfo = await ^{recipeNameCapitalLetters}.getUserById(userId); 

--- a/v2/emailpassword/common-customizations/sessions/session-verification-in-api/verify-session.mdx
+++ b/v2/emailpassword/common-customizations/sessions/session-verification-in-api/verify-session.mdx
@@ -157,23 +157,13 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-let { SessionRequest } = require("supertokens-node/framework/express");
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session
-    let userId = session!.getUserId();
+    let userId = session.getUserId();
 
     //highlight-end
     //....
@@ -515,23 +505,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-import { SessionRequest } from "supertokens-node/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession({sessionRequired: false})(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session;
-
     if (session !== undefined) {
         let userId = session.getUserId();
         // session exists

--- a/v2/emailpassword/common-customizations/verify-session.mdx
+++ b/v2/emailpassword/common-customizations/verify-session.mdx
@@ -157,23 +157,13 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-let { SessionRequest } = require("supertokens-node/framework/express");
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session
-    let userId = session!.getUserId();
+    let userId = session.getUserId();
 
     //highlight-end
     //....
@@ -515,23 +505,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-import { SessionRequest } from "supertokens-node/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession({sessionRequired: false})(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session;
-
     if (session !== undefined) {
         let userId = session.getUserId();
         // session exists

--- a/v2/emailpassword/nestjs/guide.mdx
+++ b/v2/emailpassword/nestjs/guide.mdx
@@ -336,6 +336,7 @@ export class AuthGuard implements CanActivate {
 
     let err = undefined;
     const resp = ctx.getResponse();
+    // You can create an optional version of this by passing {sessionRequired: false} to verifySession
     await verifySession()(
       ctx.getRequest(),
       resp,

--- a/v2/passwordless/common-customizations/get-user-info.mdx
+++ b/v2/passwordless/common-customizations/get-user-info.mdx
@@ -293,20 +293,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let userId = req.session.getUserId();
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
+    let userId = session.getUserId();
     //highlight-next-line
     let userInfo = await ^{recipeNameCapitalLetters}.getUserById({userId}); 
     //....

--- a/v2/passwordless/common-customizations/sessions/session-verification-in-api/verify-session.mdx
+++ b/v2/passwordless/common-customizations/sessions/session-verification-in-api/verify-session.mdx
@@ -157,23 +157,13 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-let { SessionRequest } = require("supertokens-node/framework/express");
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session
-    let userId = session!.getUserId();
+    let userId = session.getUserId();
 
     //highlight-end
     //....
@@ -515,23 +505,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-import { SessionRequest } from "supertokens-node/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession({sessionRequired: false})(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session;
-
     if (session !== undefined) {
         let userId = session.getUserId();
         // session exists

--- a/v2/passwordless/common-customizations/verify-session.mdx
+++ b/v2/passwordless/common-customizations/verify-session.mdx
@@ -157,23 +157,13 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-let { SessionRequest } = require("supertokens-node/framework/express");
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session
-    let userId = session!.getUserId();
+    let userId = session.getUserId();
 
     //highlight-end
     //....
@@ -515,23 +505,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-import { SessionRequest } from "supertokens-node/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession({sessionRequired: false})(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session;
-
     if (session !== undefined) {
         let userId = session.getUserId();
         // session exists

--- a/v2/passwordless/nestjs/guide.mdx
+++ b/v2/passwordless/nestjs/guide.mdx
@@ -351,6 +351,7 @@ export class AuthGuard implements CanActivate {
 
     let err = undefined;
     const resp = ctx.getResponse();
+    // You can create an optional version of this by passing {sessionRequired: false} to verifySession
     await verifySession()(
       ctx.getRequest(),
       resp,

--- a/v2/session/common-customizations/sessions/session-verification-in-api/verify-session.mdx
+++ b/v2/session/common-customizations/sessions/session-verification-in-api/verify-session.mdx
@@ -157,23 +157,13 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-let { SessionRequest } = require("supertokens-node/framework/express");
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session
-    let userId = session!.getUserId();
+    let userId = session.getUserId();
 
     //highlight-end
     //....
@@ -515,23 +505,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-import { SessionRequest } from "supertokens-node/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession({sessionRequired: false})(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session;
-
     if (session !== undefined) {
         let userId = session.getUserId();
         // session exists

--- a/v2/session/nestjs/guide.mdx
+++ b/v2/session/nestjs/guide.mdx
@@ -334,6 +334,7 @@ export class AuthGuard implements CanActivate {
 
     let err = undefined;
     const resp = ctx.getResponse();
+    // You can create an optional version of this by passing {sessionRequired: false} to verifySession
     await verifySession()(
       ctx.getRequest(),
       resp,

--- a/v2/thirdparty/common-customizations/get-user-info.mdx
+++ b/v2/thirdparty/common-customizations/get-user-info.mdx
@@ -250,20 +250,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let userId = req.session.getUserId();
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
+    let userId = session.getUserId();
     // You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki
     //highlight-next-line
     let userInfo = await ^{recipeNameCapitalLetters}.getUserById(userId); 

--- a/v2/thirdparty/common-customizations/sessions/session-verification-in-api/verify-session.mdx
+++ b/v2/thirdparty/common-customizations/sessions/session-verification-in-api/verify-session.mdx
@@ -157,23 +157,13 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-let { SessionRequest } = require("supertokens-node/framework/express");
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session
-    let userId = session!.getUserId();
+    let userId = session.getUserId();
 
     //highlight-end
     //....
@@ -515,23 +505,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-import { SessionRequest } from "supertokens-node/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession({sessionRequired: false})(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session;
-
     if (session !== undefined) {
         let userId = session.getUserId();
         // session exists

--- a/v2/thirdparty/common-customizations/verify-session.mdx
+++ b/v2/thirdparty/common-customizations/verify-session.mdx
@@ -157,23 +157,13 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-let { SessionRequest } = require("supertokens-node/framework/express");
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session
-    let userId = session!.getUserId();
+    let userId = session.getUserId();
 
     //highlight-end
     //....
@@ -515,23 +505,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-import { SessionRequest } from "supertokens-node/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession({sessionRequired: false})(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session;
-
     if (session !== undefined) {
         let userId = session.getUserId();
         // session exists

--- a/v2/thirdparty/nestjs/guide.mdx
+++ b/v2/thirdparty/nestjs/guide.mdx
@@ -384,6 +384,7 @@ export class AuthGuard implements CanActivate {
 
     let err = undefined;
     const resp = ctx.getResponse();
+    // You can create an optional version of this by passing {sessionRequired: false} to verifySession
     await verifySession()(
       ctx.getRequest(),
       resp,

--- a/v2/thirdpartyemailpassword/common-customizations/get-user-info.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/get-user-info.mdx
@@ -250,20 +250,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let userId = req.session.getUserId();
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
+    let userId = session.getUserId();
     // You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki
     //highlight-next-line
     let userInfo = await ^{recipeNameCapitalLetters}.getUserById(userId); 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/session-verification-in-api/verify-session.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/session-verification-in-api/verify-session.mdx
@@ -157,23 +157,13 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-let { SessionRequest } = require("supertokens-node/framework/express");
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session
-    let userId = session!.getUserId();
+    let userId = session.getUserId();
 
     //highlight-end
     //....
@@ -515,23 +505,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-import { SessionRequest } from "supertokens-node/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession({sessionRequired: false})(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session;
-
     if (session !== undefined) {
         let userId = session.getUserId();
         // session exists

--- a/v2/thirdpartyemailpassword/common-customizations/verify-session.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/verify-session.mdx
@@ -157,23 +157,13 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-let { SessionRequest } = require("supertokens-node/framework/express");
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession()(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session
-    let userId = session!.getUserId();
+    let userId = session.getUserId();
 
     //highlight-end
     //....
@@ -515,23 +505,12 @@ export default async function likeComment(req, res) {
 <TabItem value="nestjs">
 
 ```tsx
-import { verifySession } from "supertokens-node/recipe/session/framework/express";
-import { SessionRequest } from "supertokens-node/framework/express";
-
 @Controller()
 export class ExampleController {
   @Post('example')
-  async postExample(@Request() req, @Response({passthrough: true}) res): Promise<boolean> {
+  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  async postExample(@Request() req, @Session() session, @Response({passthrough: true}) res): Promise<boolean> {
     //highlight-start
-    // This should be done inside a guard, for more information please read our NestJS guide.
-    let exception;
-    await verifySession({sessionRequired: false})(req, res, (e) => exception = e);
-    if (exception) {
-        throw exception;
-    }
-
-    let session = (req as SessionRequest).session;
-
     if (session !== undefined) {
         let userId = session.getUserId();
         // session exists

--- a/v2/thirdpartyemailpassword/nestjs/guide.mdx
+++ b/v2/thirdpartyemailpassword/nestjs/guide.mdx
@@ -381,6 +381,7 @@ export class AuthGuard implements CanActivate {
 
     let err = undefined;
     const resp = ctx.getResponse();
+    // You can create an optional version of this by passing {sessionRequired: false} to verifySession
     await verifySession()(
       ctx.getRequest(),
       resp,


### PR DESCRIPTION
## Summary of change
Re-using the Guard in verify session and get user info docs.

## Related issues
- supertokens/docs#185

## Checklist
- [x] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [x] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [x] Changes required to the demo apps corresponding to the docs?
