### PR TITLE
Remove sorting logic from frontend for compatibility table

### DIFF
--- a/v2/src/components/compatibility/index.tsx
+++ b/v2/src/components/compatibility/index.tsx
@@ -59,17 +59,6 @@ export default class CompatibilityMatrix extends React.PureComponent<Props, Stat
         return "FREE";
     }
 
-    sortDoubleDecimalNumbers = (compatibilityObject: any) => {
-        let sortedObject = {}
-        for (let dataKey in compatibilityObject) {
-            const data = compatibilityObject[dataKey]
-            if (typeof data === 'object') {
-
-            }
-        }
-
-    }
-
     getFrameworkDropdown = () => {
         return (
             <div
@@ -593,40 +582,6 @@ export default class CompatibilityMatrix extends React.PureComponent<Props, Stat
         });
     }
 
-    // this should take an array only
-    sortDoubleDecimalCompatibilityResponse = (compatibilityList: any) => {
-        if (Array.isArray(compatibilityList)) {
-            let compatibilitMap: any = {}
-            const compatibilityFiltered = []
-            const finalOutputArray = []
-            for (let i = 0; i < compatibilityList.length; i++) {
-                const compatibilityItem: string = compatibilityList[i]
-                const filteredNumber = parseInt(compatibilityItem.split('.').join(''))
-                compatibilitMap = {
-                    ...compatibilitMap,
-                    [filteredNumber]: compatibilityItem
-                }
-                compatibilityFiltered.push(filteredNumber)
-            }
-            const sortedCompatibilityItem = compatibilityFiltered.sort((a, b) => b - a)
-
-            for (let i = 0; i < sortedCompatibilityItem.length; i++) {
-                const currentComaptibilityElement = sortedCompatibilityItem[i]
-                finalOutputArray.push(compatibilitMap[currentComaptibilityElement])
-            }
-            return finalOutputArray
-        }
-        return this.sortCompatibilityResponse(compatibilityList)
-    }
-
-    sortCompatibilityResponse = (compatibilityList: any) => {
-        // Core Driver 
-        for (let item in compatibilityList) {
-            compatibilityList[item] = this.sortDoubleDecimalCompatibilityResponse(compatibilityList[item])
-        }
-        return compatibilityList
-    }
-
     fetchCompatibilityIfNeeded = async () => {
         if (this.state.selectedDriver === "" || this.state.selectedFrontend === "" || this.state.selectedPlugin === "") {
             return;
@@ -639,8 +594,8 @@ export default class CompatibilityMatrix extends React.PureComponent<Props, Stat
         }));
 
         try {
-            const compatibilityResponse = this.sortCompatibilityResponse(await getCompatibility(this.getCurrentPlanType(),
-                this.state.selectedDriver, this.state.selectedPlugin, this.state.selectedFrontend));
+            const compatibilityResponse = await getCompatibility(this.getCurrentPlanType(),
+                this.state.selectedDriver, this.state.selectedPlugin, this.state.selectedFrontend);
             this.setState(oldState => ({
                 ...oldState,
                 isFetchingCompatibility: false,


### PR DESCRIPTION
## Related issues
- #247 

## Summary of change
- The Backend API sends sorted compatibility data.
- As a result, we do not need the sorting logic on frontend.
- So we are removing the sorting logic from the frontend.
  - The method `sortCompatibilityResponse` is called on the response from the backend which handles the sorting. The method itself and the call to that method on the response is removed.
  - The method `sortDoubleDecimalCompatibilityResponse` is used inside `sortCompatibilityResponse` to handle sorting. It is not used anywhere else. This method is also removed.
- The `sortDoubleDecimalNumbers` method is not used anywhere in the component and it does not have any useful logic, so that method is removed too.
- Note: The form doesn't work on the preview because of CORS error. Here's the [demo video](https://drive.google.com/file/d/1cg-wf_suZBd7SCLCS7YYJsis8fHsdwFX/view?usp=sharing)

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
No TODOs remaining.