### PR TITLE
refactor: Update section on how to enable account linking to say its in progress

### DIFF
--- a/v2/thirdparty/common-customizations/account-linking.mdx
+++ b/v2/thirdparty/common-customizations/account-linking.mdx
@@ -25,9 +25,4 @@ Hence, by doing automatic account linking, we are increasing the attack surface 
 :::
 
 ## How to enable this feature?
-We do not have this feature inbuilt (yet), but you can implement this using our [function override](../advanced-customizations/backend-functions-override/about) feature.
-
-:::info
-- An example app that has this feature implemented can be found on [our github](https://github.com/supertokens/supertokens-auth-react/tree/master/examples/with-thirdpartyemailpassword-passwordless) (using NodeJS).
-- The example uses `thirdpartyemailpassword` and `passwordless` recipe.
-:::
+SuperTokens does not support Account Linking yet but we are actively working on this feature.

--- a/v2/thirdpartyemailpassword/common-customizations/account-linking.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/account-linking.mdx
@@ -25,9 +25,4 @@ Hence, by doing automatic account linking, we are increasing the attack surface 
 :::
 
 ## How to enable this feature?
-We do not have this feature inbuilt (yet), but you can implement this using our [function override](../advanced-customizations/backend-functions-override/about) feature.
-
-:::info
-- An example app that has this feature implemented can be found on [our github](https://github.com/supertokens/supertokens-auth-react/tree/master/examples/with-thirdpartyemailpassword-passwordless) (using NodeJS).
-- The example uses `thirdpartyemailpassword` and `passwordless` recipe.
-:::
+SuperTokens does not support Account Linking yet but we are actively working on this feature.

--- a/v2/thirdpartypasswordless/common-customizations/account-linking.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/account-linking.mdx
@@ -25,9 +25,4 @@ Hence, by doing automatic account linking, we are increasing the attack surface 
 :::
 
 ## How to enable this feature?
-We do not have this feature inbuilt (yet), but you can implement this using our [function override](../advanced-customizations/backend-functions-override/about) feature.
-
-:::info
-- An example app that has this feature implemented can be found on [our github](https://github.com/supertokens/supertokens-auth-react/tree/master/examples/with-thirdpartyemailpassword-passwordless) (using NodeJS).
-- The example uses `thirdpartyemailpassword` and `passwordless` recipe.
-:::
+SuperTokens does not support Account Linking yet but we are actively working on this feature.


### PR DESCRIPTION
## Summary of change

- Update `How to enable this feature?` section in `/common-customizations/account-linking` to explain that the feature is still a work in progress and SuperTokens does not support this yet

## Related issues
- ...

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] 