### PR TITLE
Add additional information about using plain javascript and add an admonition for using multiple recipes

### DIFF
--- a/v2/emailpassword/quick-setup/backend.mdx
+++ b/v2/emailpassword/quick-setup/backend.mdx
@@ -359,7 +359,7 @@ init(
 </CoreInjector>
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. `^{recipeNameCapitalLetters}` provides the login feature and `Session` is used for session management (post login).
 :::
 
 </AppInfoForm>

--- a/v2/emailpassword/quick-setup/backend.mdx
+++ b/v2/emailpassword/quick-setup/backend.mdx
@@ -358,6 +358,10 @@ init(
 
 </CoreInjector>
 
+:::info NOTE
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+:::
+
 </AppInfoForm>
 
 

--- a/v2/emailpassword/quick-setup/frontend.mdx
+++ b/v2/emailpassword/quick-setup/frontend.mdx
@@ -290,7 +290,7 @@ To use SuperTokens with plain javascript you need to use the `supertokens-websit
 
 To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
 
-You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
+You can refer to [this blog post](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/emailpassword/quick-setup/frontend.mdx
+++ b/v2/emailpassword/quick-setup/frontend.mdx
@@ -108,7 +108,7 @@ class App extends React.Component {
 ```
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. `^{recipeNameCapitalLetters}` provides the login feature and `Session` is used for session management (post login).
 :::
 
 </AppInfoForm>

--- a/v2/emailpassword/quick-setup/frontend.mdx
+++ b/v2/emailpassword/quick-setup/frontend.mdx
@@ -285,8 +285,8 @@ class App extends React.Component {
 </TabItem>
 <TabItem value="vanillajs">
 
-:::caution Not supported
-We do not provide a UI for non ReactJS frameworks yet. So you will have to build your own UI, and integrate them with [our APIs](../apis#frontend-driver-interface).
+:::caution Note
+`supertokens-website` does not provide any UI but can handle session management for you. You can build your own UI and use the [API spec](https://app.swaggerhub.com/apis/supertokens/FDI) to call SuperTokens APIs manually. You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/emailpassword/quick-setup/frontend.mdx
+++ b/v2/emailpassword/quick-setup/frontend.mdx
@@ -107,6 +107,10 @@ class App extends React.Component {
 }
 ```
 
+:::info NOTE
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can also add other recipes to the list to use multiple recipes at a time!
+:::
+
 </AppInfoForm>
 
 </TabItem>

--- a/v2/emailpassword/quick-setup/frontend.mdx
+++ b/v2/emailpassword/quick-setup/frontend.mdx
@@ -108,7 +108,7 @@ class App extends React.Component {
 ```
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can also add other recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
 :::
 
 </AppInfoForm>

--- a/v2/emailpassword/quick-setup/frontend.mdx
+++ b/v2/emailpassword/quick-setup/frontend.mdx
@@ -286,7 +286,11 @@ class App extends React.Component {
 <TabItem value="vanillajs">
 
 :::caution Note
-`supertokens-website` does not provide any UI but can handle session management for you. You can build your own UI and use the [API spec](https://app.swaggerhub.com/apis/supertokens/FDI) to call SuperTokens APIs manually. You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
+To use SuperTokens with plain javascript you need to use the `supertokens-website` SDK. The SDK provides session management features.
+
+To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
+
+You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/passwordless/quick-setup/backend.mdx
+++ b/v2/passwordless/quick-setup/backend.mdx
@@ -413,7 +413,7 @@ init(
 </CoreInjector>
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. `^{recipeNameCapitalLetters}` provides the login feature and `Session` is used for session management (post login).
 :::
 
 </PasswordlessBackendForm>

--- a/v2/passwordless/quick-setup/backend.mdx
+++ b/v2/passwordless/quick-setup/backend.mdx
@@ -411,7 +411,13 @@ init(
 </BackendSDKTabs>
 
 </CoreInjector>
+
+:::info NOTE
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+:::
+
 </PasswordlessBackendForm>
+
 </AppInfoForm>
 
 ## 3) Set up your delivery method

--- a/v2/passwordless/quick-setup/frontend.mdx
+++ b/v2/passwordless/quick-setup/frontend.mdx
@@ -106,7 +106,7 @@ class App extends React.Component {
 ```
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can also add other recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
 :::
 
 </PasswordlessFrontendForm>

--- a/v2/passwordless/quick-setup/frontend.mdx
+++ b/v2/passwordless/quick-setup/frontend.mdx
@@ -286,8 +286,8 @@ class App extends React.Component {
 </TabItem>
 <TabItem value="vanillajs">
 
-:::caution Not supported
-We do not provide a UI for non ReactJS frameworks yet. So you will have to build your own UI, and integrate them with [our APIs](../apis#frontend-driver-interface).
+:::caution Note
+`supertokens-website` does not provide any UI but can handle session management for you. You can build your own UI and use the [API spec](https://app.swaggerhub.com/apis/supertokens/FDI) to call SuperTokens APIs manually. You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/passwordless/quick-setup/frontend.mdx
+++ b/v2/passwordless/quick-setup/frontend.mdx
@@ -291,7 +291,7 @@ To use SuperTokens with plain javascript you need to use the `supertokens-websit
 
 To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
 
-You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
+You can refer to [this blog post](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/passwordless/quick-setup/frontend.mdx
+++ b/v2/passwordless/quick-setup/frontend.mdx
@@ -105,6 +105,10 @@ class App extends React.Component {
 }
 ```
 
+:::info NOTE
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can also add other recipes to the list to use multiple recipes at a time!
+:::
+
 </PasswordlessFrontendForm>
 </AppInfoForm>
 

--- a/v2/passwordless/quick-setup/frontend.mdx
+++ b/v2/passwordless/quick-setup/frontend.mdx
@@ -106,7 +106,7 @@ class App extends React.Component {
 ```
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. `^{recipeNameCapitalLetters}` provides the login feature and `Session` is used for session management (post login).
 :::
 
 </PasswordlessFrontendForm>

--- a/v2/passwordless/quick-setup/frontend.mdx
+++ b/v2/passwordless/quick-setup/frontend.mdx
@@ -287,7 +287,11 @@ class App extends React.Component {
 <TabItem value="vanillajs">
 
 :::caution Note
-`supertokens-website` does not provide any UI but can handle session management for you. You can build your own UI and use the [API spec](https://app.swaggerhub.com/apis/supertokens/FDI) to call SuperTokens APIs manually. You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
+To use SuperTokens with plain javascript you need to use the `supertokens-website` SDK. The SDK provides session management features.
+
+To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
+
+You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/src/components/tabs/FrontendSDKTabs.tsx
+++ b/v2/src/components/tabs/FrontendSDKTabs.tsx
@@ -69,7 +69,7 @@ function DefaultVanillaJSTabItem() {
 
                     To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec <a href="https://supertokens.com/docs/fdi">here</a><br/><br/>
 
-                    You can refer to <a href="https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens">this example</a> to know how this is done, the example uses social login but the same setup applies to other recipes as well.
+                    You can refer to <a href="https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens">this blog post</a> to know how this is done, the example uses social login but the same setup applies to other recipes as well.
                 </div>
             </div>
         </TabItem>

--- a/v2/src/components/tabs/FrontendSDKTabs.tsx
+++ b/v2/src/components/tabs/FrontendSDKTabs.tsx
@@ -61,11 +61,11 @@ function DefaultVanillaJSTabItem() {
                                 </path>
                             </svg>
                         </span>
-                        not supported / not applicable
+                        Note
                     </h5>
                 </div>
                 <div className="admonition-content">
-                    If this requires a call to the backend, you will need to call <a href="/docs/thirdpartyemailpassword/apis#frontend-driver-interface">our APIs</a> yourself. Otherwise, since you are building your own login UI, you will have to handle this yourself.
+                    <code>supertokens-website</code> does not provide any UI but can handle session management for you. You can build your own UI and use the <a href="https://app.swaggerhub.com/apis/supertokens/FDI">API spec</a> to call SuperTokens APIs manually. You can refer to <a href="https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens">this example</a> to know how this is done, the example uses social login but the same setup applies to other recipes as well.
                 </div>
             </div>
         </TabItem>

--- a/v2/src/components/tabs/FrontendSDKTabs.tsx
+++ b/v2/src/components/tabs/FrontendSDKTabs.tsx
@@ -65,7 +65,11 @@ function DefaultVanillaJSTabItem() {
                     </h5>
                 </div>
                 <div className="admonition-content">
-                    <code>supertokens-website</code> does not provide any UI but can handle session management for you. You can build your own UI and use the <a href="https://app.swaggerhub.com/apis/supertokens/FDI">API spec</a> to call SuperTokens APIs manually. You can refer to <a href="https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens">this example</a> to know how this is done, the example uses social login but the same setup applies to other recipes as well.
+                    To use SuperTokens with plain javascript you need to use the <code>supertokens-website</code> SDK. The SDK provides session management features.<br/><br/>
+
+                    To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec <a href="https://supertokens.com/docs/fdi">here</a><br/><br/>
+
+                    You can refer to <a href="https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens">this example</a> to know how this is done, the example uses social login but the same setup applies to other recipes as well.
                 </div>
             </div>
         </TabItem>

--- a/v2/thirdparty/quick-setup/backend.mdx
+++ b/v2/thirdparty/quick-setup/backend.mdx
@@ -372,7 +372,7 @@ init(
 </CoreInjector>
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. `^{recipeNameCapitalLetters}` provides the login feature and `Session` is used for session management (post login).
 :::
 
 </AppInfoForm>

--- a/v2/thirdparty/quick-setup/backend.mdx
+++ b/v2/thirdparty/quick-setup/backend.mdx
@@ -371,6 +371,10 @@ init(
 
 </CoreInjector>
 
+:::info NOTE
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+:::
+
 </AppInfoForm>
 
 

--- a/v2/thirdparty/quick-setup/frontend.mdx
+++ b/v2/thirdparty/quick-setup/frontend.mdx
@@ -110,7 +110,7 @@ class App extends React.Component {
 ```
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can also add other recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
 :::
 
 </AppInfoForm>

--- a/v2/thirdparty/quick-setup/frontend.mdx
+++ b/v2/thirdparty/quick-setup/frontend.mdx
@@ -109,6 +109,10 @@ class App extends React.Component {
 }
 ```
 
+:::info NOTE
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can also add other recipes to the list to use multiple recipes at a time!
+:::
+
 </AppInfoForm>
 
 </TabItem>

--- a/v2/thirdparty/quick-setup/frontend.mdx
+++ b/v2/thirdparty/quick-setup/frontend.mdx
@@ -293,7 +293,7 @@ To use SuperTokens with plain javascript you need to use the `supertokens-websit
 
 To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
 
-You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
+You can refer to [this blog post](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/thirdparty/quick-setup/frontend.mdx
+++ b/v2/thirdparty/quick-setup/frontend.mdx
@@ -289,7 +289,11 @@ class App extends React.Component {
 <TabItem value="vanillajs">
 
 :::caution Note
-`supertokens-website` does not provide any UI but can handle session management for you. You can build your own UI and use the [API spec](https://app.swaggerhub.com/apis/supertokens/FDI) to call SuperTokens APIs manually. You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
+To use SuperTokens with plain javascript you need to use the `supertokens-website` SDK. The SDK provides session management features.
+
+To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
+
+You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/thirdparty/quick-setup/frontend.mdx
+++ b/v2/thirdparty/quick-setup/frontend.mdx
@@ -288,8 +288,8 @@ class App extends React.Component {
 </TabItem>
 <TabItem value="vanillajs">
 
-:::caution Not supported
-We do not provide a UI for non ReactJS frameworks yet. So you will have to build your own UI, and integrate them with [our APIs](../apis#frontend-driver-interface).
+:::caution Note
+`supertokens-website` does not provide any UI but can handle session management for you. You can build your own UI and use the [API spec](https://app.swaggerhub.com/apis/supertokens/FDI) to call SuperTokens APIs manually. You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/thirdparty/quick-setup/frontend.mdx
+++ b/v2/thirdparty/quick-setup/frontend.mdx
@@ -110,7 +110,7 @@ class App extends React.Component {
 ```
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. `^{recipeNameCapitalLetters}` provides the login feature and `Session` is used for session management (post login).
 :::
 
 </AppInfoForm>

--- a/v2/thirdpartyemailpassword/quick-setup/backend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/backend.mdx
@@ -368,7 +368,7 @@ init(
 </CoreInjector>
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. `^{recipeNameCapitalLetters}` provides the login feature and `Session` is used for session management (post login).
 :::
 
 </AppInfoForm>

--- a/v2/thirdpartyemailpassword/quick-setup/backend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/backend.mdx
@@ -367,6 +367,10 @@ init(
 
 </CoreInjector>
 
+:::info NOTE
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+:::
+
 </AppInfoForm>
 
 ## 3) Initialise Social login providers

--- a/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
@@ -111,6 +111,10 @@ class App extends React.Component {
 }
 ```
 
+:::info NOTE
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can also add other recipes to the list to use multiple recipes at a time!
+:::
+
 </AppInfoForm>
 
 </TabItem>

--- a/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
@@ -291,7 +291,11 @@ class App extends React.Component {
 <TabItem value="vanillajs">
 
 :::caution Note
-`supertokens-website` does not provide any UI but can handle session management for you. You can build your own UI and use the [API spec](https://app.swaggerhub.com/apis/supertokens/FDI) to call SuperTokens APIs manually. You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
+To use SuperTokens with plain javascript you need to use the `supertokens-website` SDK. The SDK provides session management features.
+
+To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
+
+You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
@@ -295,7 +295,7 @@ To use SuperTokens with plain javascript you need to use the `supertokens-websit
 
 To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
 
-You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
+You can refer to [this blog post](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
@@ -112,7 +112,7 @@ class App extends React.Component {
 ```
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can also add other recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
 :::
 
 </AppInfoForm>

--- a/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
@@ -112,7 +112,7 @@ class App extends React.Component {
 ```
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. `^{recipeNameCapitalLetters}` provides the login feature and `Session` is used for session management (post login).
 :::
 
 </AppInfoForm>

--- a/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
@@ -290,8 +290,8 @@ class App extends React.Component {
 </TabItem>
 <TabItem value="vanillajs">
 
-:::caution Not supported
-We do not provide a UI for non ReactJS frameworks yet. So you will have to build your own UI, and integrate them with [our APIs](../apis#frontend-driver-interface).
+:::caution Note
+`supertokens-website` does not provide any UI but can handle session management for you. You can build your own UI and use the [API spec](https://app.swaggerhub.com/apis/supertokens/FDI) to call SuperTokens APIs manually. You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/thirdpartypasswordless/quick-setup/backend.mdx
+++ b/v2/thirdpartypasswordless/quick-setup/backend.mdx
@@ -421,7 +421,13 @@ init(
 </BackendSDKTabs>
 
 </CoreInjector>
+
+:::info NOTE
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+:::
+
 </PasswordlessBackendForm>
+
 </AppInfoForm>
 
 ## 3) Set up your delivery method

--- a/v2/thirdpartypasswordless/quick-setup/backend.mdx
+++ b/v2/thirdpartypasswordless/quick-setup/backend.mdx
@@ -423,7 +423,7 @@ init(
 </CoreInjector>
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. `^{recipeNameCapitalLetters}` provides the login feature and `Session` is used for session management (post login).
 :::
 
 </PasswordlessBackendForm>

--- a/v2/thirdpartypasswordless/quick-setup/frontend.mdx
+++ b/v2/thirdpartypasswordless/quick-setup/frontend.mdx
@@ -113,6 +113,10 @@ class App extends React.Component {
 }
 ```
 
+:::info NOTE
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can also add other recipes to the list to use multiple recipes at a time!
+:::
+
 </PasswordlessFrontendForm>
 </AppInfoForm>
 

--- a/v2/thirdpartypasswordless/quick-setup/frontend.mdx
+++ b/v2/thirdpartypasswordless/quick-setup/frontend.mdx
@@ -295,7 +295,11 @@ class App extends React.Component {
 <TabItem value="vanillajs">
 
 :::caution Note
-`supertokens-website` does not provide any UI but can handle session management for you. You can build your own UI and use the [API spec](https://app.swaggerhub.com/apis/supertokens/FDI) to call SuperTokens APIs manually. You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
+To use SuperTokens with plain javascript you need to use the `supertokens-website` SDK. The SDK provides session management features.
+
+To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
+
+You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/thirdpartypasswordless/quick-setup/frontend.mdx
+++ b/v2/thirdpartypasswordless/quick-setup/frontend.mdx
@@ -114,7 +114,7 @@ class App extends React.Component {
 ```
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can also add other recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
 :::
 
 </PasswordlessFrontendForm>

--- a/v2/thirdpartypasswordless/quick-setup/frontend.mdx
+++ b/v2/thirdpartypasswordless/quick-setup/frontend.mdx
@@ -299,7 +299,7 @@ To use SuperTokens with plain javascript you need to use the `supertokens-websit
 
 To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
 
-You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
+You can refer to [this blog post](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/thirdpartypasswordless/quick-setup/frontend.mdx
+++ b/v2/thirdpartypasswordless/quick-setup/frontend.mdx
@@ -294,8 +294,8 @@ class App extends React.Component {
 </TabItem>
 <TabItem value="vanillajs">
 
-:::caution Not supported
-We do not provide a UI for non ReactJS frameworks yet. So you will have to build your own UI, and integrate them with [our APIs](../apis#frontend-driver-interface).
+:::caution Note
+`supertokens-website` does not provide any UI but can handle session management for you. You can build your own UI and use the [API spec](https://app.swaggerhub.com/apis/supertokens/FDI) to call SuperTokens APIs manually. You can refer to [this example](https://supertokens.com/blog/adding-social-login-to-your-website-with-supertokens) to know how this is done, the example uses social login but the same setup applies to other recipes as well.
 :::
 
 </TabItem>

--- a/v2/thirdpartypasswordless/quick-setup/frontend.mdx
+++ b/v2/thirdpartypasswordless/quick-setup/frontend.mdx
@@ -114,7 +114,7 @@ class App extends React.Component {
 ```
 
 :::info NOTE
-Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. The SuperTokens SDK uses both recipes to provide the auth functionality. You can add more recipes to the list to use multiple recipes at a time!
+Notice that `SuperTokens.init` uses both the `^{recipeNameCapitalLetters}` and `Session` recipes. `^{recipeNameCapitalLetters}` provides the login feature and `Session` is used for session management (post login).
 :::
 
 </PasswordlessFrontendForm>


### PR DESCRIPTION
## Summary of change
- Changes the admonition for Plain Javascript to better explain how to use the SDK by building your own UI
- Adds an admonition to the frontend and backend quick setup guides for all recipes to explain that SuperTokens.init uses both the recipe itself and the session recipe and that the user can do the same thing to use multiple recipes

## Related issues
- None

## Checklist
- [ ] ~~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~~
- [ ] ~~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~~
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] ~~Changes required to the demo apps corresponding to the docs?~~

## Remaining TODOs for this PR
- [ ] ...