### PR TITLE
Modify react native tab for quick setup and UI operations

### DIFF
--- a/v2/emailpassword/quick-setup/frontend.mdx
+++ b/v2/emailpassword/quick-setup/frontend.mdx
@@ -296,8 +296,10 @@ You can refer to [this blog post](https://supertokens.com/blog/adding-social-log
 </TabItem>
 <TabItem value="react-native">
 
-:::caution Not supported
-We do not provide a UI for React Native apps yet. So you will have to build your own UI, and integrate them with [our APIs](../apis#frontend-driver-interface).
+:::caution Note
+To use SuperTokens with React Native you need to use the `supertokens-react-native` SDK. The SDK provides session management features.
+
+To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
 :::
 
 </TabItem>

--- a/v2/passwordless/quick-setup/frontend.mdx
+++ b/v2/passwordless/quick-setup/frontend.mdx
@@ -297,8 +297,10 @@ You can refer to [this blog post](https://supertokens.com/blog/adding-social-log
 </TabItem>
 <TabItem value="react-native">
 
-:::caution Not supported
-We do not provide a UI for React Native apps yet. So you will have to build your own UI, and integrate them with [our APIs](../apis#frontend-driver-interface).
+:::caution Note
+To use SuperTokens with React Native you need to use the `supertokens-react-native` SDK. The SDK provides session management features.
+
+To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
 :::
 
 </TabItem>

--- a/v2/src/components/tabs/FrontendSDKTabs.tsx
+++ b/v2/src/components/tabs/FrontendSDKTabs.tsx
@@ -37,11 +37,13 @@ function DefaultRNTabItem() {
                                 </path>
                             </svg>
                         </span>
-                        not supported / not applicable
+                        Note
                     </h5>
                 </div>
                 <div className="admonition-content">
-                    If this requires a call to the backend, you will need to call <a href="/docs/thirdpartyemailpassword/apis#frontend-driver-interface">our APIs</a> yourself. Otherwise, since you are building your own login UI, you will have to handle this yourself.
+                    To use SuperTokens with React Native you need to use the <code>supertokens-react-native</code> SDK. The SDK provides session management features.<br/><br/>
+                    
+                    To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec <a href="https://supertokens.com/docs/fdi">here</a>
                 </div>
             </div>
         </TabItem>

--- a/v2/thirdparty/quick-setup/frontend.mdx
+++ b/v2/thirdparty/quick-setup/frontend.mdx
@@ -299,8 +299,10 @@ You can refer to [this blog post](https://supertokens.com/blog/adding-social-log
 </TabItem>
 <TabItem value="react-native">
 
-:::caution Not supported
-We do not provide a UI for React Native apps yet. So you will have to build your own UI, and integrate them with [our APIs](../apis#frontend-driver-interface).
+:::caution Note
+To use SuperTokens with React Native you need to use the `supertokens-react-native` SDK. The SDK provides session management features.
+
+To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
 :::
 
 </TabItem>

--- a/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/frontend.mdx
@@ -301,8 +301,10 @@ You can refer to [this blog post](https://supertokens.com/blog/adding-social-log
 </TabItem>
 <TabItem value="react-native">
 
-:::caution Not supported
-We do not provide a UI for React Native apps yet. So you will have to build your own UI, and integrate them with [our APIs](../apis#frontend-driver-interface).
+:::caution Note
+To use SuperTokens with React Native you need to use the `supertokens-react-native` SDK. The SDK provides session management features.
+
+To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
 :::
 
 </TabItem>

--- a/v2/thirdpartypasswordless/quick-setup/frontend.mdx
+++ b/v2/thirdpartypasswordless/quick-setup/frontend.mdx
@@ -305,8 +305,10 @@ You can refer to [this blog post](https://supertokens.com/blog/adding-social-log
 </TabItem>
 <TabItem value="react-native">
 
-:::caution Not supported
-We do not provide a UI for React Native apps yet. So you will have to build your own UI, and integrate them with [our APIs](../apis#frontend-driver-interface).
+:::caution Note
+To use SuperTokens with React Native you need to use the `supertokens-react-native` SDK. The SDK provides session management features.
+
+To add login functionality, you need to build your own UI and call the APIs exposed by the backend SDKs. You can find the API spec [here](https://supertokens.com/docs/fdi)
 :::
 
 </TabItem>


### PR DESCRIPTION
## Summary of change
- Changes the content of the admonition for react-native in the frontend quick setup guide and snippets that apply to pre-built UI

## Related issues
- None

## Checklist
- [ ] ~~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~~
- [ ] ~~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~~
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] ~~Changes required to the demo apps corresponding to the docs?~~

## Remaining TODOs for this PR
- [ ] ...