### PR TITLE
Remove current entered values preview from appInfoForm

### DIFF
--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -237,26 +237,6 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         </span>
     )
 
-    getCurrentFormValuesAsString = () => {
-        const values = [];
-        if (this.props.askForAppName) {
-            values.push(`appName: "${this.state.appName}"`);
-        }
-        if (this.props.askForAPIDomain) {
-            values.push(`apiDomain: "${this.state.apiDomain}"`);
-        }
-        if (this.props.askForWebsiteDomain) {
-            values.push(`websiteDomain: "${this.state.websiteDomain}"`);
-        }
-        if (this.state.showAPIBasePath) {
-            values.push(`apiBasePath: "${this.state.apiBasePath}"`);
-        }
-        if (this.state.showWebsiteBasePath) {
-            values.push(`websiteBasePath: "${this.state.websiteBasePath}"`);
-        }
-        return values.join(",\n");
-    }
-
     render() {
         if (this.state.formSubmitted) {
             return (
@@ -289,11 +269,6 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                                 YOUR CONFIGURATION VALUES
                             </div>
                             <div style={{ height: "10px" }} />
-                            <div className="app-info-form__current-values-preview">
-                                <pre>
-                                    {this.getCurrentFormValuesAsString()}
-                                </pre>
-                            </div>
                             <div
                                 style={{
                                     fontSize: "16px",

--- a/v2/src/components/appInfoForm/style.css
+++ b/v2/src/components/appInfoForm/style.css
@@ -147,21 +147,6 @@
   justify-content: center;
 }
 
-.app-info-form__current-values-preview {
-  margin-bottom: 1rem;
-}
-
-.app-info-form__current-values-preview pre {
-  max-width: 33.8125rem;
-  width: 100%;
-  border: 0.0625rem solid rgb(78, 78, 78);
-  background-color: rgb(54, 54, 54);
-  padding: 1rem;
-  border-radius: 0.375rem;
-  font-size: 0.9375rem;
-  margin-top: 1rem;
-}
-
 .app-info-form-submitted-container {
   width: calc(100% - 5.5rem);
   margin-left: 1.25rem;


### PR DESCRIPTION
## Summary of change
- Removes the preview snippet that shows the currently saved values for the fields in AppInfoForm.

<img width="706" alt="image" src="https://user-images.githubusercontent.com/92283713/161025188-f8d8d178-f6c0-496d-8c37-21f1367193d8.png">

## Related issues
- #258 - https://github.com/supertokens/docs/issues/258#issuecomment-1084330307

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
- [x] Design review