### PR TITLE
Add alt text to images of themes for thirdparty, emailpassword and thirdpartyemailpassword

### DIFF
--- a/v2/emailpassword/common-customizations/styling/themes.mdx
+++ b/v2/emailpassword/common-customizations/styling/themes.mdx
@@ -9,29 +9,29 @@ Combining the techniques described in the previous two sections we have created 
 
 ## Default Theme ([See working demo](https://emailpassword.demo.supertokens.com))
 
-<img width="600px" src="/docs/static/assets/emailpassword/signin-light.png" />
+<img width="600px" alt="Prebuilt sign in form in default theme" src="/docs/static/assets/emailpassword/signin-light.png" />
 <br/>
-<img width="600px" src="/docs/static/assets/emailpassword/signup-light.png" />
+<img width="600px" alt="Prebuilt sign up form in default theme" src="/docs/static/assets/emailpassword/signup-light.png" />
 
 
 ## Dark Theme ([See UI demo](https://60422138fc41c9cd7eb8f4cd--affectionate-galileo-626692.netlify.app/auth?rid=emailpassword&redirectToPath=%2F&theme=dark))
 
-<img width="700px" src="/docs/static/assets/emailpassword/darkin.png" />
+<img width="700px" alt="Prebuilt sign in form in dark theme" src="/docs/static/assets/emailpassword/darkin.png" />
 <br/>
-<img width="700px" src="/docs/static/assets/emailpassword/darkup.png" />
+<img width="700px" alt="Prebuilt sign up form in dark theme" src="/docs/static/assets/emailpassword/darkup.png" />
 
 ## Hydrogen Theme ([See UI demo](https://60422138fc41c9cd7eb8f4cd--affectionate-galileo-626692.netlify.app/auth?rid=emailpassword&redirectToPath=%2F&theme=hydrogen))
 
 
-<img width="700px" src="/docs/static/assets/emailpassword/hydrogenin.png" />
+<img width="700px" alt="Prebuilt sign in form in Hydrogen theme" src="/docs/static/assets/emailpassword/hydrogenin.png" />
 <br/>
-<img width="700px" src="/docs/static/assets/emailpassword/hydrogenup.png" />
+<img width="700px" alt="Prebuilt sign up form in Hydrogen theme" src="/docs/static/assets/emailpassword/hydrogenup.png" />
 
 ## Helium Theme ([See UI demo](https://60422138fc41c9cd7eb8f4cd--affectionate-galileo-626692.netlify.app/auth?rid=emailpassword&redirectToPath=%2F&theme=helium))
 
-<img width="700px" src="/docs/static/assets/emailpassword/heliumin.png" />
+<img width="700px" alt="Prebuilt sign in form in Helium theme" src="/docs/static/assets/emailpassword/heliumin.png" />
 <br/>
-<img width="700px" src="/docs/static/assets/emailpassword/heliumup.png" />
+<img width="700px" alt="Prebuilt sign up form in Helium theme" src="/docs/static/assets/emailpassword/heliumup.png" />
 
 
 

--- a/v2/thirdparty/common-customizations/styling/themes.mdx
+++ b/v2/thirdparty/common-customizations/styling/themes.mdx
@@ -9,19 +9,19 @@ Combining the techniques described in the previous two sections we have created 
 
 ## Default Theme ([See working demo](https://thirdparty.demo.supertokens.com))
 
-<img width="600px" src="/docs/static/assets/thirdparty/default-theme.png" />
+<img width="600px" alt="Prebuilt sign in/sign up form in default theme" src="/docs/static/assets/thirdparty/default-theme.png" />
 
 
 ## Dark Theme ([See UI demo](https://60422138fc41c9cd7eb8f4cd--affectionate-galileo-626692.netlify.app/auth?rid=thirdparty&theme=dark))
 
-<img width="700px" src="/docs/static/assets/thirdparty/dark-theme.png" />
+<img width="700px" alt="Prebuilt sign in/sign up form in dark theme" src="/docs/static/assets/thirdparty/dark-theme.png" />
 
 ## Hydrogen Theme ([See UI demo](https://60422138fc41c9cd7eb8f4cd--affectionate-galileo-626692.netlify.app/auth?rid=thirdparty&theme=hydrogen))
 
 
-<img width="700px" src="/docs/static/assets/thirdparty/hydrogen-theme.png" />
+<img width="700px" alt="Prebuilt sign in/sign up form in Hydrogen theme" src="/docs/static/assets/thirdparty/hydrogen-theme.png" />
 <br/>
 
 ## Helium Theme ([See UI demo](https://60422138fc41c9cd7eb8f4cd--affectionate-galileo-626692.netlify.app/auth?rid=thirdparty&theme=helium))
 
-<img width="700px" src="/docs/static/assets/thirdparty/helium-theme.png" />
+<img width="700px" alt="Prebuilt sign in/sign up form in Helium theme" src="/docs/static/assets/thirdparty/helium-theme.png" />

--- a/v2/thirdpartyemailpassword/common-customizations/styling/themes.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/styling/themes.mdx
@@ -9,27 +9,27 @@ Combining the techniques described in the previous two sections we have created 
 
 ## Default Theme ([See working demo](https://thirdpartyemailpassword.demo.supertokens.com))
 
-<img width="600px" src="/docs/static/assets/thirdpartyemailpassword/signin-light.png" />
+<img width="600px" alt="Prebuilt sign in form in default theme" src="/docs/static/assets/thirdpartyemailpassword/signin-light.png" />
 <br/>
-<img width="600px" src="/docs/static/assets/thirdpartyemailpassword/signup-light.png" />
+<img width="600px" alt="Prebuilt sign up form in default theme" src="/docs/static/assets/thirdpartyemailpassword/signup-light.png" />
 
 
 ## Dark Theme ([See UI demo](https://60422138fc41c9cd7eb8f4cd--affectionate-galileo-626692.netlify.app/auth?rid=thirdpartyemailpassword&redirectToPath=%2F&theme=dark))
 
-<img width="700px" src="/docs/static/assets/thirdpartyemailpassword/darkin.png" />
+<img width="700px" alt="Prebuilt sign in form in dark theme" src="/docs/static/assets/thirdpartyemailpassword/darkin.png" />
 <br/>
-<img width="700px" src="/docs/static/assets/thirdpartyemailpassword/darkup.png" />
+<img width="700px" alt="Prebuilt sign up form in dark theme" src="/docs/static/assets/thirdpartyemailpassword/darkup.png" />
 
 ## Hydrogen Theme ([See UI demo](https://60422138fc41c9cd7eb8f4cd--affectionate-galileo-626692.netlify.app/auth?rid=thirdpartyemailpassword&redirectToPath=%2F&theme=hydrogen))
 
 
-<img width="700px" src="/docs/static/assets/thirdpartyemailpassword/hydrogenin.png" />
+<img width="700px" alt="Prebuilt sign in form in Hydrogen theme" src="/docs/static/assets/thirdpartyemailpassword/hydrogenin.png" />
 <br/>
-<img width="700px" src="/docs/static/assets/thirdpartyemailpassword/hydrogenup.png" />
+<img width="700px" alt="Prebuilt sign up form in Hydrogen theme" src="/docs/static/assets/thirdpartyemailpassword/hydrogenup.png" />
 
 ## Helium Theme ([See UI demo](https://60422138fc41c9cd7eb8f4cd--affectionate-galileo-626692.netlify.app/auth?rid=thirdpartyemailpassword&redirectToPath=%2F&theme=helium))
 
-<img width="700px" src="/docs/static/assets/thirdpartyemailpassword/heliumin.png" />
+<img width="700px" alt="Prebuilt sign in form in Helium theme" src="/docs/static/assets/thirdpartyemailpassword/heliumin.png" />
 <br/>
-<img width="700px" src="/docs/static/assets/thirdpartyemailpassword/heliumup.png" />
+<img width="700px" alt="Prebuilt sign up form in Helium theme" src="/docs/static/assets/thirdpartyemailpassword/heliumup.png" />
 


### PR DESCRIPTION
## Summary of change
Adds alt text to the images of themes in the following pages
- https://test.supertokens.com/docs/emailpassword/common-customizations/styling/themes
- https://test.supertokens.com/docs/thirdparty/common-customizations/styling/themes
- https://test.supertokens.com/docs/thirdpartyemailpassword/common-customizations/styling/themes

## Related issues
- #305 

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
No TODOs remaining