### PR TITLE
In appInfoForm, validate the equal paths case only if the domains exist

### DIFF
--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -696,10 +696,11 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             const normalisedWebsiteBasePath = this.getNormalisedBasePath(websiteBasePath);
 
             const nextJSApiRouteUsed = this.props.showNextJSAPIRouteCheckbox && this.state.nextJSApiRouteUsed;
-            const areNormalisedDomainsEqual = normalisedApiDomain === normalisedWebsiteDomain
+            const areNormalisedDomainsEqual = normalisedApiDomain === normalisedWebsiteDomain;
 
+            const doNormalisedDomainsExist = normalisedApiDomain.length > 0 && normalisedWebsiteDomain.length > 0;
 
-            if (nextJSApiRouteUsed || areNormalisedDomainsEqual) {
+            if (doNormalisedDomainsExist && (nextJSApiRouteUsed || areNormalisedDomainsEqual)) {
                 if (normalisedApiBasePath === normalisedWebsiteBasePath) {
                     validationErrors.apiBasePath = "apiBasePath and websiteBasePath cannot be equal.";
                 } else if (normalisedApiBasePath.startsWith(normalisedWebsiteBasePath)) {


### PR DESCRIPTION
## Summary of problem
- If we do not add any domains, and enter same values for `apiBasePath` and `websiteBasePath`, the `appInfoForm` shows 3 errors, 2 on the empty domains and 1 on `apiBasePath` saying that the paths cannot be equal.

## Summary of change
- If the domains are empty, the paths should not be validated for the case where if the domains are equal, the paths cannot be equal or be prefixed by each other.

## Related issues
- #275 

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
No TODOs remaining