### PR TITLE
Created plugin to add `rel="nofollow"` to external links in docs

### DIFF
--- a/v2/docusaurus.config.js
+++ b/v2/docusaurus.config.js
@@ -5,8 +5,12 @@
  * Remark plugins intercept markdown content before they are parsed into HTML
  * Read more here: https://github.com/remarkjs/remark/blob/main/doc/plugins.md
  */
-let remarkPlugins = [
-  require("./src/plugins/markdownVariables"),
+ let remarkPlugins = [
+  require("./src/plugins/markdownVariables")
+];
+
+let rehypePlugins = [
+  require('./src/plugins/addNofollowToExternalLinks')
 ];
 
 module.exports = {
@@ -120,6 +124,7 @@ module.exports = {
           showLastUpdateTime: true,
           editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
           remarkPlugins: remarkPlugins,
+          rehypePlugins: rehypePlugins
         },
         theme: {
           // this is applied to all docs.. not just the community one.
@@ -154,6 +159,7 @@ module.exports = {
         showLastUpdateTime: true,
         editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
         remarkPlugins: remarkPlugins,
+        rehypePlugins: rehypePlugins
       },
     ],
     [
@@ -166,6 +172,7 @@ module.exports = {
         showLastUpdateTime: true,
         editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
         remarkPlugins: remarkPlugins,
+        rehypePlugins: rehypePlugins
       },
     ],
     [
@@ -176,6 +183,7 @@ module.exports = {
         routeBasePath: 'docs/guides',
         editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
         remarkPlugins: remarkPlugins,
+        rehypePlugins: rehypePlugins
       },
     ],
     [
@@ -188,6 +196,7 @@ module.exports = {
         showLastUpdateTime: true,
         editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
         remarkPlugins: remarkPlugins,
+        rehypePlugins: rehypePlugins
       },
     ],
     [
@@ -200,6 +209,7 @@ module.exports = {
         showLastUpdateTime: true,
         editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
         remarkPlugins: remarkPlugins,
+        rehypePlugins: rehypePlugins
       },
     ],
     [
@@ -212,6 +222,7 @@ module.exports = {
         showLastUpdateTime: true,
         editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
         remarkPlugins: remarkPlugins,
+        rehypePlugins: rehypePlugins
       },
     ],
     [
@@ -224,6 +235,7 @@ module.exports = {
         showLastUpdateTime: true,
         editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
         remarkPlugins: remarkPlugins,
+        rehypePlugins: rehypePlugins
       },
     ],
     [
@@ -236,6 +248,7 @@ module.exports = {
         showLastUpdateTime: true,
         editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
         remarkPlugins: remarkPlugins,
+        rehypePlugins: rehypePlugins
       },
     ],
     [
@@ -248,6 +261,7 @@ module.exports = {
         showLastUpdateTime: true,
         editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
         remarkPlugins: remarkPlugins,
+        rehypePlugins: rehypePlugins
       },
     ],
     [
@@ -260,6 +274,7 @@ module.exports = {
         showLastUpdateTime: true,
         editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
         remarkPlugins: remarkPlugins,
+        rehypePlugins: rehypePlugins
       },
     ],
     [
@@ -272,6 +287,7 @@ module.exports = {
         showLastUpdateTime: true,
         editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
         remarkPlugins: remarkPlugins,
+        rehypePlugins: rehypePlugins
       },
     ],
     [
@@ -284,6 +300,7 @@ module.exports = {
         showLastUpdateTime: true,
         editUrl: 'https://github.com/supertokens/docs/tree/master/v2/',
         remarkPlugins: remarkPlugins,
+        rehypePlugins: rehypePlugins
       },
     ]
   ],

--- a/v2/src/plugins/addNofollowToExternalLinks.js
+++ b/v2/src/plugins/addNofollowToExternalLinks.js
@@ -1,0 +1,84 @@
+const url = require("url");
+
+module.exports = () => {
+  /**
+   * Check if the URL is external or not
+   * @param {string} href the URL that is to be checked
+   * @returns boolean true if the URL is external and false otherwise
+   */
+  function isUrlExternal (href) {
+    try {
+      const hrefFromURL = new url.URL(href);
+      const host = hrefFromURL.host;
+      const protocol = hrefFromURL.protocol;
+
+      // no nofollow needed for email or phone number links
+      if (protocol === "mailto:" || protocol === "tel:") {
+        return false;
+      }
+
+      // if the host contains `supertokens.com`
+      if (host.includes("supertokens.com")) {
+        return false;
+      }
+
+      // if the host does not contain `supertokens.com`, it is an external URL
+      return true;
+    } catch {
+      // the URL constructor throws in case the URL is relative
+      // in that case it is not an external url
+      return false;
+    }
+  }
+
+  /**
+   * Check if the node element is a link and if it should have `nofollow`
+   * @param {Node} data element node from the document's tree
+   * @returns boolean true if `nofollow` should be added and false otherwise
+   */
+  function shouldAddNofollowToLink (data) {
+    return (
+      data !== undefined &&
+      data.type === "element" &&
+      data.tagName === "a" &&
+      data.properties !== undefined &&
+      isUrlExternal(data.properties.href)
+    )
+  }
+
+  /**
+   * Add `nofollow` to the element passed if it is an external link and recursively do the same to the element's children
+   * @param {Node} data element node from the document's tree
+   * @returns updated element with `nofollow` in external links
+   */
+  function addNofollowToExternalLinks(data) {
+    try {
+      if (shouldAddNofollowToLink(data)) {
+        data.properties = Object.assign({}, data.properties, {
+          rel: "nofollow noreferrer noopener"
+        });
+      }
+  
+      if (data.children) {
+        data.children = data.children.map((child) => {
+          return addNofollowToExternalLinks(child);
+        });
+      }
+  
+      return data;
+    } catch (error) {
+      console.log(error.message);
+    }
+  };
+
+  const transformer = (data, _) => {
+    if (data.children !== undefined && data.children.length > 0) {
+      data.children = data.children.map((child) => {
+        return addNofollowToExternalLinks(child);
+      });
+    }
+    return data;
+  }
+
+  return transformer;
+}


### PR DESCRIPTION
## Summary of change
- Created a rehype plugin that modifies the nodes of docs that are links.
- It checks if the link is an external link and adds `rel="nofollow noopener noreferrer"` ( I included `noopener noreferrer` because that was already being added before this plugin. )
- The reason why I added a rehype plugin instead of a remark plugin, is that after the remark plugins make changes to nodes, docusaurus was adding `_target="blank" rel="noopener noreferrer"` to the links and discarding the `nofollow` added by the remark plugin.

## Related issues
- #317 

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
- [x] Testing