### PR TITLE
Bug fix for AppInfoForm and updated error message for invalid apiBasePath when using Netlify functions

### DIFF
--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -671,11 +671,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                     ) {
                         // if the netlify api route checkbox is set to true
                         // the api base path can only start with `/.netlify/functions`
-                        validationErrors.apiBasePath = "apiBasePath must be prefixed with `/.netlify/functions`, for example to use `/auth` set the apiBasePath to `/.netlify/functions/auth`";
-                    } else if (netlifyApiRouteUsed && validApiBasePath === "/.netlify/functions/") {
-                        // if the netlify api route is `/.netlify/functions/` without any scope
-                        // we show this error, as functions at `/.netlify/functions/` route aren't possible
-                        validationErrors.apiBasePath = "apiBasePath should be of the format '/.netlify/functions/*' when using Netlify Serverless Functions.";
+                        validationErrors.apiBasePath = "apiBasePath must be prefixed by `/.netlify/functions/` and should contain a path after that. For example to use `/auth` set the apiBasePath to `/.netlify/functions/auth`. However using just `/.netlify/functions/` is considered invalid by Netlify.";
                     }
                 } else {
                     validationErrors.apiBasePath = "Please enter a valid path."


### PR DESCRIPTION
## Related issues
- #263 
- #254 

## Summary of changes
- fixed #263 - Convert the domain to lower case using `String.toLowerCase()` method when calling the normalization class `NormalisedURLDomain`.
- #254: Updated the error message we show when using Netlify Functions and the apiBasePath is not prefixed by `/.netlify/functions/` or does not contain any path after that.
  - Updated message: **"apiBasePath must be prefixed with \`/.netlify/functions\`, for example to use \`/auth\` set the apiBasePath to \`/.netlify/functions/auth\`"**

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
No todos remaining