### PR TITLE
Format name of signed in user displayed in the navbar button

### DIFF
--- a/v2/src/theme/NavbarItem/SignUpButton/index.tsx
+++ b/v2/src/theme/NavbarItem/SignUpButton/index.tsx
@@ -33,7 +33,37 @@ export default function SignUpButton() {
 async function fetchUserName(): Promise<string | undefined> {
     try {
         const { name } = await getUserInformation();
-        return name;
+        const formattedName = formatNameToDisplayInNavbar(name);
+        return formattedName;
     } catch (e) { }
     return undefined;
+}
+
+/**
+ * Use this method to format the full name of the user to display in the navbar
+ * @param fullName full name of the user fetched from the API
+ * @returns formatted name to display in the navbar
+ */
+ export function formatNameToDisplayInNavbar(fullName: string): string {
+    let userName = "";
+
+    if (fullName !== undefined) {
+        const [firstName, middleName, ..._] = fullName.split(" ");
+
+        if (firstName.length > 8) {
+            // if the first name is longer than 8 characters
+            // display the first 8 characters and append '...'
+            userName = `${firstName.substring(0, 8)}...`;
+        } else if (firstName.length <= 8 && middleName !== undefined) {
+            // if the first name is shorter than 9 characters
+            // and there is a string defined in `middleName`
+            // display the first name and initial from `middleName`
+            const initial = middleName[0].toUpperCase();
+            userName = `${firstName} ${initial}.`;
+        } else {
+            userName = firstName;
+        }
+    }
+
+    return userName;
 }

--- a/v2/src/theme/NavbarItem/SignUpButton/style.css
+++ b/v2/src/theme/NavbarItem/SignUpButton/style.css
@@ -22,6 +22,7 @@
   color: #ffffff;
   font-size: 16px;
   font-weight: 600;
+  cursor: pointer;
 }
 
 .signUpButton:hover {


### PR DESCRIPTION
## Summary of change
- Formats the full name of the signed in user received from the backend before displaying on the navbar yellow button
- Formatting rules as per - https://github.com/supertokens/main-website/issues/808
- This PR is related to https://github.com/supertokens/main-website/pull/805, but does not depend on it.
- The function used to format the user name is the same as in https://github.com/supertokens/main-website/pull/805
- Updated the cursor to be displayed as pointer when hovering over the button

## Screenshots

#### When the user has a long first name ( first name length > 8 )
<img width="1423" alt="docs_long_first_name" src="https://user-images.githubusercontent.com/92283713/169750113-bbe9f4bd-4ea9-43e0-9c63-028559125c8b.png">

#### When the user has a short first name ( first name length ≤ 8 )
<img width="1421" alt="docs_short_first_name" src="https://user-images.githubusercontent.com/92283713/169750133-27b29c60-e8b9-48b6-b522-4a8680269dc6.png">

#### When the user only has a first name
<img width="1423" alt="Screenshot 2022-05-23 at 11 05 28 AM" src="https://user-images.githubusercontent.com/92283713/169750314-cb1d386f-317e-4641-9dfa-cdbcef4c2e7c.png">

## Related issues
- https://github.com/supertokens/main-website/issues/808

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
No TODOs