### PR TITLE
Fix testing spelling

### DIFF
--- a/v2/thirdparty/nestjs/guide.mdx
+++ b/v2/thirdparty/nestjs/guide.mdx
@@ -186,7 +186,7 @@ export class SupertokensService {
                 ThirdParty.init({
                     signInAndUpFeature: {
                         providers: [
-                            // We have provided you with development keys which you can use for testsing.
+                            // We have provided you with development keys which you can use for testing.
                             // IMPORTANT: Please replace them with your own OAuth keys for production use.
                             ThirdParty.Google({
                                 clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",

--- a/v2/thirdparty/nextjs/init.mdx
+++ b/v2/thirdparty/nextjs/init.mdx
@@ -110,7 +110,7 @@ export const backendConfig = (): TypeInput => {
       ThirdPartyNode.init({
         signInAndUpFeature: {
           providers: [
-            // We have provided you with development keys which you can use for testsing.
+            // We have provided you with development keys which you can use for testing.
             // IMPORTANT: Please replace them with your own OAuth keys for production use.
             ThirdPartyNode.Google({
               clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",

--- a/v2/thirdparty/quick-setup/backend.mdx
+++ b/v2/thirdparty/quick-setup/backend.mdx
@@ -407,7 +407,7 @@ SuperTokens.init({
             //highlight-start
             signInAndUpFeature: {
                 providers: [
-                    // We have provided you with development keys which you can use for testsing.
+                    // We have provided you with development keys which you can use for testing.
                     // IMPORTANT: Please replace them with your own OAuth keys for production use.
                     Google({
                         clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",
@@ -453,7 +453,7 @@ func main() {
 		// highlight-start
 		SignInAndUpFeature: tpmodels.TypeInputSignInAndUp{
 			Providers: []tpmodels.TypeProvider{
-				// We have provided you with development keys which you can use for testsing.
+				// We have provided you with development keys which you can use for testing.
 				// IMPORTANT: Please replace them with your own OAuth keys for production use.
 				thirdparty.Google(tpmodels.GoogleConfig{
 					ClientID:     "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",
@@ -492,7 +492,7 @@ from supertokens_python.recipe import thirdparty
 thirdparty.init(
     # highlight-start
     sign_in_and_up_feature=thirdparty.SignInAndUpFeature(providers=[
-        # We have provided you with development keys which you can use for testsing.
+        # We have provided you with development keys which you can use for testing.
         # IMPORTANT: Please replace them with your own OAuth keys for production use.
         Google(
             client_id='1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com',

--- a/v2/thirdparty/serverless/with-aws-lambda/backend-config.mdx
+++ b/v2/thirdparty/serverless/with-aws-lambda/backend-config.mdx
@@ -55,7 +55,7 @@ function getBackendConfig() {
       ThirdParty.init({
         signInAndUpFeature: {
           providers: [
-            // We have provided you with development keys which you can use for testsing.
+            // We have provided you with development keys which you can use for testing.
             // IMPORTANT: Please replace them with your own OAuth keys for production use.
             ThirdParty.Google({
               clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",

--- a/v2/thirdparty/serverless/with-netlify/backend-config.mdx
+++ b/v2/thirdparty/serverless/with-netlify/backend-config.mdx
@@ -56,7 +56,7 @@ function getBackendConfig() {
       ThirdParty.init({
         signInAndUpFeature: {
           providers: [
-            // We have provided you with development keys which you can use for testsing.
+            // We have provided you with development keys which you can use for testing.
             // IMPORTANT: Please replace them with your own OAuth keys for production use.
             ThirdParty.Google({
               clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",

--- a/v2/thirdpartyemailpassword/nestjs/guide.mdx
+++ b/v2/thirdpartyemailpassword/nestjs/guide.mdx
@@ -184,7 +184,7 @@ export class SupertokensService {
             recipeList: [
                 ThirdPartyEmailPassword.init({
                     providers: [
-                        // We have provided you with development keys which you can use for testsing.
+                        // We have provided you with development keys which you can use for testing.
                         // IMPORTANT: Please replace them with your own OAuth keys for production use.
                         ThirdPartyEmailPassword.Google({
                             clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",

--- a/v2/thirdpartyemailpassword/nextjs/init.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/init.mdx
@@ -106,7 +106,7 @@ export const backendConfig = (): TypeInput => {
     recipeList: [
       ThirdPartyEmailPasswordNode.init({
         providers: [
-          // We have provided you with development keys which you can use for testsing.
+          // We have provided you with development keys which you can use for testing.
           // IMPORTANT: Please replace them with your own OAuth keys for production use.
           ThirdPartyEmailPasswordNode.Google({
             clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",

--- a/v2/thirdpartyemailpassword/quick-setup/backend.mdx
+++ b/v2/thirdpartyemailpassword/quick-setup/backend.mdx
@@ -401,7 +401,7 @@ SuperTokens.init({
         ThirdPartyEmailPassword.init({
             //highlight-start
             providers: [
-                // We have provided you with development keys which you can use for testsing.
+                // We have provided you with development keys which you can use for testing.
                 // IMPORTANT: Please replace them with your own OAuth keys for production use.
                 Google({
                     clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",
@@ -449,7 +449,7 @@ func main() {
     thirdpartyemailpassword.Init(&tpepmodels.TypeInput{
         // highlight-start
         Providers: []tpmodels.TypeProvider{
-            // We have provided you with development keys which you can use for testsing.
+            // We have provided you with development keys which you can use for testing.
             // IMPORTANT: Please replace them with your own OAuth keys for production use.
             thirdparty.Google(tpmodels.GoogleConfig{
                 ClientID:     "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",
@@ -487,7 +487,7 @@ from supertokens_python.recipe import thirdpartyemailpassword
 thirdpartyemailpassword.init(
     # highlight-start
     providers=[
-        # We have provided you with development keys which you can use for testsing.
+        # We have provided you with development keys which you can use for testing.
         # IMPORTANT: Please replace them with your own OAuth keys for production use.
         Google(
             client_id='1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com',

--- a/v2/thirdpartyemailpassword/serverless/with-aws-lambda/backend-config.mdx
+++ b/v2/thirdpartyemailpassword/serverless/with-aws-lambda/backend-config.mdx
@@ -55,7 +55,7 @@ function getBackendConfig() {
     recipeList: [
       ThirdPartyEmailPassword.init({
         providers: [
-          // We have provided you with development keys which you can use for testsing.
+          // We have provided you with development keys which you can use for testing.
           // IMPORTANT: Please replace them with your own OAuth keys for production use.
           ThirdPartyEmailPassword.Google({
             clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",

--- a/v2/thirdpartyemailpassword/serverless/with-netlify/backend-config.mdx
+++ b/v2/thirdpartyemailpassword/serverless/with-netlify/backend-config.mdx
@@ -56,7 +56,7 @@ function getBackendConfig(): SuperTokensTypes.TypeInput {
     recipeList: [
       ThirdPartyEmailPassword.init({
         providers: [
-          // We have provided you with development keys which you can use for testsing.
+          // We have provided you with development keys which you can use for testing.
           // IMPORTANT: Please replace them with your own OAuth keys for production use.
           ThirdPartyEmailPassword.Google({
             clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",

--- a/v2/thirdpartypasswordless/quick-setup/backend.mdx
+++ b/v2/thirdpartypasswordless/quick-setup/backend.mdx
@@ -466,7 +466,7 @@ SuperTokens.init({
             ^{form_contactMethod_sendCB_Node}
             //highlight-start
             providers: [
-                // We have provided you with development keys which you can use for testsing.
+                // We have provided you with development keys which you can use for testing.
                 // IMPORTANT: Please replace them with your own OAuth keys for production use.
                 Google({
                     clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",
@@ -514,7 +514,7 @@ func main() {
     ^{codeImportRecipeName}.Init(^{goModelNameForInit}.TypeInput{
         // highlight-start
         Providers: []tpmodels.TypeProvider{
-            // We have provided you with development keys which you can use for testsing.
+            // We have provided you with development keys which you can use for testing.
             // IMPORTANT: Please replace them with your own OAuth keys for production use.
             thirdparty.Google(tpmodels.GoogleConfig{
                 ClientID:     "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",
@@ -553,7 +553,7 @@ from supertokens_python.recipe import ^{codeImportRecipeName}
     ^{pythonRecipeInitDefault} # typecheck-only, removed from output
     # highlight-start
     providers=[
-        # We have provided you with development keys which you can use for testsing.
+        # We have provided you with development keys which you can use for testing.
         # IMPORTANT: Please replace them with your own OAuth keys for production use.
         Google(
             client_id='1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com',

--- a/v2/thirdpartypasswordless/serverless/with-aws-lambda/backend-config.mdx
+++ b/v2/thirdpartypasswordless/serverless/with-aws-lambda/backend-config.mdx
@@ -56,7 +56,7 @@ function getBackendConfig() {
     recipeList: [
       ^{recipeNameCapitalLetters}.init({
         providers: [
-          // We have provided you with development keys which you can use for testsing.
+          // We have provided you with development keys which you can use for testing.
           // IMPORTANT: Please replace them with your own OAuth keys for production use.
           ^{recipeNameCapitalLetters}.Google({
             clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",

--- a/v2/thirdpartypasswordless/serverless/with-netlify/backend-config.mdx
+++ b/v2/thirdpartypasswordless/serverless/with-netlify/backend-config.mdx
@@ -58,7 +58,7 @@ function getBackendConfig() {
     recipeList: [
       ^{recipeNameCapitalLetters}.init({
         providers: [
-          // We have provided you with development keys which you can use for testsing.
+          // We have provided you with development keys which you can use for testing.
           // IMPORTANT: Please replace them with your own OAuth keys for production use.
           ^{recipeNameCapitalLetters}.Google({
             clientId: "1060725074195-kmeum4crr01uirfl2op9kd5acmi9jutn.apps.googleusercontent.com",


### PR DESCRIPTION
## Summary of change
I was reading your docs and saw a small spelling error for OAuth tokens that you so kindly provide. So I went ahead and fixed it with ripgrep and sed :smile: 

For full transparency I ran this:
`rg testsing --files-with-matches | xargs sed -i 's/testsing/testing/'`

Let me know if there is something that I missed or if I am not following the correct protocol :smile_cat: 

This is a great tool :star: !

## Related issues
None, a simple spell fix in multiple files

## Checklist
~~- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)~~
~~- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)~~
~~- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~~
~~- [ ] Changes required to the demo apps corresponding to the docs?~~
