### PR TITLE
Add alt text to architecture page flowcharts

### DIFF
--- a/v2/community/architecture.mdx
+++ b/v2/community/architecture.mdx
@@ -29,10 +29,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service_generic.png" />
+<img src="/img/architecture/managed_service_generic.png" alt="Flowchart of architecture when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted_generic.png" />
+<img src="/img/architecture/self_hosted_generic.png" alt="Flowchart of architecture when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 
@@ -72,10 +72,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service.png" />
+<img src="/img/architecture/managed_service.png" alt="Flowchart of sign in flow when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted.png" />
+<img src="/img/architecture/self_hosted.png" alt="Flowchart of sign in flow when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 

--- a/v2/emailpassword/architecture.mdx
+++ b/v2/emailpassword/architecture.mdx
@@ -29,10 +29,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service_generic.png" />
+<img src="/img/architecture/managed_service_generic.png" alt="Flowchart of architecture when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted_generic.png" />
+<img src="/img/architecture/self_hosted_generic.png" alt="Flowchart of architecture when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 
@@ -72,10 +72,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service.png" />
+<img src="/img/architecture/managed_service.png" alt="Flowchart of sign in flow when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted.png" />
+<img src="/img/architecture/self_hosted.png" alt="Flowchart of sign in flow when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 

--- a/v2/passwordless/architecture.mdx
+++ b/v2/passwordless/architecture.mdx
@@ -29,10 +29,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service_generic.png" />
+<img src="/img/architecture/managed_service_generic.png" alt="Flowchart of architecture when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted_generic.png" />
+<img src="/img/architecture/self_hosted_generic.png" alt="Flowchart of architecture when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 
@@ -72,10 +72,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service.png" />
+<img src="/img/architecture/managed_service.png" alt="Flowchart of sign in flow when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted.png" />
+<img src="/img/architecture/self_hosted.png" alt="Flowchart of sign in flow when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 

--- a/v2/session/architecture.mdx
+++ b/v2/session/architecture.mdx
@@ -29,10 +29,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service_generic.png" />
+<img src="/img/architecture/managed_service_generic.png" alt="Flowchart of architecture when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted_generic.png" />
+<img src="/img/architecture/self_hosted_generic.png" alt="Flowchart of architecture when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 
@@ -72,10 +72,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service.png" />
+<img src="/img/architecture/managed_service.png" alt="Flowchart of sign in flow when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted.png" />
+<img src="/img/architecture/self_hosted.png" alt="Flowchart of sign in flow when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 

--- a/v2/thirdparty/architecture.mdx
+++ b/v2/thirdparty/architecture.mdx
@@ -29,10 +29,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service_generic.png" />
+<img src="/img/architecture/managed_service_generic.png" alt="Flowchart of architecture when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted_generic.png" />
+<img src="/img/architecture/self_hosted_generic.png" alt="Flowchart of architecture when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 
@@ -72,10 +72,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service.png" />
+<img src="/img/architecture/managed_service.png" alt="Flowchart of sign in flow when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted.png" />
+<img src="/img/architecture/self_hosted.png" alt="Flowchart of sign in flow when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 

--- a/v2/thirdpartyemailpassword/architecture.mdx
+++ b/v2/thirdpartyemailpassword/architecture.mdx
@@ -29,10 +29,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service_generic.png" />
+<img src="/img/architecture/managed_service_generic.png" alt="Flowchart of architecture when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted_generic.png" />
+<img src="/img/architecture/self_hosted_generic.png" alt="Flowchart of architecture when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 
@@ -72,10 +72,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service.png" />
+<img src="/img/architecture/managed_service.png" alt="Flowchart of sign in flow when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted.png" />
+<img src="/img/architecture/self_hosted.png" alt="Flowchart of sign in flow when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 

--- a/v2/thirdpartypasswordless/architecture.mdx
+++ b/v2/thirdpartypasswordless/architecture.mdx
@@ -29,10 +29,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service_generic.png" />
+<img src="/img/architecture/managed_service_generic.png" alt="Flowchart of architecture when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted_generic.png" />
+<img src="/img/architecture/self_hosted_generic.png" alt="Flowchart of architecture when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 
@@ -72,10 +72,10 @@ values={[
 {label: 'Self hosted', value: 'ss'},
 ]}>
 <TabItem value="ms">
-<img src="/img/architecture/managed_service.png" />
+<img src="/img/architecture/managed_service.png" alt="Flowchart of sign in flow when using SuperTokens managed service" />
 </TabItem>
 <TabItem value="ss">
-<img src="/img/architecture/self_hosted.png" />
+<img src="/img/architecture/self_hosted.png" alt="Flowchart of sign in flow when self-hosting SuperTokens" />
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## Summary of change
- Adds alt text to flowchart images in the architecture pages

Note: The architecture files in recipes are copied from the `v2/community/architecture.mdx` file.

## Related issues
- #305 

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
No todos remaining