### PR TITLE
docs: add docs for custom translations

### DIFF
--- a/v2/emailpassword/common-customizations/translations.mdx
+++ b/v2/emailpassword/common-customizations/translations.mdx
@@ -1,0 +1,177 @@
+---
+id: translations
+title: Translating the UI
+hide_title: true
+---
+
+<!-- COPY DOCS -->
+<!-- ./passwordless/common-customizations/translations.mdx -->
+
+import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs";
+import TabItem from '@theme/TabItem';
+import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+
+# Translating the UI
+
+You can translate the UI using two main methods:
+1. You can override all displayed translation strings by providing translated versions for different languages (and even change the default English version).
+2. You can provide a translation function to integrate supertokens with your preferred internationalization library.
+
+## Translation strings
+
+### Providing translation strings
+
+You can provide translations for each segment displayed in our UIs. To see what keys you should cover, please check [here](https://github.com/supertokens/supertokens-auth-react/blob/master/lib/ts/recipe/^{codeImportRecipeName}/components/themes/translations.ts).
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import React from "react";
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.init({
+    // highlight-start
+    languageTranslations: { // This object contains all translation related options
+        translations: { // These are the displayed translation strings for each language
+          // The property names define the language code of the translations
+          en: {
+            // Here each key is a translation key and the value is the string that will be displayed
+            // Setting the value to undefined will either display the translation from the default language or the translation key
+            BRANDING_POWERED_BY_START: "We ❤️ ",
+          },
+          hu: {
+            BRANDING_POWERED_BY_START: "Sok szeretettel: ",
+            // This key is associated with an empty string by default, but you can override these as well.
+            BRANDING_POWERED_BY_END: " 😊",
+          }
+        },
+        /* 
+         * This optional property sets the default and fallback language. 
+         * It can be any string that will be used to fetch translations from the above object.
+         * Defaults to "en"
+         */
+        defaultLanguage: "hu", 
+    },
+    // highlight-end
+    appInfo: {
+        appName: "...",
+        apiDomain: "...",
+        websiteDomain: "...",
+    },
+    recipeList: [
+      // ...
+    ],
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+### Loading translations
+
+After initialization, you can load translations by calling the `SuperTokens.loadTranslation`:
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import SuperTokens from "supertokens-auth-react";
+
+// This method takes an object as a parameter, which is structured the same as above.
+// This will be merged into the existing definitions, so any properties missing here won't remove them from the already loaded translations
+SuperTokens.loadTranslation({
+  en: {
+    BRANDING_POWERED_BY_END: " :)",
+  }
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+### Changing the current language
+
+You can update which translations store is displayed by calling the `SuperTokens.changeLanguage`.
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.changeLanguage("hu");
+```
+</TabItem>
+</FrontendSDKTabs>
+
+## Library integration
+
+You can easily integrate SuperTokens with your internationalization library of choice. You can check out an example using i18next [here](https://github.com/supertokens/supertokens-auth-react/blob/master/examples/with-i18next/src/App.js). To do this you need to do two things:
+
+1. Provide the translation function in `SuperTokens.init`
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import React from "react";
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.init({
+    languageTranslations: {
+        translationFunc: (key: string) => {
+          // The string returned by this function will be displayed
+          return key + "!";
+        },
+    },
+    appInfo: {
+        appName: "...",
+        apiDomain: "...",
+        websiteDomain: "...",
+    },
+    recipeList: [
+      // ...
+    ],
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+2. Call `SuperTokens.changeLanguage` or `SuperTokens.loadTranslation` when the language is updated or new translations are loaded
+
+Since the provided `tranlationFunc` is not updated, the SDK will only re-render and update the displayed translation after either of the above functions are called. You can easily do this in event handlers or at the same time as the current language is changed.
+
+## Partial translations
+
+If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. If it's missing also missing from the default store, the raw translation key is displayed. For example, this can happen for custom error messages returned by the backend API.
+
+## Saving the chosen language
+
+The currently chosen language is stored in a cookie, this way it can be restored the next time the page loads. The domain of this cookie can be customized through the `currentLanguageCookieScope` option. This can be useful if you are running our SDK in multiple applications and want to share the language choice between sub-domains.
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import React from "react";
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.init({
+    languageTranslations: {
+        currentLanguageCookieScope: "http://localhost"
+    },
+    appInfo: {
+        appName: "...",
+        apiDomain: "...",
+        websiteDomain: "...",
+    },
+    recipeList: [
+      // ...
+    ],
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+## Translations in component overrides
+
+The SDK also exports the `useTranslation` React hook you can use while overriding components. It returns a function that takes a translation segment key and returns it translated to the currently selected language. For more information on what translation keys you should use and the exact syntax, please see the original source code of the component you are overriding.

--- a/v2/emailpassword/common-customizations/translations.mdx
+++ b/v2/emailpassword/common-customizations/translations.mdx
@@ -1,6 +1,6 @@
 ---
 id: translations
-title: Translating the UI
+title: Language Translation for the UI
 hide_title: true
 ---
 
@@ -11,7 +11,7 @@ import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs";
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
 
-# Translating the UI
+# Language Translation for the UI
 
 You can translate the UI using two main methods:
 1. You can override all displayed translation strings by providing translated versions for different languages (and even change the default English version).
@@ -76,7 +76,7 @@ SuperTokens.init({
 
 ### Loading translations
 
-After initialization, you can load translations by calling the `SuperTokens.loadTranslation`:
+After initialization, you can provide additional translation data by calling the `SuperTokens.loadTranslation`. This can be useful if you are loading them asynchronously.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">
@@ -151,7 +151,7 @@ This is necessary, because the SDK will only re-render and update the displayed 
 
 ## Partial translations
 
-If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. If it's missing also missing from the default store, the raw translation key is displayed. For example, this can happen for custom error messages returned by the backend API.
+If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. The raw translation key is displayed if it's also missing from the default store. For example, this can happen for custom error messages returned by the backend API.
 
 ## Saving language preferences
 

--- a/v2/emailpassword/common-customizations/translations.mdx
+++ b/v2/emailpassword/common-customizations/translations.mdx
@@ -21,7 +21,11 @@ You can translate the UI using two main methods:
 
 ### Providing translation strings
 
-You can provide translations for each segment displayed in our UIs. To see what keys you should cover, please check [here](https://github.com/supertokens/supertokens-auth-react/blob/master/lib/ts/recipe/^{codeImportRecipeName}/components/themes/translations.ts).
+You can provide translations for each segment displayed in our UIs.
+
+:::important
+To see what keys you should cover, please check [here](https://github.com/supertokens/supertokens-auth-react/blob/master/lib/ts/recipe/^{codeImportRecipeName}/components/themes/translations.ts).
+:::
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">
@@ -39,6 +43,9 @@ SuperTokens.init({
             // Here each key is a translation key and the value is the string that will be displayed
             // Setting the value to undefined will either display the translation from the default language or the translation key
             BRANDING_POWERED_BY_START: "We ❤️ ",
+            // If you added a custom label or placeholder you can also provide translation for them if necessary
+            // You can also use these to provide translations for your component overrides
+            MY_CUSTOM_LABEL: "Age",
           },
           hu: {
             BRANDING_POWERED_BY_START: "Sok szeretettel: ",
@@ -103,7 +110,7 @@ SuperTokens.changeLanguage("hu");
 </TabItem>
 </FrontendSDKTabs>
 
-## Library integration
+## Using an internationalization library
 
 You can easily integrate SuperTokens with your internationalization library of choice. You can check out an example using i18next [here](https://github.com/supertokens/supertokens-auth-react/blob/master/examples/with-i18next/src/App.js). To do this you need to do two things:
 
@@ -117,12 +124,14 @@ import React from "react";
 import SuperTokens from "supertokens-auth-react";
 
 SuperTokens.init({
+    // highlight-start
     languageTranslations: {
         translationFunc: (key: string) => {
           // The string returned by this function will be displayed
           return key + "!";
         },
     },
+    // highlight-end
     appInfo: {
         appName: "...",
         apiDomain: "...",
@@ -136,15 +145,15 @@ SuperTokens.init({
 </TabItem>
 </FrontendSDKTabs>
 
-2. Call `SuperTokens.changeLanguage` or `SuperTokens.loadTranslation` when the language is updated or new translations are loaded
+2. Call `SuperTokens.changeLanguage` or `SuperTokens.loadTranslation` to re-render the translated UI
 
-Since the provided `tranlationFunc` is not updated, the SDK will only re-render and update the displayed translation after either of the above functions are called. You can easily do this in event handlers or at the same time as the current language is changed.
+This is necessary, because the SDK will only re-render and update the displayed strings after either of the above functions are called. You can easily do this in event handlers, when updating the language choice or while adding new translation data.
 
 ## Partial translations
 
 If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. If it's missing also missing from the default store, the raw translation key is displayed. For example, this can happen for custom error messages returned by the backend API.
 
-## Saving the chosen language
+## Saving language preferences
 
 The currently chosen language is stored in a cookie, this way it can be restored the next time the page loads. The domain of this cookie can be customized through the `currentLanguageCookieScope` option. This can be useful if you are running our SDK in multiple applications and want to share the language choice between sub-domains.
 
@@ -156,9 +165,11 @@ import React from "react";
 import SuperTokens from "supertokens-auth-react";
 
 SuperTokens.init({
+    // highlight-start
     languageTranslations: {
-        currentLanguageCookieScope: "http://localhost"
+        currentLanguageCookieScope: ".example.com",
     },
+    // highlight-end
     appInfo: {
         appName: "...",
         apiDomain: "...",
@@ -175,3 +186,24 @@ SuperTokens.init({
 ## Translations in component overrides
 
 The SDK also exports the `useTranslation` React hook you can use while overriding components. It returns a function that takes a translation segment key and returns it translated to the currently selected language. For more information on what translation keys you should use and the exact syntax, please see the original source code of the component you are overriding.
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import { useTranslation } from "supertokens-auth-react";
+
+export const HeaderOverride = () => {
+    const t = useTranslation();
+
+    return (
+        <div>
+            <img src="octocat.jpg" />
+            {t("MY_TRANSLATION_KEY") /* You can use your own custom translation keys as well as the default ones */}
+        </div>
+    );
+};
+```
+
+</TabItem>
+</FrontendSDKTabs>

--- a/v2/emailpassword/sidebars.js
+++ b/v2/emailpassword/sidebars.js
@@ -167,6 +167,7 @@ module.exports = {
             "common-customizations/styling/shadow-dom"
           ]
         },
+        "common-customizations/translations",
         {
           type: "category",
           label: "Changing base path",

--- a/v2/passwordless/common-customizations/translations.mdx
+++ b/v2/passwordless/common-customizations/translations.mdx
@@ -1,0 +1,177 @@
+---
+id: translations
+title: Translating the UI
+hide_title: true
+---
+
+<!-- COPY DOCS -->
+<!-- ./passwordless/common-customizations/translations.mdx -->
+
+import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs";
+import TabItem from '@theme/TabItem';
+import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+
+# Translating the UI
+
+You can translate the UI using two main methods:
+1. You can override all displayed translation strings by providing translated versions for different languages (and even change the default English version).
+2. You can provide a translation function to integrate supertokens with your preferred internationalization library.
+
+## Translation strings
+
+### Providing translation strings
+
+You can provide translations for each segment displayed in our UIs. To see what keys you should cover, please check [here](https://github.com/supertokens/supertokens-auth-react/blob/master/lib/ts/recipe/^{codeImportRecipeName}/components/themes/translations.ts).
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import React from "react";
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.init({
+    // highlight-start
+    languageTranslations: { // This object contains all translation related options
+        translations: { // These are the displayed translation strings for each language
+          // The property names define the language code of the translations
+          en: {
+            // Here each key is a translation key and the value is the string that will be displayed
+            // Setting the value to undefined will either display the translation from the default language or the translation key
+            BRANDING_POWERED_BY_START: "We ❤️ ",
+          },
+          hu: {
+            BRANDING_POWERED_BY_START: "Sok szeretettel: ",
+            // This key is associated with an empty string by default, but you can override these as well.
+            BRANDING_POWERED_BY_END: " 😊",
+          }
+        },
+        /* 
+         * This optional property sets the default and fallback language. 
+         * It can be any string that will be used to fetch translations from the above object.
+         * Defaults to "en"
+         */
+        defaultLanguage: "hu", 
+    },
+    // highlight-end
+    appInfo: {
+        appName: "...",
+        apiDomain: "...",
+        websiteDomain: "...",
+    },
+    recipeList: [
+      // ...
+    ],
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+### Loading translations
+
+After initialization, you can load translations by calling the `SuperTokens.loadTranslation`:
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import SuperTokens from "supertokens-auth-react";
+
+// This method takes an object as a parameter, which is structured the same as above.
+// This will be merged into the existing definitions, so any properties missing here won't remove them from the already loaded translations
+SuperTokens.loadTranslation({
+  en: {
+    BRANDING_POWERED_BY_END: " :)",
+  }
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+### Changing the current language
+
+You can update which translations store is displayed by calling the `SuperTokens.changeLanguage`.
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.changeLanguage("hu");
+```
+</TabItem>
+</FrontendSDKTabs>
+
+## Library integration
+
+You can easily integrate SuperTokens with your internationalization library of choice. You can check out an example using i18next [here](https://github.com/supertokens/supertokens-auth-react/blob/master/examples/with-i18next/src/App.js). To do this you need to do two things:
+
+1. Provide the translation function in `SuperTokens.init`
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import React from "react";
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.init({
+    languageTranslations: {
+        translationFunc: (key: string) => {
+          // The string returned by this function will be displayed
+          return key + "!";
+        },
+    },
+    appInfo: {
+        appName: "...",
+        apiDomain: "...",
+        websiteDomain: "...",
+    },
+    recipeList: [
+      // ...
+    ],
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+2. Call `SuperTokens.changeLanguage` or `SuperTokens.loadTranslation` when the language is updated or new translations are loaded
+
+Since the provided `tranlationFunc` is not updated, the SDK will only re-render and update the displayed translation after either of the above functions are called. You can easily do this in event handlers or at the same time as the current language is changed.
+
+## Partial translations
+
+If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. If it's missing also missing from the default store, the raw translation key is displayed. For example, this can happen for custom error messages returned by the backend API.
+
+## Saving the chosen language
+
+The currently chosen language is stored in a cookie, this way it can be restored the next time the page loads. The domain of this cookie can be customized through the `currentLanguageCookieScope` option. This can be useful if you are running our SDK in multiple applications and want to share the language choice between sub-domains.
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import React from "react";
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.init({
+    languageTranslations: {
+        currentLanguageCookieScope: "http://localhost"
+    },
+    appInfo: {
+        appName: "...",
+        apiDomain: "...",
+        websiteDomain: "...",
+    },
+    recipeList: [
+      // ...
+    ],
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+## Translations in component overrides
+
+The SDK also exports the `useTranslation` React hook you can use while overriding components. It returns a function that takes a translation segment key and returns it translated to the currently selected language. For more information on what translation keys you should use and the exact syntax, please see the original source code of the component you are overriding.

--- a/v2/passwordless/common-customizations/translations.mdx
+++ b/v2/passwordless/common-customizations/translations.mdx
@@ -1,6 +1,6 @@
 ---
 id: translations
-title: Translating the UI
+title: Language Translation for the UI
 hide_title: true
 ---
 
@@ -11,7 +11,7 @@ import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs";
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
 
-# Translating the UI
+# Language Translation for the UI
 
 You can translate the UI using two main methods:
 1. You can override all displayed translation strings by providing translated versions for different languages (and even change the default English version).
@@ -76,7 +76,7 @@ SuperTokens.init({
 
 ### Loading translations
 
-After initialization, you can load translations by calling the `SuperTokens.loadTranslation`:
+After initialization, you can provide additional translation data by calling the `SuperTokens.loadTranslation`. This can be useful if you are loading them asynchronously.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">
@@ -151,7 +151,7 @@ This is necessary, because the SDK will only re-render and update the displayed 
 
 ## Partial translations
 
-If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. If it's missing also missing from the default store, the raw translation key is displayed. For example, this can happen for custom error messages returned by the backend API.
+If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. The raw translation key is displayed if it's also missing from the default store. For example, this can happen for custom error messages returned by the backend API.
 
 ## Saving language preferences
 

--- a/v2/passwordless/common-customizations/translations.mdx
+++ b/v2/passwordless/common-customizations/translations.mdx
@@ -21,7 +21,11 @@ You can translate the UI using two main methods:
 
 ### Providing translation strings
 
-You can provide translations for each segment displayed in our UIs. To see what keys you should cover, please check [here](https://github.com/supertokens/supertokens-auth-react/blob/master/lib/ts/recipe/^{codeImportRecipeName}/components/themes/translations.ts).
+You can provide translations for each segment displayed in our UIs.
+
+:::important
+To see what keys you should cover, please check [here](https://github.com/supertokens/supertokens-auth-react/blob/master/lib/ts/recipe/^{codeImportRecipeName}/components/themes/translations.ts).
+:::
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">
@@ -39,6 +43,9 @@ SuperTokens.init({
             // Here each key is a translation key and the value is the string that will be displayed
             // Setting the value to undefined will either display the translation from the default language or the translation key
             BRANDING_POWERED_BY_START: "We ❤️ ",
+            // If you added a custom label or placeholder you can also provide translation for them if necessary
+            // You can also use these to provide translations for your component overrides
+            MY_CUSTOM_LABEL: "Age",
           },
           hu: {
             BRANDING_POWERED_BY_START: "Sok szeretettel: ",
@@ -103,7 +110,7 @@ SuperTokens.changeLanguage("hu");
 </TabItem>
 </FrontendSDKTabs>
 
-## Library integration
+## Using an internationalization library
 
 You can easily integrate SuperTokens with your internationalization library of choice. You can check out an example using i18next [here](https://github.com/supertokens/supertokens-auth-react/blob/master/examples/with-i18next/src/App.js). To do this you need to do two things:
 
@@ -117,12 +124,14 @@ import React from "react";
 import SuperTokens from "supertokens-auth-react";
 
 SuperTokens.init({
+    // highlight-start
     languageTranslations: {
         translationFunc: (key: string) => {
           // The string returned by this function will be displayed
           return key + "!";
         },
     },
+    // highlight-end
     appInfo: {
         appName: "...",
         apiDomain: "...",
@@ -136,15 +145,15 @@ SuperTokens.init({
 </TabItem>
 </FrontendSDKTabs>
 
-2. Call `SuperTokens.changeLanguage` or `SuperTokens.loadTranslation` when the language is updated or new translations are loaded
+2. Call `SuperTokens.changeLanguage` or `SuperTokens.loadTranslation` to re-render the translated UI
 
-Since the provided `tranlationFunc` is not updated, the SDK will only re-render and update the displayed translation after either of the above functions are called. You can easily do this in event handlers or at the same time as the current language is changed.
+This is necessary, because the SDK will only re-render and update the displayed strings after either of the above functions are called. You can easily do this in event handlers, when updating the language choice or while adding new translation data.
 
 ## Partial translations
 
 If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. If it's missing also missing from the default store, the raw translation key is displayed. For example, this can happen for custom error messages returned by the backend API.
 
-## Saving the chosen language
+## Saving language preferences
 
 The currently chosen language is stored in a cookie, this way it can be restored the next time the page loads. The domain of this cookie can be customized through the `currentLanguageCookieScope` option. This can be useful if you are running our SDK in multiple applications and want to share the language choice between sub-domains.
 
@@ -156,9 +165,11 @@ import React from "react";
 import SuperTokens from "supertokens-auth-react";
 
 SuperTokens.init({
+    // highlight-start
     languageTranslations: {
-        currentLanguageCookieScope: "http://localhost"
+        currentLanguageCookieScope: ".example.com",
     },
+    // highlight-end
     appInfo: {
         appName: "...",
         apiDomain: "...",
@@ -175,3 +186,24 @@ SuperTokens.init({
 ## Translations in component overrides
 
 The SDK also exports the `useTranslation` React hook you can use while overriding components. It returns a function that takes a translation segment key and returns it translated to the currently selected language. For more information on what translation keys you should use and the exact syntax, please see the original source code of the component you are overriding.
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import { useTranslation } from "supertokens-auth-react";
+
+export const HeaderOverride = () => {
+    const t = useTranslation();
+
+    return (
+        <div>
+            <img src="octocat.jpg" />
+            {t("MY_TRANSLATION_KEY") /* You can use your own custom translation keys as well as the default ones */}
+        </div>
+    );
+};
+```
+
+</TabItem>
+</FrontendSDKTabs>

--- a/v2/passwordless/sidebars.js
+++ b/v2/passwordless/sidebars.js
@@ -134,6 +134,7 @@ module.exports = {
             "common-customizations/styling/shadow-dom"
           ]
         },
+        "common-customizations/translations",
         {
           type: "category",
           label: "Changing base path",

--- a/v2/thirdparty/common-customizations/translations.mdx
+++ b/v2/thirdparty/common-customizations/translations.mdx
@@ -1,0 +1,177 @@
+---
+id: translations
+title: Translating the UI
+hide_title: true
+---
+
+<!-- COPY DOCS -->
+<!-- ./passwordless/common-customizations/translations.mdx -->
+
+import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs";
+import TabItem from '@theme/TabItem';
+import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+
+# Translating the UI
+
+You can translate the UI using two main methods:
+1. You can override all displayed translation strings by providing translated versions for different languages (and even change the default English version).
+2. You can provide a translation function to integrate supertokens with your preferred internationalization library.
+
+## Translation strings
+
+### Providing translation strings
+
+You can provide translations for each segment displayed in our UIs. To see what keys you should cover, please check [here](https://github.com/supertokens/supertokens-auth-react/blob/master/lib/ts/recipe/^{codeImportRecipeName}/components/themes/translations.ts).
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import React from "react";
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.init({
+    // highlight-start
+    languageTranslations: { // This object contains all translation related options
+        translations: { // These are the displayed translation strings for each language
+          // The property names define the language code of the translations
+          en: {
+            // Here each key is a translation key and the value is the string that will be displayed
+            // Setting the value to undefined will either display the translation from the default language or the translation key
+            BRANDING_POWERED_BY_START: "We ❤️ ",
+          },
+          hu: {
+            BRANDING_POWERED_BY_START: "Sok szeretettel: ",
+            // This key is associated with an empty string by default, but you can override these as well.
+            BRANDING_POWERED_BY_END: " 😊",
+          }
+        },
+        /* 
+         * This optional property sets the default and fallback language. 
+         * It can be any string that will be used to fetch translations from the above object.
+         * Defaults to "en"
+         */
+        defaultLanguage: "hu", 
+    },
+    // highlight-end
+    appInfo: {
+        appName: "...",
+        apiDomain: "...",
+        websiteDomain: "...",
+    },
+    recipeList: [
+      // ...
+    ],
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+### Loading translations
+
+After initialization, you can load translations by calling the `SuperTokens.loadTranslation`:
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import SuperTokens from "supertokens-auth-react";
+
+// This method takes an object as a parameter, which is structured the same as above.
+// This will be merged into the existing definitions, so any properties missing here won't remove them from the already loaded translations
+SuperTokens.loadTranslation({
+  en: {
+    BRANDING_POWERED_BY_END: " :)",
+  }
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+### Changing the current language
+
+You can update which translations store is displayed by calling the `SuperTokens.changeLanguage`.
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.changeLanguage("hu");
+```
+</TabItem>
+</FrontendSDKTabs>
+
+## Library integration
+
+You can easily integrate SuperTokens with your internationalization library of choice. You can check out an example using i18next [here](https://github.com/supertokens/supertokens-auth-react/blob/master/examples/with-i18next/src/App.js). To do this you need to do two things:
+
+1. Provide the translation function in `SuperTokens.init`
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import React from "react";
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.init({
+    languageTranslations: {
+        translationFunc: (key: string) => {
+          // The string returned by this function will be displayed
+          return key + "!";
+        },
+    },
+    appInfo: {
+        appName: "...",
+        apiDomain: "...",
+        websiteDomain: "...",
+    },
+    recipeList: [
+      // ...
+    ],
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+2. Call `SuperTokens.changeLanguage` or `SuperTokens.loadTranslation` when the language is updated or new translations are loaded
+
+Since the provided `tranlationFunc` is not updated, the SDK will only re-render and update the displayed translation after either of the above functions are called. You can easily do this in event handlers or at the same time as the current language is changed.
+
+## Partial translations
+
+If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. If it's missing also missing from the default store, the raw translation key is displayed. For example, this can happen for custom error messages returned by the backend API.
+
+## Saving the chosen language
+
+The currently chosen language is stored in a cookie, this way it can be restored the next time the page loads. The domain of this cookie can be customized through the `currentLanguageCookieScope` option. This can be useful if you are running our SDK in multiple applications and want to share the language choice between sub-domains.
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import React from "react";
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.init({
+    languageTranslations: {
+        currentLanguageCookieScope: "http://localhost"
+    },
+    appInfo: {
+        appName: "...",
+        apiDomain: "...",
+        websiteDomain: "...",
+    },
+    recipeList: [
+      // ...
+    ],
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+## Translations in component overrides
+
+The SDK also exports the `useTranslation` React hook you can use while overriding components. It returns a function that takes a translation segment key and returns it translated to the currently selected language. For more information on what translation keys you should use and the exact syntax, please see the original source code of the component you are overriding.

--- a/v2/thirdparty/common-customizations/translations.mdx
+++ b/v2/thirdparty/common-customizations/translations.mdx
@@ -1,6 +1,6 @@
 ---
 id: translations
-title: Translating the UI
+title: Language Translation for the UI
 hide_title: true
 ---
 
@@ -11,7 +11,7 @@ import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs";
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
 
-# Translating the UI
+# Language Translation for the UI
 
 You can translate the UI using two main methods:
 1. You can override all displayed translation strings by providing translated versions for different languages (and even change the default English version).
@@ -76,7 +76,7 @@ SuperTokens.init({
 
 ### Loading translations
 
-After initialization, you can load translations by calling the `SuperTokens.loadTranslation`:
+After initialization, you can provide additional translation data by calling the `SuperTokens.loadTranslation`. This can be useful if you are loading them asynchronously.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">
@@ -151,7 +151,7 @@ This is necessary, because the SDK will only re-render and update the displayed 
 
 ## Partial translations
 
-If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. If it's missing also missing from the default store, the raw translation key is displayed. For example, this can happen for custom error messages returned by the backend API.
+If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. The raw translation key is displayed if it's also missing from the default store. For example, this can happen for custom error messages returned by the backend API.
 
 ## Saving language preferences
 

--- a/v2/thirdparty/common-customizations/translations.mdx
+++ b/v2/thirdparty/common-customizations/translations.mdx
@@ -21,7 +21,11 @@ You can translate the UI using two main methods:
 
 ### Providing translation strings
 
-You can provide translations for each segment displayed in our UIs. To see what keys you should cover, please check [here](https://github.com/supertokens/supertokens-auth-react/blob/master/lib/ts/recipe/^{codeImportRecipeName}/components/themes/translations.ts).
+You can provide translations for each segment displayed in our UIs.
+
+:::important
+To see what keys you should cover, please check [here](https://github.com/supertokens/supertokens-auth-react/blob/master/lib/ts/recipe/^{codeImportRecipeName}/components/themes/translations.ts).
+:::
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">
@@ -39,6 +43,9 @@ SuperTokens.init({
             // Here each key is a translation key and the value is the string that will be displayed
             // Setting the value to undefined will either display the translation from the default language or the translation key
             BRANDING_POWERED_BY_START: "We ❤️ ",
+            // If you added a custom label or placeholder you can also provide translation for them if necessary
+            // You can also use these to provide translations for your component overrides
+            MY_CUSTOM_LABEL: "Age",
           },
           hu: {
             BRANDING_POWERED_BY_START: "Sok szeretettel: ",
@@ -103,7 +110,7 @@ SuperTokens.changeLanguage("hu");
 </TabItem>
 </FrontendSDKTabs>
 
-## Library integration
+## Using an internationalization library
 
 You can easily integrate SuperTokens with your internationalization library of choice. You can check out an example using i18next [here](https://github.com/supertokens/supertokens-auth-react/blob/master/examples/with-i18next/src/App.js). To do this you need to do two things:
 
@@ -117,12 +124,14 @@ import React from "react";
 import SuperTokens from "supertokens-auth-react";
 
 SuperTokens.init({
+    // highlight-start
     languageTranslations: {
         translationFunc: (key: string) => {
           // The string returned by this function will be displayed
           return key + "!";
         },
     },
+    // highlight-end
     appInfo: {
         appName: "...",
         apiDomain: "...",
@@ -136,15 +145,15 @@ SuperTokens.init({
 </TabItem>
 </FrontendSDKTabs>
 
-2. Call `SuperTokens.changeLanguage` or `SuperTokens.loadTranslation` when the language is updated or new translations are loaded
+2. Call `SuperTokens.changeLanguage` or `SuperTokens.loadTranslation` to re-render the translated UI
 
-Since the provided `tranlationFunc` is not updated, the SDK will only re-render and update the displayed translation after either of the above functions are called. You can easily do this in event handlers or at the same time as the current language is changed.
+This is necessary, because the SDK will only re-render and update the displayed strings after either of the above functions are called. You can easily do this in event handlers, when updating the language choice or while adding new translation data.
 
 ## Partial translations
 
 If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. If it's missing also missing from the default store, the raw translation key is displayed. For example, this can happen for custom error messages returned by the backend API.
 
-## Saving the chosen language
+## Saving language preferences
 
 The currently chosen language is stored in a cookie, this way it can be restored the next time the page loads. The domain of this cookie can be customized through the `currentLanguageCookieScope` option. This can be useful if you are running our SDK in multiple applications and want to share the language choice between sub-domains.
 
@@ -156,9 +165,11 @@ import React from "react";
 import SuperTokens from "supertokens-auth-react";
 
 SuperTokens.init({
+    // highlight-start
     languageTranslations: {
-        currentLanguageCookieScope: "http://localhost"
+        currentLanguageCookieScope: ".example.com",
     },
+    // highlight-end
     appInfo: {
         appName: "...",
         apiDomain: "...",
@@ -175,3 +186,24 @@ SuperTokens.init({
 ## Translations in component overrides
 
 The SDK also exports the `useTranslation` React hook you can use while overriding components. It returns a function that takes a translation segment key and returns it translated to the currently selected language. For more information on what translation keys you should use and the exact syntax, please see the original source code of the component you are overriding.
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import { useTranslation } from "supertokens-auth-react";
+
+export const HeaderOverride = () => {
+    const t = useTranslation();
+
+    return (
+        <div>
+            <img src="octocat.jpg" />
+            {t("MY_TRANSLATION_KEY") /* You can use your own custom translation keys as well as the default ones */}
+        </div>
+    );
+};
+```
+
+</TabItem>
+</FrontendSDKTabs>

--- a/v2/thirdparty/sidebars.js
+++ b/v2/thirdparty/sidebars.js
@@ -152,6 +152,7 @@ module.exports = {
             "common-customizations/styling/shadow-dom"
           ]
         },
+        "common-customizations/translations",
         {
           type: "category",
           label: "Changing base path",

--- a/v2/thirdpartyemailpassword/common-customizations/translations.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/translations.mdx
@@ -1,0 +1,177 @@
+---
+id: translations
+title: Translating the UI
+hide_title: true
+---
+
+<!-- COPY DOCS -->
+<!-- ./passwordless/common-customizations/translations.mdx -->
+
+import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs";
+import TabItem from '@theme/TabItem';
+import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+
+# Translating the UI
+
+You can translate the UI using two main methods:
+1. You can override all displayed translation strings by providing translated versions for different languages (and even change the default English version).
+2. You can provide a translation function to integrate supertokens with your preferred internationalization library.
+
+## Translation strings
+
+### Providing translation strings
+
+You can provide translations for each segment displayed in our UIs. To see what keys you should cover, please check [here](https://github.com/supertokens/supertokens-auth-react/blob/master/lib/ts/recipe/^{codeImportRecipeName}/components/themes/translations.ts).
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import React from "react";
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.init({
+    // highlight-start
+    languageTranslations: { // This object contains all translation related options
+        translations: { // These are the displayed translation strings for each language
+          // The property names define the language code of the translations
+          en: {
+            // Here each key is a translation key and the value is the string that will be displayed
+            // Setting the value to undefined will either display the translation from the default language or the translation key
+            BRANDING_POWERED_BY_START: "We ❤️ ",
+          },
+          hu: {
+            BRANDING_POWERED_BY_START: "Sok szeretettel: ",
+            // This key is associated with an empty string by default, but you can override these as well.
+            BRANDING_POWERED_BY_END: " 😊",
+          }
+        },
+        /* 
+         * This optional property sets the default and fallback language. 
+         * It can be any string that will be used to fetch translations from the above object.
+         * Defaults to "en"
+         */
+        defaultLanguage: "hu", 
+    },
+    // highlight-end
+    appInfo: {
+        appName: "...",
+        apiDomain: "...",
+        websiteDomain: "...",
+    },
+    recipeList: [
+      // ...
+    ],
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+### Loading translations
+
+After initialization, you can load translations by calling the `SuperTokens.loadTranslation`:
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import SuperTokens from "supertokens-auth-react";
+
+// This method takes an object as a parameter, which is structured the same as above.
+// This will be merged into the existing definitions, so any properties missing here won't remove them from the already loaded translations
+SuperTokens.loadTranslation({
+  en: {
+    BRANDING_POWERED_BY_END: " :)",
+  }
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+### Changing the current language
+
+You can update which translations store is displayed by calling the `SuperTokens.changeLanguage`.
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.changeLanguage("hu");
+```
+</TabItem>
+</FrontendSDKTabs>
+
+## Library integration
+
+You can easily integrate SuperTokens with your internationalization library of choice. You can check out an example using i18next [here](https://github.com/supertokens/supertokens-auth-react/blob/master/examples/with-i18next/src/App.js). To do this you need to do two things:
+
+1. Provide the translation function in `SuperTokens.init`
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import React from "react";
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.init({
+    languageTranslations: {
+        translationFunc: (key: string) => {
+          // The string returned by this function will be displayed
+          return key + "!";
+        },
+    },
+    appInfo: {
+        appName: "...",
+        apiDomain: "...",
+        websiteDomain: "...",
+    },
+    recipeList: [
+      // ...
+    ],
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+2. Call `SuperTokens.changeLanguage` or `SuperTokens.loadTranslation` when the language is updated or new translations are loaded
+
+Since the provided `tranlationFunc` is not updated, the SDK will only re-render and update the displayed translation after either of the above functions are called. You can easily do this in event handlers or at the same time as the current language is changed.
+
+## Partial translations
+
+If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. If it's missing also missing from the default store, the raw translation key is displayed. For example, this can happen for custom error messages returned by the backend API.
+
+## Saving the chosen language
+
+The currently chosen language is stored in a cookie, this way it can be restored the next time the page loads. The domain of this cookie can be customized through the `currentLanguageCookieScope` option. This can be useful if you are running our SDK in multiple applications and want to share the language choice between sub-domains.
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import React from "react";
+import SuperTokens from "supertokens-auth-react";
+
+SuperTokens.init({
+    languageTranslations: {
+        currentLanguageCookieScope: "http://localhost"
+    },
+    appInfo: {
+        appName: "...",
+        apiDomain: "...",
+        websiteDomain: "...",
+    },
+    recipeList: [
+      // ...
+    ],
+});
+```
+</TabItem>
+</FrontendSDKTabs>
+
+## Translations in component overrides
+
+The SDK also exports the `useTranslation` React hook you can use while overriding components. It returns a function that takes a translation segment key and returns it translated to the currently selected language. For more information on what translation keys you should use and the exact syntax, please see the original source code of the component you are overriding.

--- a/v2/thirdpartyemailpassword/common-customizations/translations.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/translations.mdx
@@ -1,6 +1,6 @@
 ---
 id: translations
-title: Translating the UI
+title: Language Translation for the UI
 hide_title: true
 ---
 
@@ -11,7 +11,7 @@ import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs";
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
 
-# Translating the UI
+# Language Translation for the UI
 
 You can translate the UI using two main methods:
 1. You can override all displayed translation strings by providing translated versions for different languages (and even change the default English version).
@@ -76,7 +76,7 @@ SuperTokens.init({
 
 ### Loading translations
 
-After initialization, you can load translations by calling the `SuperTokens.loadTranslation`:
+After initialization, you can provide additional translation data by calling the `SuperTokens.loadTranslation`. This can be useful if you are loading them asynchronously.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">
@@ -151,7 +151,7 @@ This is necessary, because the SDK will only re-render and update the displayed 
 
 ## Partial translations
 
-If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. If it's missing also missing from the default store, the raw translation key is displayed. For example, this can happen for custom error messages returned by the backend API.
+If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. The raw translation key is displayed if it's also missing from the default store. For example, this can happen for custom error messages returned by the backend API.
 
 ## Saving language preferences
 

--- a/v2/thirdpartyemailpassword/common-customizations/translations.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/translations.mdx
@@ -21,7 +21,11 @@ You can translate the UI using two main methods:
 
 ### Providing translation strings
 
-You can provide translations for each segment displayed in our UIs. To see what keys you should cover, please check [here](https://github.com/supertokens/supertokens-auth-react/blob/master/lib/ts/recipe/^{codeImportRecipeName}/components/themes/translations.ts).
+You can provide translations for each segment displayed in our UIs.
+
+:::important
+To see what keys you should cover, please check [here](https://github.com/supertokens/supertokens-auth-react/blob/master/lib/ts/recipe/^{codeImportRecipeName}/components/themes/translations.ts).
+:::
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">
@@ -39,6 +43,9 @@ SuperTokens.init({
             // Here each key is a translation key and the value is the string that will be displayed
             // Setting the value to undefined will either display the translation from the default language or the translation key
             BRANDING_POWERED_BY_START: "We ❤️ ",
+            // If you added a custom label or placeholder you can also provide translation for them if necessary
+            // You can also use these to provide translations for your component overrides
+            MY_CUSTOM_LABEL: "Age",
           },
           hu: {
             BRANDING_POWERED_BY_START: "Sok szeretettel: ",
@@ -103,7 +110,7 @@ SuperTokens.changeLanguage("hu");
 </TabItem>
 </FrontendSDKTabs>
 
-## Library integration
+## Using an internationalization library
 
 You can easily integrate SuperTokens with your internationalization library of choice. You can check out an example using i18next [here](https://github.com/supertokens/supertokens-auth-react/blob/master/examples/with-i18next/src/App.js). To do this you need to do two things:
 
@@ -117,12 +124,14 @@ import React from "react";
 import SuperTokens from "supertokens-auth-react";
 
 SuperTokens.init({
+    // highlight-start
     languageTranslations: {
         translationFunc: (key: string) => {
           // The string returned by this function will be displayed
           return key + "!";
         },
     },
+    // highlight-end
     appInfo: {
         appName: "...",
         apiDomain: "...",
@@ -136,15 +145,15 @@ SuperTokens.init({
 </TabItem>
 </FrontendSDKTabs>
 
-2. Call `SuperTokens.changeLanguage` or `SuperTokens.loadTranslation` when the language is updated or new translations are loaded
+2. Call `SuperTokens.changeLanguage` or `SuperTokens.loadTranslation` to re-render the translated UI
 
-Since the provided `tranlationFunc` is not updated, the SDK will only re-render and update the displayed translation after either of the above functions are called. You can easily do this in event handlers or at the same time as the current language is changed.
+This is necessary, because the SDK will only re-render and update the displayed strings after either of the above functions are called. You can easily do this in event handlers, when updating the language choice or while adding new translation data.
 
 ## Partial translations
 
 If the SDK can't find a segment in the current language's translation store, we will check the default language store and use the translation from there. If it's missing also missing from the default store, the raw translation key is displayed. For example, this can happen for custom error messages returned by the backend API.
 
-## Saving the chosen language
+## Saving language preferences
 
 The currently chosen language is stored in a cookie, this way it can be restored the next time the page loads. The domain of this cookie can be customized through the `currentLanguageCookieScope` option. This can be useful if you are running our SDK in multiple applications and want to share the language choice between sub-domains.
 
@@ -156,9 +165,11 @@ import React from "react";
 import SuperTokens from "supertokens-auth-react";
 
 SuperTokens.init({
+    // highlight-start
     languageTranslations: {
-        currentLanguageCookieScope: "http://localhost"
+        currentLanguageCookieScope: ".example.com",
     },
+    // highlight-end
     appInfo: {
         appName: "...",
         apiDomain: "...",
@@ -175,3 +186,24 @@ SuperTokens.init({
 ## Translations in component overrides
 
 The SDK also exports the `useTranslation` React hook you can use while overriding components. It returns a function that takes a translation segment key and returns it translated to the currently selected language. For more information on what translation keys you should use and the exact syntax, please see the original source code of the component you are overriding.
+
+<FrontendSDKTabs>
+<TabItem value="reactjs">
+
+```tsx
+import { useTranslation } from "supertokens-auth-react";
+
+export const HeaderOverride = () => {
+    const t = useTranslation();
+
+    return (
+        <div>
+            <img src="octocat.jpg" />
+            {t("MY_TRANSLATION_KEY") /* You can use your own custom translation keys as well as the default ones */}
+        </div>
+    );
+};
+```
+
+</TabItem>
+</FrontendSDKTabs>

--- a/v2/thirdpartyemailpassword/sidebars.js
+++ b/v2/thirdpartyemailpassword/sidebars.js
@@ -179,6 +179,7 @@ module.exports = {
             "common-customizations/styling/shadow-dom"
           ]
         },
+        "common-customizations/translations",
         {
           type: "category",
           label: "Changing base path",


### PR DESCRIPTION
## Summary of change
Adding docs about adding custom translations

## Related issues
- https://github.com/supertokens/supertokens-auth-react/issues/233

## Checklist
- [x] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [x] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [x] Changes required to the demo apps corresponding to the docs?
