### PR TITLE
Replaced dead link

### DIFF
--- a/v2/community/sdks.mdx
+++ b/v2/community/sdks.mdx
@@ -34,7 +34,7 @@ import GuidesLink from "/src/components/guidesLink"
 
 - ### ReactJS (All features supported)
 
-    See the [supertokens-auth-react reference documentation](https://supertokens.com/docs/auth-react) for more information.
+    See the [supertokens-auth-react reference documentation](https://www.npmjs.com/package/supertokens-web-js) for more information.
 
 - ### Vanilla JS (no login UI, contains helper functions)
 


### PR DESCRIPTION
Replaced the dead link on the docs website with a working link to NPM

## Summary of change
(A few sentences about this PR)

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [x] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [x] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [x] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [x] Item1
- [x] Item2