### PR TITLE
Fixes issue of v2 auth-react docs not having h1 title

### DIFF
--- a/v2/auth-react/emailpassword/config/email-verification.mdx
+++ b/v2/auth-react/emailpassword/config/email-verification.mdx
@@ -4,6 +4,8 @@ title: emailVerificationFeature
 hide_title: true
 ---
 
+# emailVerificationFeature
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react/emailpassword/config/reset-password.mdx
+++ b/v2/auth-react/emailpassword/config/reset-password.mdx
@@ -4,6 +4,8 @@ title: resetPasswordUsingTokenFeature
 hide_title: true
 ---
 
+# resetPasswordUsingTokenFeature
+
 ```tsx
 SuperTokens.init({
     appInfo: {

--- a/v2/auth-react/emailpassword/config/sign-in.mdx
+++ b/v2/auth-react/emailpassword/config/sign-in.mdx
@@ -4,6 +4,8 @@ title: signInAndUpFeature.signIn
 hide_title: true
 ---
 
+# signInAndUpFeature.signIn
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react/emailpassword/config/sign-up.mdx
+++ b/v2/auth-react/emailpassword/config/sign-up.mdx
@@ -4,6 +4,8 @@ title: signInAndUpFeature.signUp
 hide_title: true
 ---
 
+# signInAndUpFeature.signUp
+
 ```tsx
 SuperTokens.init({
     appInfo: {

--- a/v2/auth-react/emailpassword/email-password-auth.mdx
+++ b/v2/auth-react/emailpassword/email-password-auth.mdx
@@ -4,7 +4,7 @@ title: <EmailPasswordAuth />
 hide_title: true
 ---
 
-## `<EmailPasswordAuth />`
+# `<EmailPasswordAuth />`
 
 ### About
 

--- a/v2/auth-react/emailpassword/redirect-to-auth.mdx
+++ b/v2/auth-react/emailpassword/redirect-to-auth.mdx
@@ -7,7 +7,7 @@ hide_title: true
 <!-- COPY DOCS -->
 <!-- ./auth-react/emailpassword/redirect-to-auth.mdx -->
 
-## `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean})`
+# `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean})`
 
 The `redirectToAuth` method redirects the user to sign-in/sign-up page UI.
 

--- a/v2/auth-react/emailpassword/sign-out.mdx
+++ b/v2/auth-react/emailpassword/sign-out.mdx
@@ -4,7 +4,7 @@ title: signOut
 hide_title: true
 ---
 
-## `signOut()`
+# `signOut()`
 
 
 The `signOut` method simply revokes the session for the user on the frontend and backend.

--- a/v2/auth-react/session/session-auth.mdx
+++ b/v2/auth-react/session/session-auth.mdx
@@ -4,7 +4,7 @@ title: <SessionAuth />
 hide_title: true
 ---
 
-## `<SessionAuth />`
+# `<SessionAuth />`
 
 The `SessionAuth` component is used to wrap any component that requires the session context.
 It will update the context if any of these events happens:

--- a/v2/auth-react/session/sign-out.mdx
+++ b/v2/auth-react/session/sign-out.mdx
@@ -4,7 +4,7 @@ title: signOut
 hide_title: true
 ---
 
-## `signOut()`
+# `signOut()`
 
 
 The `signOut` method simply revokes the session for the user on the frontend and backend.

--- a/v2/auth-react/thirdparty/config/email-verification.mdx
+++ b/v2/auth-react/thirdparty/config/email-verification.mdx
@@ -4,6 +4,8 @@ title: Email Verification
 hide_title: true
 ---
 
+# Email Verification
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react/thirdparty/config/sign-in-and-up.mdx
+++ b/v2/auth-react/thirdparty/config/sign-in-and-up.mdx
@@ -4,6 +4,8 @@ title: signInAndUpFeature
 hide_title: true
 ---
 
+# signInAndUpFeature
+
 ```tsx
 import SuperTokens from "supertokens-auth-react";
 import ThirdParty, {Google, Facebook, Github} from "supertokens-auth-react/recipe/thirparty";

--- a/v2/auth-react/thirdparty/redirect-to-auth.mdx
+++ b/v2/auth-react/thirdparty/redirect-to-auth.mdx
@@ -7,7 +7,7 @@ hide_title: true
 <!-- COPY DOCS -->
 <!-- ./auth-react/emailpassword/redirect-to-auth.mdx -->
 
-## `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean})`
+# `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean})`
 
 The `redirectToAuth` method redirects the user to sign-in/sign-up page UI.
 

--- a/v2/auth-react/thirdparty/sign-out.mdx
+++ b/v2/auth-react/thirdparty/sign-out.mdx
@@ -4,7 +4,7 @@ title: signOut
 hide_title: true
 ---
 
-## `signOut()`
+# `signOut()`
 
 
 The `signOut` method simply revokes the session for the user on the frontend and backend.

--- a/v2/auth-react/thirdparty/third-party-auth.mdx
+++ b/v2/auth-react/thirdparty/third-party-auth.mdx
@@ -4,7 +4,7 @@ title: <ThirdPartyAuth />
 hide_title: true
 ---
 
-## `<ThirdPartyAuth />`
+# `<ThirdPartyAuth />`
 
 ### About
 

--- a/v2/auth-react/thirdpartyemailpassword/config/email-verification.mdx
+++ b/v2/auth-react/thirdpartyemailpassword/config/email-verification.mdx
@@ -4,6 +4,8 @@ title: emailVerificationFeature
 hide_title: true
 ---
 
+# emailVerificationFeature
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react/thirdpartyemailpassword/config/reset-password.mdx
+++ b/v2/auth-react/thirdpartyemailpassword/config/reset-password.mdx
@@ -4,6 +4,8 @@ title: resetPasswordUsingTokenFeature
 hide_title: true
 ---
 
+# resetPasswordUsingTokenFeature
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react/thirdpartyemailpassword/config/sign-in-and-up.mdx
+++ b/v2/auth-react/thirdpartyemailpassword/config/sign-in-and-up.mdx
@@ -4,6 +4,8 @@ title: signInAndUpFeature
 hide_title: true
 ---
 
+# signInAndUpFeature
+
 ```tsx
 import SuperTokens from "supertokens-auth-react";
 import ThirdPartyEmailPassword, {Google, Facebook, Github} from "supertokens-auth-react/recipe/thirpartyemailpassword";

--- a/v2/auth-react/thirdpartyemailpassword/config/sign-in.mdx
+++ b/v2/auth-react/thirdpartyemailpassword/config/sign-in.mdx
@@ -4,6 +4,8 @@ title: signInAndUpFeature.signIn
 hide_title: true
 ---
 
+# signInAndUpFeature.signIn
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react/thirdpartyemailpassword/config/sign-up.mdx
+++ b/v2/auth-react/thirdpartyemailpassword/config/sign-up.mdx
@@ -4,6 +4,8 @@ title: signInAndUpFeature.signUpForm
 hide_title: true
 ---
 
+# signInAndUpFeature.signUpForm
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react/thirdpartyemailpassword/redirect-to-auth.mdx
+++ b/v2/auth-react/thirdpartyemailpassword/redirect-to-auth.mdx
@@ -7,7 +7,7 @@ hide_title: true
 <!-- COPY DOCS -->
 <!-- ./auth-react/emailpassword/redirect-to-auth.mdx -->
 
-## `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean})`
+# `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean})`
 
 The `redirectToAuth` method redirects the user to sign-in/sign-up page UI.
 

--- a/v2/auth-react/thirdpartyemailpassword/sign-out.mdx
+++ b/v2/auth-react/thirdpartyemailpassword/sign-out.mdx
@@ -4,7 +4,7 @@ title: signOut
 hide_title: true
 ---
 
-## `signOut()`
+# `signOut()`
 
 
 The `signOut` method simply revokes the session for the user on the frontend and backend.

--- a/v2/auth-react/thirdpartyemailpassword/third-party-email-password-auth.mdx
+++ b/v2/auth-react/thirdpartyemailpassword/third-party-email-password-auth.mdx
@@ -4,7 +4,7 @@ title: <ThirdPartyEmailPasswordAuth />
 hide_title: true
 ---
 
-## `<ThirdPartyEmailPasswordAuth />`
+# `<ThirdPartyEmailPasswordAuth />`
 
 ### About
 

--- a/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/config/email-verification.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/config/email-verification.mdx
@@ -4,6 +4,8 @@ title: emailVerificationFeature
 hide_title: true
 ---
 
+# emailVerificationFeature
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/config/reset-password.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/config/reset-password.mdx
@@ -4,6 +4,8 @@ title: resetPasswordUsingTokenFeature
 hide_title: true
 ---
 
+# resetPasswordUsingTokenFeature
+
 ```tsx
 SuperTokens.init({
     appInfo: {

--- a/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/config/sign-in.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/config/sign-in.mdx
@@ -4,6 +4,8 @@ title: signInAndUpFeature.signIn
 hide_title: true
 ---
 
+# signInAndUpFeature.signIn
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/config/sign-up.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/config/sign-up.mdx
@@ -4,6 +4,8 @@ title: signInAndUpFeature.signUp
 hide_title: true
 ---
 
+# signInAndUpFeature.signUp
+
 ```tsx
 SuperTokens.init({
     appInfo: {

--- a/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/email-password-auth.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/email-password-auth.mdx
@@ -4,7 +4,7 @@ title: <EmailPasswordAuth />
 hide_title: true
 ---
 
-## `<EmailPasswordAuth />`
+# `<EmailPasswordAuth />`
 
 ### About
 

--- a/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/redirect-to-auth.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/redirect-to-auth.mdx
@@ -7,7 +7,7 @@ hide_title: true
 <!-- COPY DOCS -->
 <!-- ./auth-react/emailpassword/redirect-to-auth.mdx -->
 
-## `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean})`
+# `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean})`
 
 The `redirectToAuth` method redirects the user to sign-in/sign-up page UI.
 

--- a/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/sign-out.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/emailpassword/sign-out.mdx
@@ -4,7 +4,7 @@ title: signOut
 hide_title: true
 ---
 
-## `signOut()`
+# `signOut()`
 
 
 The `signOut` method simply revokes the session for the user on the frontend and backend.

--- a/v2/auth-react_versioned_docs/version-0.15.X/session/session-auth.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/session/session-auth.mdx
@@ -4,7 +4,7 @@ title: <SessionAuth />
 hide_title: true
 ---
 
-## `<SessionAuth />`
+# `<SessionAuth />`
 
 The `SessionAuth` component is used to wrap any component that requires the session context.
 It will update the context if any of these events happens:

--- a/v2/auth-react_versioned_docs/version-0.15.X/session/sign-out.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/session/sign-out.mdx
@@ -4,7 +4,7 @@ title: signOut
 hide_title: true
 ---
 
-## `signOut()`
+# `signOut()`
 
 
 The `signOut` method simply revokes the session for the user on the frontend and backend.

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdparty/config/email-verification.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdparty/config/email-verification.mdx
@@ -4,6 +4,8 @@ title: Email Verification
 hide_title: true
 ---
 
+# Email Verification
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdparty/config/sign-in-and-up.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdparty/config/sign-in-and-up.mdx
@@ -4,6 +4,8 @@ title: signInAndUpFeature
 hide_title: true
 ---
 
+# signInAndUpFeature
+
 ```tsx
 import SuperTokens from "supertokens-auth-react";
 import ThirdParty, {Google, Facebook, Github} from "supertokens-auth-react/recipe/thirparty";

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdparty/redirect-to-auth.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdparty/redirect-to-auth.mdx
@@ -7,7 +7,7 @@ hide_title: true
 <!-- COPY DOCS -->
 <!-- ./auth-react/emailpassword/redirect-to-auth.mdx -->
 
-## `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean})`
+# `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean})`
 
 The `redirectToAuth` method redirects the user to sign-in/sign-up page UI.
 

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdparty/sign-out.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdparty/sign-out.mdx
@@ -4,7 +4,7 @@ title: signOut
 hide_title: true
 ---
 
-## `signOut()`
+# `signOut()`
 
 
 The `signOut` method simply revokes the session for the user on the frontend and backend.

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdparty/third-party-auth.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdparty/third-party-auth.mdx
@@ -4,7 +4,7 @@ title: <ThirdPartyAuth />
 hide_title: true
 ---
 
-## `<ThirdPartyAuth />`
+# `<ThirdPartyAuth />`
 
 ### About
 

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/config/email-verification.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/config/email-verification.mdx
@@ -4,6 +4,8 @@ title: emailVerificationFeature
 hide_title: true
 ---
 
+# emailVerificationFeature
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/config/reset-password.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/config/reset-password.mdx
@@ -4,6 +4,8 @@ title: resetPasswordUsingTokenFeature
 hide_title: true
 ---
 
+# resetPasswordUsingTokenFeature
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/config/sign-in-and-up.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/config/sign-in-and-up.mdx
@@ -4,6 +4,8 @@ title: signInAndUpFeature
 hide_title: true
 ---
 
+# signInAndUpFeature
+
 ```tsx
 import SuperTokens from "supertokens-auth-react";
 import ThirdPartyEmailPassword, {Google, Facebook, Github} from "supertokens-auth-react/recipe/thirpartyemailpassword";

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/config/sign-in.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/config/sign-in.mdx
@@ -4,6 +4,8 @@ title: signInAndUpFeature.signIn
 hide_title: true
 ---
 
+# signInAndUpFeature.signIn
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/config/sign-up.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/config/sign-up.mdx
@@ -4,6 +4,8 @@ title: signInAndUpFeature.signUpForm
 hide_title: true
 ---
 
+# signInAndUpFeature.signUpForm
+
 ```tsx
 SuperTokens.init({
     recipeList: [

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/redirect-to-auth.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/redirect-to-auth.mdx
@@ -7,7 +7,7 @@ hide_title: true
 <!-- COPY DOCS -->
 <!-- ./auth-react/emailpassword/redirect-to-auth.mdx -->
 
-## `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean})`
+# `redirectToAuth({show?: "signin" | "signup", redirectBack?: boolean})`
 
 The `redirectToAuth` method redirects the user to sign-in/sign-up page UI.
 

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/sign-out.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/sign-out.mdx
@@ -4,7 +4,7 @@ title: signOut
 hide_title: true
 ---
 
-## `signOut()`
+# `signOut()`
 
 
 The `signOut` method simply revokes the session for the user on the frontend and backend.

--- a/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/third-party-email-password-auth.mdx
+++ b/v2/auth-react_versioned_docs/version-0.15.X/thirdpartyemailpassword/third-party-email-password-auth.mdx
@@ -4,7 +4,7 @@ title: <ThirdPartyEmailPasswordAuth />
 hide_title: true
 ---
 
-## `<ThirdPartyEmailPasswordAuth />`
+# `<ThirdPartyEmailPasswordAuth />`
 
 ### About
 


### PR DESCRIPTION
## Summary of change
Some docs for auth-react SDK in v2 docs do not have a `h1` title, in this PR we add the title to those pages.

## Related issues
- https://github.com/supertokens/for-zenhub/issues/130

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
No TODOs remaining