### PR TITLE
Remove usage of replaceAll from question component in passwordless docs

### DIFF
--- a/v2/src/components/snippetConfigForm/index.tsx
+++ b/v2/src/components/snippetConfigForm/index.tsx
@@ -119,13 +119,13 @@ export default class SnippetConfigForm<T extends keyof any> extends React.PureCo
               if (typeof c === "string") {
                 for (const [ind, question] of this.props.questions.entries()) {
                   const value = this.state.answers[ind];
-                  c = c.replaceAll(`^{form_${question.id}}`, value);
+                  c = c.split(`^{form_${question.id}}`).join(value);
                   const selectedAns = question.options.find((opt) => opt.value === value);
                   if (selectedAns && selectedAns.variableMap) {
                     for (const [name, value] of Object.entries<string>(selectedAns.variableMap)) {
                       const key = `form_${question.id}_${name}`;
 
-                      c = (replaceWithIndent(key, value, c) as any).replaceAll(`^{${key}}`, value);
+                      c = replaceWithIndent(key, value, c).split(`^{${key}}`).join(value);
                     }
                   }
                 }
@@ -168,7 +168,7 @@ export function ConditionalSection(props: PropsWithChildren<ConditionalSectionPr
   return props.children;
 }
 
-function replaceWithIndent(target: string, replecement: string, str: string) {
+function replaceWithIndent(target: string, replecement: string, str: string): string {
   const regex = new RegExp(`(\\n\\s*)\\^{${target}}`, "g");
 
   return str.replace(regex, (match, p1) => {


### PR DESCRIPTION
## Summary of change
- The question component in passwordless docs uses `replaceAll` method in strings, which is not available in Safari 12.
- We replace this `replaceAll(stringWhichIsReplaced, stringThatReplaces)` by `.split(stringWhichIsReplaced).join(stringThatReplaces)`. This method is used in the `AppInfoForm` and works on Safari 12.

### Demo
- [iPad Air iOS v12.4](https://drive.google.com/file/d/1xSkouLU4Vfe25JORA0mZgDKIYX1cb-JD/view?usp=sharing)

## Related issues
- #267 

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
No todos remaining