### PR TITLE
Fix typo in name Django

### DIFF
--- a/v2/emailpassword/quick-setup/backend.mdx
+++ b/v2/emailpassword/quick-setup/backend.mdx
@@ -332,7 +332,7 @@ init(
            # TODO: See next step*/
         )
     ],
-    mode='asgi' # use wsgi if you are running djnago server in sync mode
+    mode='asgi' # use wsgi if you are running django server in sync mode
 })
 ```
 

--- a/v2/passwordless/quick-setup/backend.mdx
+++ b/v2/passwordless/quick-setup/backend.mdx
@@ -374,7 +374,7 @@ init(
             )
         )
     ],
-    mode='asgi' # use wsgi if you are running djnago server in sync mode
+    mode='asgi' # use wsgi if you are running django server in sync mode
 })
 ```
 

--- a/v2/session/quick-setup/backend.mdx
+++ b/v2/session/quick-setup/backend.mdx
@@ -292,7 +292,7 @@ init(
     recipe_list=[
 	    session.init()
     ],
-    mode='asgi' # use wsgi if you are running djnago server in sync mode
+    mode='asgi' # use wsgi if you are running django server in sync mode
 })
 ```
 

--- a/v2/thirdparty/quick-setup/backend.mdx
+++ b/v2/thirdparty/quick-setup/backend.mdx
@@ -334,7 +334,7 @@ init(
            # TODO: See next step*/
         )
     ],
-    mode='asgi' # use wsgi if you are running djnago server in sync mode
+    mode='asgi' # use wsgi if you are running django server in sync mode
 })
 ```
 

--- a/v2/thirdpartyemailpassword/quick-setup/backend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/backend.mdx
@@ -337,7 +337,7 @@ init(
            # TODO: See next step*/
         )
     ],
-    mode='asgi' # use wsgi if you are running djnago server in sync mode
+    mode='asgi' # use wsgi if you are running django server in sync mode
 })
 ```
 


### PR DESCRIPTION
## Summary of change
Fix typo. Change `djnago` -> `django`

## Related issues
NA

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
NA