### PR TITLE
Updated external links that were not getting fixed by the plugin

### DIFF
--- a/v2/emailpassword/common-customizations/styling/changing-style.mdx
+++ b/v2/emailpassword/common-customizations/styling/changing-style.mdx
@@ -27,7 +27,7 @@ First, let's open our website at `/auth`. The Sign-in widget should show up. Let
 
 Each stylable components contains `data-supertokens` attributes (in our example `data-supertokens="button"`). 
 
-Let's add a `button` attribute to our configuration file. The syntax for styling is the same as <a href="https://www.w3schools.com/react/react_css.asp" target="_blank" rel="noopener noreferrer">React inline styling</a>
+Let's add a `button` attribute to our configuration file. The syntax for styling is the same as [React inline styling](https://www.w3schools.com/react/react_css.asp).
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/passwordless/common-customizations/styling/changing-style.mdx
+++ b/v2/passwordless/common-customizations/styling/changing-style.mdx
@@ -26,7 +26,7 @@ First, let's open our website at `/auth`. The Sign-in widget should show up. Let
 
 Each stylable components contains `data-supertokens` attributes (in our example `data-supertokens="button"`). 
 
-Let's add a `button` attribute to our configuration file. The syntax for styling is the same as <a href="https://www.w3schools.com/react/react_css.asp" target="_blank" rel="noopener noreferrer">React inline styling</a>
+Let's add a `button` attribute to our configuration file. The syntax for styling is the same as [React inline styling](https://www.w3schools.com/react/react_css.asp).
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -422,7 +422,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                                     }}
                                 />
                                 <span>
-                                    I am using NextJS' <a target="_blank" href="https://nextjs.org/docs/api-routes/introduction">API route</a>
+                                    I am using NextJS' <a target="_blank" rel="nofollow noopener noreferrer" href="https://nextjs.org/docs/api-routes/introduction">API route</a>
                                 </span>
                             </label>
                         )}

--- a/v2/thirdparty/common-customizations/sign-in-and-up/custom-providers.mdx
+++ b/v2/thirdparty/common-customizations/sign-in-and-up/custom-providers.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 If SuperTokens doesn't support a provider out of the box, you can use custom providers to add a new third party provider to your application. 
 
 :::note
-If you think that this provider should be supported by SuperTokens by default, make sure to let us know <a href="https://github.com/supertokens/supertokens-node/issues/88">here</a>
+If you think that this provider should be supported by SuperTokens by default, make sure to let us know [here](https://github.com/supertokens/supertokens-node/issues/88).
 :::
 
 

--- a/v2/thirdparty/common-customizations/styling/changing-style.mdx
+++ b/v2/thirdparty/common-customizations/styling/changing-style.mdx
@@ -25,7 +25,7 @@ First, let's open our website at `/auth`. The Sign-in widget should show up. Let
 
 Each stylable components contains `data-supertokens` attributes (in our example `data-supertokens="headerTitle"`). 
 
-Let's add a `headerTitle` attribute to our configuration file. The syntax for styling is the same as <a href="https://www.w3schools.com/react/react_css.asp" target="_blank" rel="noopener noreferrer">React inline styling</a>
+Let's add a `headerTitle` attribute to our configuration file. The syntax for styling is the same as [React inline styling](https://www.w3schools.com/react/react_css.asp).
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/thirdpartyemailpassword/common-customizations/signup-form/custom-providers.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/signup-form/custom-providers.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 If SuperTokens doesn't support a provider out of the box, you can use custom providers to add a new third party provider to your application. 
 
 :::note
-If you think that this provider should be supported by SuperTokens by default, make sure to let us know <a href="https://github.com/supertokens/supertokens-node/issues/88">here</a>
+If you think that this provider should be supported by SuperTokens by default, make sure to let us know [here](https://github.com/supertokens/supertokens-node/issues/88).
 :::
 
 

--- a/v2/thirdpartyemailpassword/common-customizations/styling/changing-style.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/styling/changing-style.mdx
@@ -25,7 +25,7 @@ First, let's open our website at `/auth`. The Sign-in widget should show up. Let
 
 Each stylable components contains `data-supertokens` attributes (in our example `data-supertokens="button"`). 
 
-Let's add a `button` attribute to our configuration file. The syntax for styling is the same as <a href="https://www.w3schools.com/react/react_css.asp" target="_blank" rel="noopener noreferrer">React inline styling</a>
+Let's add a `button` attribute to our configuration file. The syntax for styling is the same as [React inline styling](https://www.w3schools.com/react/react_css.asp).
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/thirdpartypasswordless/common-customizations/signup-form/custom-providers.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/signup-form/custom-providers.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 If SuperTokens doesn't support a provider out of the box, you can use custom providers to add a new third party provider to your application. 
 
 :::note
-If you think that this provider should be supported by SuperTokens by default, make sure to let us know <a href="https://github.com/supertokens/supertokens-node/issues/88">here</a>
+If you think that this provider should be supported by SuperTokens by default, make sure to let us know [here](https://github.com/supertokens/supertokens-node/issues/88).
 :::
 
 

--- a/v2/thirdpartypasswordless/common-customizations/styling/changing-style.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/styling/changing-style.mdx
@@ -25,7 +25,7 @@ First, let's open our website at `/auth`. The Sign-in widget should show up. Let
 
 Each stylable components contains `data-supertokens` attributes (in our example `data-supertokens="button"`). 
 
-Let's add a `button` attribute to our configuration file. The syntax for styling is the same as <a href="https://www.w3schools.com/react/react_css.asp" target="_blank" rel="noopener noreferrer">React inline styling</a>
+Let's add a `button` attribute to our configuration file. The syntax for styling is the same as [React inline styling](https://www.w3schools.com/react/react_css.asp).
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">


### PR DESCRIPTION
## Summary of change
- The rehype plugin added in the PR #319 adds `rel="nofollow noopener noreferrer"` to external links written in markdown syntax. This PR updates the links in docs that are not written using the markdown syntax to use the markdown syntax so that the attributes are added to them.
- We also add `rel="nofollow noopener noreferrer` to the NextJS API routes link in the `AppInfoForm`.

## Related issues
- #317 

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
- [x] Testing