### PR TITLE
Docs redesign: updated styles for admonitions

### DIFF
--- a/v2/change_me/introduction.mdx
+++ b/v2/change_me/introduction.mdx
@@ -85,7 +85,6 @@ Tip with no title
 :::tip
 
 Tip with no title
-`This is an inline snipppet`
 
 :::
 ```
@@ -93,7 +92,6 @@ Tip with no title
 :::info
 
 Useful information.
-`This is an inline snipppet`
 
 :::
 
@@ -105,28 +103,9 @@ Useful information.
 :::
 ```
 
-:::caution Important
-This is a contributors guide and NOT a user guide. Please visit [these docs](https://supertokens.com/docs/guides) if you are using or evaluating SuperTokens.
-:::
-
 :::caution
 
-Warning! You better pay attention! `This is an inline snipppet`
-
-- This is a list inside the container
-- second item
-
-Some other text
-
-- a new list
-    - nested list item one
-    - nested list item two
-- another item
-
-1. numbered list
-    1. nested unordered list
-    2. second item
-2. second item
+Warning! You better pay attention!
 
 :::
 
@@ -140,7 +119,7 @@ Warning! You better pay attention!
 
 :::danger
 
-Danger danger, mayday! `This is an inline snipppet` and [this is an inline link](http://google.com)
+Danger danger, mayday!
 
 :::
 

--- a/v2/change_me/introduction.mdx
+++ b/v2/change_me/introduction.mdx
@@ -105,10 +105,28 @@ Useful information.
 :::
 ```
 
+:::caution Important
+This is a contributors guide and NOT a user guide. Please visit [these docs](https://supertokens.com/docs/guides) if you are using or evaluating SuperTokens.
+:::
+
 :::caution
 
-Warning! You better pay attention!
-`This is an inline snipppet`
+Warning! You better pay attention! `This is an inline snipppet`
+
+- This is a list inside the container
+- second item
+
+Some other text
+
+- a new list
+    - nested list item one
+    - nested list item two
+- another item
+
+1. numbered list
+    1. nested unordered list
+    2. second item
+2. second item
 
 :::
 

--- a/v2/change_me/introduction.mdx
+++ b/v2/change_me/introduction.mdx
@@ -144,3 +144,27 @@ The documentation pages load assets from the following places
 All documentation pages have a common styling for [hyperlinks](https://supertokens.com/) and **bold text**
 
 <br/><br/><br/>
+
+:::tip
+this is tip
+:::
+
+:::success
+This is successful
+:::
+
+:::note
+This is a note
+:::
+
+:::important
+This is important
+:::
+
+:::caution
+This is caution
+:::
+
+:::danger
+This is danger
+:::

--- a/v2/change_me/introduction.mdx
+++ b/v2/change_me/introduction.mdx
@@ -85,6 +85,7 @@ Tip with no title
 :::tip
 
 Tip with no title
+`This is an inline snipppet`
 
 :::
 ```
@@ -92,6 +93,7 @@ Tip with no title
 :::info
 
 Useful information.
+`This is an inline snipppet`
 
 :::
 
@@ -106,6 +108,7 @@ Useful information.
 :::caution
 
 Warning! You better pay attention!
+`This is an inline snipppet`
 
 :::
 
@@ -119,7 +122,7 @@ Warning! You better pay attention!
 
 :::danger
 
-Danger danger, mayday!
+Danger danger, mayday! `This is an inline snipppet` and [this is an inline link](http://google.com)
 
 :::
 

--- a/v2/change_me/introduction.mdx
+++ b/v2/change_me/introduction.mdx
@@ -146,7 +146,7 @@ All documentation pages have a common styling for [hyperlinks](https://supertoke
 <br/><br/><br/>
 
 :::tip
-this is tip with `some pre text`.
+this is tip with `some pre text`, with some **bold** and some *italic* text
 
 - onorderd list
 - onorderd list
@@ -161,7 +161,7 @@ this is tip with `some pre text`.
 :::
 
 :::success
-This is successful with `some pre text`.
+This is successful with `some pre text`, with some **bold** and some *italic* text
 
 - onorderd list
 - onorderd list
@@ -176,7 +176,7 @@ l
 :::
 
 :::note
-This is a note with `some pre text`.
+This is a note with `some pre text`, with some **bold** and some *italic* text
 
 - onorderd list
 - onorderd list
@@ -191,7 +191,7 @@ This is a note with `some pre text`.
 :::
 
 :::important
-This is important with `some pre text`.
+This is important with `some pre text`, with some **bold** and some *italic* text
 
 - onorderd list
 - onorderd list
@@ -206,7 +206,7 @@ This is important with `some pre text`.
 :::
 
 :::caution
-This is caution with `some pre text`.
+This is caution with `some pre text`, with some **bold** and some *italic* text
 
 - onorderd list
 - onorderd list
@@ -221,7 +221,7 @@ This is caution with `some pre text`.
 :::
 
 :::danger
-This is danger with `some pre text`.
+This is danger with `some pre text`, with some **bold** and some *italic* text
 
 - onorderd list
 - onorderd list

--- a/v2/change_me/introduction.mdx
+++ b/v2/change_me/introduction.mdx
@@ -146,25 +146,91 @@ All documentation pages have a common styling for [hyperlinks](https://supertoke
 <br/><br/><br/>
 
 :::tip
-this is tip
+this is tip with `some pre text`.
+
+- onorderd list
+- onorderd list
+- onorderd list
+
+[Some link](https://github.com)
+
+1. first
+2. second
+3. third
+
 :::
 
 :::success
-This is successful
+This is successful with `some pre text`.
+
+- onorderd list
+- onorderd list
+- onorderd list
+
+[Some link](https://github.com)
+
+1. first
+2. second
+3. third
+l
 :::
 
 :::note
-This is a note
+This is a note with `some pre text`.
+
+- onorderd list
+- onorderd list
+- onorderd list
+
+[Some link](https://github.com)
+
+1. first
+2. second
+3. third
+
 :::
 
 :::important
-This is important
+This is important with `some pre text`.
+
+- onorderd list
+- onorderd list
+- onorderd list
+
+[Some link](https://github.com)
+
+1. first
+2. second
+3. third
+
 :::
 
 :::caution
-This is caution
+This is caution with `some pre text`.
+
+- onorderd list
+- onorderd list
+- onorderd list
+
+[Some link](https://github.com)
+
+1. first
+2. second
+3. third
+
 :::
 
 :::danger
-This is danger
+This is danger with `some pre text`.
+
+- onorderd list
+- onorderd list
+- onorderd list
+
+[Some link](https://github.com)
+
+1. first
+2. second
+3. third
+
 :::

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -179,12 +179,9 @@ html[data-theme='dark'] .admonition {
   box-shadow: var(--container-box-shadow);
 }
 
-html[data-theme='dark'] .markdown .admonition ul {
+html[data-theme='dark'] .admonition .admonition-content ul,
+html[data-theme='dark'] .admonition .admonition-content ol {
   padding-left: 16px;
-}
-
-html[data-theme='dark'] .markdown .admonition p {
-  margin-bottom: 0px;
 }
 
 html[data-theme='dark'] .admonition .admonition-heading {
@@ -192,18 +189,22 @@ html[data-theme='dark'] .admonition .admonition-heading {
   white-space: nowrap;
 }
 
-html[data-theme='dark'] .markdown .admonition .admonition-content a {
+html[data-theme='dark'] .admonition .admonition-content a {
   color: white;
   font-weight: bold;
   text-decoration: underline;
 }
 
-html[data-theme="dark"] .markdown .admonition .admonition-content code {
+html[data-theme="dark"] .admonition .admonition-content code {
   background-color: rgba(255, 255, 255, .1);
   border-color: rgba(0, 0, 0, .1);
 }
 
-html[data-theme='dark'] .markdown .admonition .admonition-heading h5 {
+html[data-theme="dark"] .admonition .admonition-content *:last-child {
+  margin-bottom: 0px;
+}
+
+html[data-theme='dark'] .admonition .admonition-heading h5 {
   font-size: 12px;
   font-weight: bold;
   text-transform: uppercase;

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -195,6 +195,12 @@ html[data-theme='dark'] .admonition .admonition-heading {
 html[data-theme='dark'] .markdown .admonition .admonition-content a {
   color: white;
   font-weight: bold;
+  text-decoration: underline;
+}
+
+html[data-theme="dark"] .markdown .admonition .admonition-content code {
+  background-color: rgba(255, 255, 255, .1);
+  border-color: rgba(0, 0, 0, .1);
 }
 
 html[data-theme='dark'] .markdown .admonition .admonition-heading h5 {

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -57,3 +57,74 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
 .markdown a {
   text-decoration: underline;
 }
+
+/* Admonition updates */
+html[data-theme='dark'] .admonition {
+  background-color: rgba(0, 98, 255, .2);
+  border: 0px;
+  border-left: 6px solid rgb(0, 98, 255);
+  color: rgb(185, 192, 202);
+  margin: 16px 0px;
+}
+
+html[data-theme='dark'] .markdown .admonition ul {
+  padding-left: 16px;
+}
+
+html[data-theme='dark'] .markdown .admonition p {
+  margin-bottom: 0px;
+}
+
+html[data-theme='dark'] .admonition .admonition-heading {
+  height: fit-content;
+  white-space: nowrap;
+}
+
+html[data-theme='dark'] .markdown .admonition .admonition-content a {
+  color: var(--ifm-link-color);
+}
+
+html[data-theme='dark'] .markdown .admonition .admonition-heading h5 {
+  font-size: 12px;
+  font-weight: bold;
+  text-transform: uppercase;
+  display: block;
+  width: max-content;
+  margin: 0px 0px 16px;
+  line-height: 1.25;
+  background-color: rgb(0, 98, 255);
+  padding: 1px 8px;
+  border-radius: 8px;
+  color: white;
+}
+
+html[data-theme='dark'] .admonition.admonition-caution .admonition-heading h5 {
+  background-color: rgb(196, 76, 52);
+}
+
+html[data-theme='dark'] .admonition.admonition-caution {
+  background-color: rgba(196, 76, 52, .2);
+  border-color: rgb(196, 76, 52);
+}
+
+html[data-theme='dark'] .admonition.admonition-success .admonition-heading h5 {
+  background-color: rgb(38, 147, 71);
+}
+
+html[data-theme='dark'] .admonition.admonition-success {
+  background-color: rgba(38, 147, 71, .2);
+  border-color: rgb(38, 147, 71);
+}
+
+html[data-theme='dark'] .admonition.admonition-danger .admonition-heading h5 {
+  background-color: rgb(196, 52, 52);
+}
+
+html[data-theme='dark'] .admonition.admonition-danger {
+  background-color: rgba(196, 52, 52, .2);
+  border-color: rgb(196, 52, 52);
+}
+
+html[data-theme='dark'] .admonition .admonition-heading .admonition-icon {
+  display: none;
+}

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -174,7 +174,7 @@ html[data-theme='dark'] .admonition {
   background-color: rgba(0, 98, 255, .2);
   border: 0px;
   border-left: 6px solid rgb(0, 98, 255);
-  color: rgb(185, 192, 202);
+  color: rgb(173, 205, 255);
   margin: 20px 0px;
   box-shadow: var(--container-box-shadow);
 }
@@ -226,6 +226,7 @@ html[data-theme='dark'] .admonition.admonition-caution .admonition-heading h5 {
 html[data-theme='dark'] .admonition.admonition-caution {
   background-color: rgba(196, 76, 52, .2);
   border-color: rgb(196, 76, 52);
+  color: rgb(255, 184, 170);
 }
 
 /* colors for success admonition */
@@ -236,6 +237,7 @@ html[data-theme='dark'] .admonition.admonition-success .admonition-heading h5 {
 html[data-theme='dark'] .admonition.admonition-success {
   background-color: rgba(38, 147, 71, .2);
   border-color: rgb(38, 147, 71);
+  color: rgb(173, 255, 198);
 }
 
 /* colors for danger admonition */
@@ -246,16 +248,19 @@ html[data-theme='dark'] .admonition.admonition-danger .admonition-heading h5 {
 html[data-theme='dark'] .admonition.admonition-danger {
   background-color: rgba(196, 52, 52, .2);
   border-color: rgb(196, 52, 52);
+  color: rgb(255, 170, 170);
 }
 
 /* colors for note admonitions */
 html[data-theme='dark'] .admonition.admonition-note .admonition-heading h5 {
   background-color: rgb(173, 173, 173);
+  color: rgb(56, 56, 56);
 }
 
 html[data-theme='dark'] .admonition.admonition-note {
   background-color: rgba(173, 173, 173, 0.2);
   border-color: rgb(173, 173, 173);
+  color: rgb(221, 221, 221);
 }
 
 html[data-theme='dark'] .admonition .admonition-heading .admonition-icon {

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -218,6 +218,7 @@ html[data-theme='dark'] .admonition .admonition-heading h5 {
   color: white;
 }
 
+/* colors for caution admonition */
 html[data-theme='dark'] .admonition.admonition-caution .admonition-heading h5 {
   background-color: rgb(196, 76, 52);
 }
@@ -227,6 +228,7 @@ html[data-theme='dark'] .admonition.admonition-caution {
   border-color: rgb(196, 76, 52);
 }
 
+/* colors for success admonition */
 html[data-theme='dark'] .admonition.admonition-success .admonition-heading h5 {
   background-color: rgb(38, 147, 71);
 }
@@ -236,6 +238,7 @@ html[data-theme='dark'] .admonition.admonition-success {
   border-color: rgb(38, 147, 71);
 }
 
+/* colors for danger admonition */
 html[data-theme='dark'] .admonition.admonition-danger .admonition-heading h5 {
   background-color: rgb(196, 52, 52);
 }
@@ -245,6 +248,7 @@ html[data-theme='dark'] .admonition.admonition-danger {
   border-color: rgb(196, 52, 52);
 }
 
+/* colors for note admonitions */
 html[data-theme='dark'] .admonition.admonition-note .admonition-heading h5 {
   background-color: rgb(173, 173, 173);
 }

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -175,7 +175,8 @@ html[data-theme='dark'] .admonition {
   border: 0px;
   border-left: 6px solid rgb(0, 98, 255);
   color: rgb(185, 192, 202);
-  margin: 16px 0px;
+  margin: 20px 0px;
+  box-shadow: var(--container-box-shadow);
 }
 
 html[data-theme='dark'] .markdown .admonition ul {

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -245,6 +245,15 @@ html[data-theme='dark'] .admonition.admonition-danger {
   border-color: rgb(196, 52, 52);
 }
 
+html[data-theme='dark'] .admonition.admonition-note .admonition-heading h5 {
+  background-color: rgb(173, 173, 173);
+}
+
+html[data-theme='dark'] .admonition.admonition-note {
+  background-color: rgba(173, 173, 173, 0.2);
+  border-color: rgb(173, 173, 173);
+}
+
 html[data-theme='dark'] .admonition .admonition-heading .admonition-icon {
   display: none;
 }

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -229,12 +229,14 @@ html[data-theme='dark'] .admonition.admonition-caution {
   color: rgb(255, 184, 170);
 }
 
-/* colors for success admonition */
-html[data-theme='dark'] .admonition.admonition-success .admonition-heading h5 {
+/* colors for success and tip admonitions */
+html[data-theme='dark'] .admonition.admonition-success .admonition-heading h5,
+html[data-theme='dark'] .admonition.admonition-tip .admonition-heading h5 {
   background-color: rgb(38, 147, 71);
 }
 
-html[data-theme='dark'] .admonition.admonition-success {
+html[data-theme='dark'] .admonition.admonition-success,
+html[data-theme='dark'] .admonition.admonition-tip {
   background-color: rgba(38, 147, 71, .2);
   border-color: rgb(38, 147, 71);
   color: rgb(173, 255, 198);


### PR DESCRIPTION
## Summary of change
- Updated styles for admonition as per the 3rd admonition design in this [Zeplin design](https://app.zeplin.io/project/5aaa0de98d835c7b25637f2e/screen/6170fdc5160556a2de9430df)

## Related issues
- Epic: https://github.com/supertokens/main-website/issues/576
- #260 

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
- [x] Design review