### PR TITLE
add alt tag to icons in sidebar menu

### DIFF
--- a/v2/src/components/appInfoForm/formItem.tsx
+++ b/v2/src/components/appInfoForm/formItem.tsx
@@ -99,6 +99,7 @@ export default function FormItem(props: FormItemType) {
                     </span>
                     <div className="question">
                         <img
+                            alt="Information about the question"
                             id={`app-info-form-question-icon-${props.index}`}
                             className="app-info-form-question-icon"
                             src="/img/form-question.png"

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -250,7 +250,9 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                                 style={{
                                     width: "17px",
                                 }}
-                                src="/img/form-submitted-tick.png" />
+                                src="/img/form-submitted-tick.png"
+                                alt="Form submitted"
+                            />
                         </div>
                         <div
                             style={{

--- a/v2/src/components/question/index.tsx
+++ b/v2/src/components/question/index.tsx
@@ -44,6 +44,7 @@ export function Question(props: PropsWithChildren<{
                             marginRight: "10px"
                         }}>
                         <img
+                            alt="Answer submitted"
                             style={{
                                 width: "17px",
                             }}

--- a/v2/src/components/snippetConfigForm/formQuestion.tsx
+++ b/v2/src/components/snippetConfigForm/formQuestion.tsx
@@ -52,6 +52,7 @@ export function Question(props: PropsWithChildren<{
                             marginRight: "10px"
                         }}>
                         <img
+                            alt="Answer submitted"
                             style={{
                                 width: "17px",
                             }}

--- a/v2/src/theme/DocSidebar/index.js
+++ b/v2/src/theme/DocSidebar/index.js
@@ -138,7 +138,14 @@ function DocSidebarItemCategory ({
             marginLeft: `${depth * 16}px`,
           } : {}}
         >{label}</span>
-        {item.customProps && item.customProps.logoUrl && <img className={styles.sidebarItemLogo} src={item.customProps.logoUrl} title={label + 'logo'} />}
+        {item.customProps && item.customProps.logoUrl && (
+          <img
+            className={styles.sidebarItemLogo}
+            src={item.customProps.logoUrl}
+            title={label + ' logo'}
+            alt={label + " logo"}
+          />
+        )}
         <div className={styles.spacer}></div>
       </a>
       <ul
@@ -212,7 +219,14 @@ function DocSidebarItemLink({
             <IconExternalLink />
           </span>
         )}
-        {item.customProps && item.customProps.logoUrl && <img className={styles.sidebarItemLogo} src={item.customProps.logoUrl} title={label + 'logo'} />}
+        {item.customProps && item.customProps.logoUrl && (
+          <img
+            className={styles.sidebarItemLogo}
+            src={item.customProps.logoUrl}
+            title={label + ' logo'}
+            alt={label + ' logo'}
+          />
+        )}
       </Link>
       <div className={styles.spacer}></div>
     </li>


### PR DESCRIPTION
## Summary of change
- Adds `alt` tags to the images displayed in the left sidebar.
- Adds `alt` tag to the "Double check" image used in AppInfoForm and Question components 'saved' state.
- Adds `alt` tag to the "?" icon next to questions in the AppInfoForm

## Related issues
- #299 
- #301 

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
No todos remaining