### PR TITLE
Added alt text to account migration and auth0 database images

### DIFF
--- a/v2/emailpassword/migration/from-auth0/account-migration/modifications-to-login.mdx
+++ b/v2/emailpassword/migration/from-auth0/account-migration/modifications-to-login.mdx
@@ -21,7 +21,7 @@ The following code is implemented for Nodejs, but, you can apply the same logic 
 If you have not stored your user's Auth0 userId in your database you can **ignore** the steps mentioned in **Box 5** and **Box 8** of the flow diagram.
 :::
 
-<img src="/img/thirdpartyemailpassword/ep-account-migration.png" />
+<img alt="Flow of login to migrate users with email-password accounts in Auth0 to SuperTokens" src="/img/thirdpartyemailpassword/ep-account-migration.png" />
 
 ## Implementation
 
@@ -172,11 +172,11 @@ We will be using Auth0's APIs to validate user credentials. Please refer to Auth
 For example:
 - The default connection name for the database is `Username-Password-Authentication`, you can find your database connections under Authentication -> Database on your Auth0 dashboard.
 
-<img src="/img/thirdpartyemailpassword/auth0-database.png" />
+<img alt="Database connections in Auth0" src="/img/thirdpartyemailpassword/auth0-database.png" />
 
 - Set your database connection name in your `Default Directory` field in your tennant settings.
 
-<img src="/img/thirdpartyemailpassword/default-directory-settings.png" />
+<img alt="Updating default directory in Auth0 tenant settings" src="/img/thirdpartyemailpassword/default-directory-settings.png" />
 
 #### Implementation
 

--- a/v2/passwordless/migration/from-auth0/account-migration/modifications-to-login.mdx
+++ b/v2/passwordless/migration/from-auth0/account-migration/modifications-to-login.mdx
@@ -21,7 +21,7 @@ The following code is implemented for Nodejs, but, you can apply the same logic 
 If you have not stored your user's Auth0 userId in your database you can **ignore** the steps mentioned in **Box 6** and **Box 8** of the flow diagram.
 :::
 
-<img src="/img/passwordless/diagrams/passwordless-migration-flow.png" />
+<img alt="Flow of login to migrate users with passwordless accounts in Auth0 to SuperTokens" src="/img/passwordless/diagrams/passwordless-migration-flow.png" />
 
 ## Implementation
 

--- a/v2/thirdparty/migration/from-auth0/account-migration/modifications-to-login.mdx
+++ b/v2/thirdparty/migration/from-auth0/account-migration/modifications-to-login.mdx
@@ -22,7 +22,7 @@ If you have not stored your user's Auth0 userId in your database you can **ignor
 :::
 
 
-<img src="/img/thirdpartyemailpassword/tp-account-migration.png" />
+<img alt="Flow of login to migrate users with thirdparty and email-password accounts in Auth0 to SuperTokens" src="/img/thirdpartyemailpassword/tp-account-migration.png" />
 
 ## Implementation
 

--- a/v2/thirdpartyemailpassword/migration/from-auth0/account-migration/modifications-to-login.mdx
+++ b/v2/thirdpartyemailpassword/migration/from-auth0/account-migration/modifications-to-login.mdx
@@ -34,7 +34,7 @@ The following code is implemented for Nodejs, but, you can apply the same logic 
 If you have not stored your user's Auth0 userId in your database you can **ignore** the steps mentioned in **Box 5** and **Box 8** of the flow diagram.
 :::
 
-<img src="/img/thirdpartyemailpassword/ep-account-migration.png" />
+<img alt="Flow of login to migrate email-password accounts in Auth0 to SuperTokens" src="/img/thirdpartyemailpassword/ep-account-migration.png" />
 
 ### Implementation
 
@@ -159,11 +159,11 @@ We will be using Auth0's APIs to validate user credentials. Please refer to Auth
 For example:
 - The default connection name for the database is `Username-Password-Authentication`, you can find your database connections under Authentication -> Database on your Auth0 dashboard.
 
-<img src="/img/thirdpartyemailpassword/auth0-database.png" />
+<img alt="Database connections in Auth0" src="/img/thirdpartyemailpassword/auth0-database.png" />
 
 - Set your database connection name in your `Default Directory` field in your tennant settings.
 
-<img src="/img/thirdpartyemailpassword/default-directory-settings.png" />
+<img alt="Updating default directory in Auth0 tenant settings" src="/img/thirdpartyemailpassword/default-directory-settings.png" />
 
 ##### Implementation
 
@@ -349,7 +349,7 @@ If you have not stored your user's Auth0 userId in your database you can **ignor
 :::
 
 
-<img src="/img/thirdpartyemailpassword/tp-account-migration.png" />
+<img alt="Flow of login to migrate thirdparty accounts in Auth0 to SuperTokens" src="/img/thirdpartyemailpassword/tp-account-migration.png" />
 
 ### Implementation
 

--- a/v2/thirdpartypasswordless/migration/from-auth0/account-migration/modifications-to-login.mdx
+++ b/v2/thirdpartypasswordless/migration/from-auth0/account-migration/modifications-to-login.mdx
@@ -33,7 +33,7 @@ The following code is implemented for Nodejs, but, you can apply the same logic 
 If you have not stored your user's Auth0 userId in your database you can **ignore** the steps mentioned in **Box 6** and **Box 8** of the flow diagram.
 :::
 
-<img src="/img/passwordless/diagrams/passwordless-migration-flow.png" />
+<img alt="Flow of login to migrate passwordless accounts in Auth0 to SuperTokens" src="/img/passwordless/diagrams/passwordless-migration-flow.png" />
 
 ## Implementation
 
@@ -333,7 +333,7 @@ If you have not stored your user's Auth0 userId in your database you can **ignor
 :::
 
 
-<img src="/img/thirdpartyemailpassword/tp-account-migration.png" />
+<img alt="Flow of login to migrate email-password accounts in Auth0 to SuperTokens" src="/img/thirdpartyemailpassword/tp-account-migration.png" />
 
 ### Implementation
 


### PR DESCRIPTION
## Summary of change
Added alt text to account migration images on following pages
- https://test.supertokens.com/docs/emailpassword/migration/from-auth0/account-migration/modifications-to-login
- https://test.supertokens.com/docs/passwordless/migration/from-auth0/account-migration/modifications-to-login
- https://test.supertokens.com/thirdparty/migration/from-auth0/account-migration/modifications-to-login
- https://test.supertokens.com/docs/thirdpartyemailpassword/migration/from-auth0/account-migration/modifications-to-login ( `Email Password Account Migration` and `Social Account Migration` tabs )
- https://test.supertokens.com/docs/thirdpartypasswordless/migration/from-auth0/account-migration/modifications-to-login ( `Passwordless Account Migration` and `Social Account Migration` tabs )

Added alt text to Auth0 Database images on following pages
- https://test.supertokens.com/docs/emailpassword/migration/from-auth0/account-migration/modifications-to-login
- https://test.supertokens.com/docs/thirdpartyemailpassword/migration/from-auth0/account-migration/modifications-to-login

## Related issues
- #305 

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
No TODOs remaining