### PR TITLE
Fix issue of no h1 tags in emailpassword, thirdpartyemailpassword, thirdparty

### DIFF
--- a/v2/emailpassword/common-customizations/signin-form/field-validators.mdx
+++ b/v2/emailpassword/common-customizations/signin-form/field-validators.mdx
@@ -4,7 +4,7 @@ title: Adding / Modifying field validators
 hide_title: true
 ---
 
-## Adding / Modifying field validators 
+# Adding / Modifying field validators 
 
 Modifying the email validation function in the sign up form automatically applies the modification to the sign in form. Please refer to the [Sign Up Form > Adding / Modifying field validators](../signup-form/field-validators#changing-the-email-and-password-validators) section.
 

--- a/v2/thirdparty/advanced-customizations/apis-override/usage.mdx
+++ b/v2/thirdparty/advanced-customizations/apis-override/usage.mdx
@@ -7,6 +7,8 @@ hide_title: true
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import TabItem from '@theme/TabItem';
 
+# How to use
+
 ## Method 1: Pre / Post API logic change:
 
 If you would like to change something pre or post our API logic, then use this method.

--- a/v2/thirdpartyemailpassword/common-customizations/signin-form/field-validators.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/signin-form/field-validators.mdx
@@ -4,7 +4,7 @@ title: Adding / Modifying field validators
 hide_title: true
 ---
 
-## Adding / Modifying field validators
+# Adding / Modifying field validators
 
 Modifying the email validation function in the sign up form automatically applies the modification to the sign in form. Please refer to the [Sign Up Form > Adding / Modifying field validators](../signup-form/field-validators#changing-the-email-and-password-validators) section.
 


### PR DESCRIPTION
## Summary of change
- Fixes the issue of pages not having h1 tags in `emailpassword`, `thirdpartyemailpassword` and `thirdparty` recipes

## Related issues
- https://github.com/supertokens/for-zenhub/issues/131

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
No todos remaining