### PR TITLE
fix replace sessionScope by cookieDomain

### DIFF
--- a/auth-react/website/versioned_docs/version-0.13.X/session/init.md
+++ b/auth-react/website/versioned_docs/version-0.13.X/session/init.md
@@ -61,7 +61,7 @@ SuperTokens.init({
 
 ## Config values
 
-- ```sessionScope``` (Optional)
+- ```cookieDomain``` (Optional)
     - Type: ```string```
     - Default: Same as the domain in the currently loaded URL.
     - Set this to your website domain across which you want to share a session. For example, if your website domain (that is loaded by the user) is ```example.com```, then the value of this should be ```example.com```. If your site has subdomains that need to keep the same session, like ```a.example.com``` and ```b.example.com```, then the value of this should be ```example.com```.

--- a/auth-react/website/versioned_docs/version-0.8.X/session/init.md
+++ b/auth-react/website/versioned_docs/version-0.8.X/session/init.md
@@ -61,7 +61,7 @@ SuperTokens.init({
 
 ## Config values
 
-- ```sessionScope``` (Optional)
+- ```cookieDomain``` (Optional)
     - Type: ```string```
     - Default: Same as the domain in the currently loaded URL.
     - Set this to your website domain across which you want to share a session. For example, if your website domain (that is loaded by the user) is ```example.com```, then the value of this should be ```example.com```. If your site has subdomains that need to keep the same session, like ```a.example.com``` and ```b.example.com```, then the value of this should be ```example.com```.

--- a/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -13,7 +13,7 @@ import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
 
 # Share sessions across sub domains
 
-Sharing sessions across multiple sub domains in SuperTokens can be configured by setting the `sessionScope` attribute of the Session recipe in your frontend code.
+Sharing sessions across multiple sub domains in SuperTokens can be configured by setting the `cookieDomain` attribute of the Session recipe in your frontend code.
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
@@ -38,7 +38,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionScope: ".example.com"
+            cookieDomain: ".example.com"
         })
     ]
 });
@@ -58,7 +58,7 @@ SuperTokens.init({
     apiDomain: "...",
     // ...
     // highlight-start
-    sessionScope: ".example.com"
+    cookieDomain: ".example.com"
     // highlight-end 
 })
 ```
@@ -72,7 +72,7 @@ supertokens.init({
     // ...
     apiDomain: "...",
     // highlight-start
-    sessionScope: ".example.com"
+    cookieDomain: ".example.com"
     // highlight-end 
 })
 ```
@@ -84,5 +84,5 @@ supertokens.init({
 </FrontendSDKTabs>
 
 :::caution
-Do not set `sessionScope` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+Do not set `cookieDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
 :::

--- a/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -13,7 +13,7 @@ import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
 
 # Share sessions across sub domains
 
-Sharing sessions across multiple sub domains in SuperTokens can be configured by setting the `sessionScope` attribute of the Session recipe in your frontend code.
+Sharing sessions across multiple sub domains in SuperTokens can be configured by setting the `cookieDomain` attribute of the Session recipe in your frontend code.
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
@@ -38,7 +38,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionScope: ".example.com"
+            cookieDomain: ".example.com"
         })
     ]
 });
@@ -58,7 +58,7 @@ SuperTokens.init({
     apiDomain: "...",
     // ...
     // highlight-start
-    sessionScope: ".example.com"
+    cookieDomain: ".example.com"
     // highlight-end 
 })
 ```
@@ -72,7 +72,7 @@ supertokens.init({
     // ...
     apiDomain: "...",
     // highlight-start
-    sessionScope: ".example.com"
+    cookieDomain: ".example.com"
     // highlight-end 
 })
 ```
@@ -84,5 +84,5 @@ supertokens.init({
 </FrontendSDKTabs>
 
 :::caution
-Do not set `sessionScope` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+Do not set `cookieDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
 :::

--- a/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -13,7 +13,7 @@ import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
 
 # Share sessions across sub domains
 
-Sharing sessions across multiple sub domains in SuperTokens can be configured by setting the `sessionScope` attribute of the Session recipe in your frontend code.
+Sharing sessions across multiple sub domains in SuperTokens can be configured by setting the `cookieDomain` attribute of the Session recipe in your frontend code.
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
@@ -38,7 +38,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionScope: ".example.com"
+            cookieDomain: ".example.com"
         })
     ]
 });
@@ -58,7 +58,7 @@ SuperTokens.init({
     apiDomain: "...",
     // ...
     // highlight-start
-    sessionScope: ".example.com"
+    cookieDomain: ".example.com"
     // highlight-end 
 })
 ```
@@ -72,7 +72,7 @@ supertokens.init({
     // ...
     apiDomain: "...",
     // highlight-start
-    sessionScope: ".example.com"
+    cookieDomain: ".example.com"
     // highlight-end 
 })
 ```
@@ -84,5 +84,5 @@ supertokens.init({
 </FrontendSDKTabs>
 
 :::caution
-Do not set `sessionScope` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+Do not set `cookieDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
 :::

--- a/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -13,7 +13,7 @@ import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
 
 # Share sessions across sub domains
 
-Sharing sessions across multiple sub domains in SuperTokens can be configured by setting the `sessionScope` attribute of the Session recipe in your frontend code.
+Sharing sessions across multiple sub domains in SuperTokens can be configured by setting the `cookieDomain` attribute of the Session recipe in your frontend code.
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
@@ -38,7 +38,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionScope: ".example.com"
+            cookieDomain: ".example.com"
         })
     ]
 });
@@ -58,7 +58,7 @@ SuperTokens.init({
     apiDomain: "...",
     // ...
     // highlight-start
-    sessionScope: ".example.com"
+    cookieDomain: ".example.com"
     // highlight-end 
 })
 ```
@@ -72,7 +72,7 @@ supertokens.init({
     // ...
     apiDomain: "...",
     // highlight-start
-    sessionScope: ".example.com"
+    cookieDomain: ".example.com"
     // highlight-end 
 })
 ```
@@ -84,5 +84,5 @@ supertokens.init({
 </FrontendSDKTabs>
 
 :::caution
-Do not set `sessionScope` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+Do not set `cookieDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
 :::

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -13,7 +13,7 @@ import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
 
 # Share sessions across sub domains
 
-Sharing sessions across multiple sub domains in SuperTokens can be configured by setting the `sessionScope` attribute of the Session recipe in your frontend code.
+Sharing sessions across multiple sub domains in SuperTokens can be configured by setting the `cookieDomain` attribute of the Session recipe in your frontend code.
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
@@ -38,7 +38,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionScope: ".example.com"
+            cookieDomain: ".example.com"
         })
     ]
 });
@@ -58,7 +58,7 @@ SuperTokens.init({
     apiDomain: "...",
     // ...
     // highlight-start
-    sessionScope: ".example.com"
+    cookieDomain: ".example.com"
     // highlight-end 
 })
 ```
@@ -72,7 +72,7 @@ supertokens.init({
     // ...
     apiDomain: "...",
     // highlight-start
-    sessionScope: ".example.com"
+    cookieDomain: ".example.com"
     // highlight-end 
 })
 ```
@@ -84,5 +84,5 @@ supertokens.init({
 </FrontendSDKTabs>
 
 :::caution
-Do not set `sessionScope` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+Do not set `cookieDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
 :::

--- a/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -13,7 +13,7 @@ import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
 
 # Share sessions across sub domains
 
-Sharing sessions across multiple sub domains in SuperTokens can be configured by setting the `sessionScope` attribute of the Session recipe in your frontend code.
+Sharing sessions across multiple sub domains in SuperTokens can be configured by setting the `cookieDomain` attribute of the Session recipe in your frontend code.
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
@@ -38,7 +38,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionScope: ".example.com"
+            cookieDomain: ".example.com"
         })
     ]
 });
@@ -58,7 +58,7 @@ SuperTokens.init({
     apiDomain: "...",
     // ...
     // highlight-start
-    sessionScope: ".example.com"
+    cookieDomain: ".example.com"
     // highlight-end 
 })
 ```
@@ -72,7 +72,7 @@ supertokens.init({
     // ...
     apiDomain: "...",
     // highlight-start
-    sessionScope: ".example.com"
+    cookieDomain: ".example.com"
     // highlight-end 
 })
 ```
@@ -84,5 +84,5 @@ supertokens.init({
 </FrontendSDKTabs>
 
 :::caution
-Do not set `sessionScope` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+Do not set `cookieDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
 :::

--- a/v2/website/api-reference.mdx
+++ b/v2/website/api-reference.mdx
@@ -8,7 +8,7 @@ hide_title: true
 
 <div class="divider"></div>
 
-## `init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, sessionScope?, autoAddCredentials?, isInIframe?, cookieDomain?, override?, onHandleEvent?, preAPIHook?})`
+## `init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, cookieDomain?, autoAddCredentials?, isInIframe?, cookieDomain?, override?, onHandleEvent?, preAPIHook?})`
 ### Parameters
 #### `apiDomain`
 - Type: `string`
@@ -24,7 +24,7 @@ hide_title: true
 - Default: `401`
 - HTTP status code that indicates session expiry - as sent by your APIs.
 
-#### `sessionScope` (Optional)
+#### `cookieDomain` (Optional)
 - Type: `string`
 - Default: `undefined`.
 - Set this if you want to share a session across sub domains. For example, if users login via `example.com` and are redirected to a subdomain like `xyz.example.com`, then the value of this should be `".example.com"`.

--- a/v2/website_versioned_docs/version-8.1.X/api-reference.mdx
+++ b/v2/website_versioned_docs/version-8.1.X/api-reference.mdx
@@ -8,7 +8,7 @@ hide_title: true
 
 <div class="divider"></div>
 
-## `init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, sessionScope?, autoAddCredentials?, isInIframe?, cookieDomain?, override?, onHandleEvent?, preAPIHook?})`
+## `init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, cookieDomain?, autoAddCredentials?, isInIframe?, cookieDomain?, override?, onHandleEvent?, preAPIHook?})`
 ### Parameters
 #### `apiDomain`
 - Type: `string`
@@ -24,7 +24,7 @@ hide_title: true
 - Default: `401`
 - HTTP status code that indicates session expiry - as sent by your APIs.
 
-#### `sessionScope` (Optional)
+#### `cookieDomain` (Optional)
 - Type: `string`
 - Default: `undefined`.
 - Set this if you want to share a session across sub domains. For example, if users login via `example.com` and are redirected to a subdomain like `xyz.example.com`, then the value of this should be `".example.com"`.

--- a/v2/website_versioned_docs/version-8.2.X/api-reference.mdx
+++ b/v2/website_versioned_docs/version-8.2.X/api-reference.mdx
@@ -8,7 +8,7 @@ hide_title: true
 
 <div class="divider"></div>
 
-## `init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, sessionScope?, autoAddCredentials?, isInIframe?, cookieDomain?, override?, onHandleEvent?, preAPIHook?})`
+## `init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, cookieDomain?, autoAddCredentials?, isInIframe?, cookieDomain?, override?, onHandleEvent?, preAPIHook?})`
 ### Parameters
 #### `apiDomain`
 - Type: `string`
@@ -24,7 +24,7 @@ hide_title: true
 - Default: `401`
 - HTTP status code that indicates session expiry - as sent by your APIs.
 
-#### `sessionScope` (Optional)
+#### `cookieDomain` (Optional)
 - Type: `string`
 - Default: `undefined`.
 - Set this if you want to share a session across sub domains. For example, if users login via `example.com` and are redirected to a subdomain like `xyz.example.com`, then the value of this should be `".example.com"`.

--- a/website/docs/api-reference.md
+++ b/website/docs/api-reference.md
@@ -8,7 +8,7 @@ hide_title: true
 
 <div class="divider"></div>
 
-## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, sessionScope?, autoAddCredentials?, isInIframe?, cookieDomain?, override?, onHandleEvent?, preAPIHook?})```
+## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, cookieDomain?, autoAddCredentials?, isInIframe?, cookieDomain?, override?, onHandleEvent?, preAPIHook?})```
 #### Parameters
 - ```apiDomain```
     - Type: ```string```
@@ -20,7 +20,7 @@ hide_title: true
     - Type: ```number```
     - Default: ```401```
     - HTTP status code that indicates session expiry - as sent by your APIs.
-- ```sessionScope``` (Optional)
+- ```cookieDomain``` (Optional)
     - Type: ```string```
     - Default: `undefined`.
     - Set this if you want to share a session across sub domains. For example, if users login via `example.com` and are redirected to a subdomain like `xyz.example.com`, then the value of this should be `".example.com"`.

--- a/website/website/versioned_docs/version-5.0.X/api-reference.md
+++ b/website/website/versioned_docs/version-5.0.X/api-reference.md
@@ -9,7 +9,7 @@ original_id: api-reference
 
 <div class="divider"></div>
 
-## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, sessionScope?, refreshAPICustomHeaders?, autoAddCredentials?})```
+## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, cookieDomain?, refreshAPICustomHeaders?, autoAddCredentials?})```
 #### Parameters
 - ```apiDomain```
     - Type: ```string```
@@ -21,7 +21,7 @@ original_id: api-reference
     - Type: ```number```
     - Default: ```401```
     - HTTP status code that indicates session expiry - as sent by your APIs.
-- ```sessionScope``` (Optional)
+- ```cookieDomain``` (Optional)
     - Type: ```string```
     - Default: Same as the domain in the currently loaded URL.
     - Set this to your website domain across which you want to share a session. For example, if your website domain (that is loaded by the user) is ```example.com```, then the value of this should be ```example.com```. If your site has subdomains that need to keep the same session, like ```a.example.com``` and ```b.example.com```, then the value of this should be ```example.com```.

--- a/website/website/versioned_docs/version-5.0.X/migration.md
+++ b/website/website/versioned_docs/version-5.0.X/migration.md
@@ -14,7 +14,7 @@ original_id: migration
 - We no longer support using this library without interceptors for ease of use.
 - We have removed the `viaInterceptors` param from the `init` function call.
 - We have removed `refreshTokenUrl` param, and replaced it with `apiDomain` and `apiBasePath`. The refresh API will always be on `apiDomain + apiBasePath + "/session/refresh"`
-- We have renamed `websiteRootDomain` to `sessionScope` - as that is more clear.
+- We have renamed `websiteRootDomain` to `cookieDomain` - as that is more clear.
 
 ## From version `4.1.X` to `4.2.X`
 ### Using ```fetch```

--- a/website/website/versioned_docs/version-5.0.X/usage/init.md
+++ b/website/website/versioned_docs/version-5.0.X/usage/init.md
@@ -7,7 +7,7 @@ original_id: init
 
 # Initialisation
 
-### The init function: [API Reference](../api-reference#init-apidomain-apibasepath-sessionexpiredstatuscode-sessionscope-refreshapicustomheaders-autoaddcredentials)
+### The init function: [API Reference](../api-reference#init-apidomain-apibasepath-sessionexpiredstatuscode-cookieDomain-refreshapicustomheaders-autoaddcredentials)
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--Via NPM-->

--- a/website/website/versioned_docs/version-5.1.X/api-reference.md
+++ b/website/website/versioned_docs/version-5.1.X/api-reference.md
@@ -9,7 +9,7 @@ original_id: api-reference
 
 <div class="divider"></div>
 
-## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, sessionScope?, refreshAPICustomHeaders?, signoutAPICustomHeaders?, autoAddCredentials?})```
+## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, cookieDomain?, refreshAPICustomHeaders?, signoutAPICustomHeaders?, autoAddCredentials?})```
 #### Parameters
 - ```apiDomain```
     - Type: ```string```
@@ -21,7 +21,7 @@ original_id: api-reference
     - Type: ```number```
     - Default: ```401```
     - HTTP status code that indicates session expiry - as sent by your APIs.
-- ```sessionScope``` (Optional)
+- ```cookieDomain``` (Optional)
     - Type: ```string```
     - Default: Same as the domain in the currently loaded URL.
     - Set this to your website domain across which you want to share a session. For example, if your website domain (that is loaded by the user) is ```example.com```, then the value of this should be ```example.com```. If your site has subdomains that need to keep the same session, like ```a.example.com``` and ```b.example.com```, then the value of this should be ```example.com```.

--- a/website/website/versioned_docs/version-6.0.X/api-reference.md
+++ b/website/website/versioned_docs/version-6.0.X/api-reference.md
@@ -9,7 +9,7 @@ original_id: api-reference
 
 <div class="divider"></div>
 
-## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, sessionScope?, refreshAPICustomHeaders?, signoutAPICustomHeaders?, autoAddCredentials?})```
+## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, cookieDomain?, refreshAPICustomHeaders?, signoutAPICustomHeaders?, autoAddCredentials?})```
 #### Parameters
 - ```apiDomain```
     - Type: ```string```
@@ -21,7 +21,7 @@ original_id: api-reference
     - Type: ```number```
     - Default: ```401```
     - HTTP status code that indicates session expiry - as sent by your APIs.
-- ```sessionScope``` (Optional)
+- ```cookieDomain``` (Optional)
     - Type: ```{scope: string, authDomain: string}```
     - Default: `undefined`.
     - Set this if you want to share a session across sub domains. For example, if users login via `example.com` and are redirected to a subdomain like `xyz.example.com`, then the value of this should be `{scope: ".example.com", authDomain: "https://example.com"}`.

--- a/website/website/versioned_docs/version-7.1.X/api-reference.md
+++ b/website/website/versioned_docs/version-7.1.X/api-reference.md
@@ -9,7 +9,7 @@ original_id: api-reference
 
 <div class="divider"></div>
 
-## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, sessionScope?, refreshAPICustomHeaders?, signoutAPICustomHeaders?, autoAddCredentials?, isInIframe?})```
+## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, cookieDomain?, refreshAPICustomHeaders?, signoutAPICustomHeaders?, autoAddCredentials?, isInIframe?})```
 #### Parameters
 - ```apiDomain```
     - Type: ```string```
@@ -21,7 +21,7 @@ original_id: api-reference
     - Type: ```number```
     - Default: ```401```
     - HTTP status code that indicates session expiry - as sent by your APIs.
-- ```sessionScope``` (Optional)
+- ```cookieDomain``` (Optional)
     - Type: ```{scope: string, authDomain: string}```
     - Default: `undefined`.
     - Set this if you want to share a session across sub domains. For example, if users login via `example.com` and are redirected to a subdomain like `xyz.example.com`, then the value of this should be `{scope: ".example.com", authDomain: "https://example.com"}`.

--- a/website/website/versioned_docs/version-7.2.X/api-reference.md
+++ b/website/website/versioned_docs/version-7.2.X/api-reference.md
@@ -9,7 +9,7 @@ original_id: api-reference
 
 <div class="divider"></div>
 
-## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, sessionScope?, refreshAPICustomHeaders?, signoutAPICustomHeaders?, autoAddCredentials?, isInIframe?, cookieDomain?})```
+## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, cookieDomain?, refreshAPICustomHeaders?, signoutAPICustomHeaders?, autoAddCredentials?, isInIframe?, cookieDomain?})```
 #### Parameters
 - ```apiDomain```
     - Type: ```string```
@@ -21,7 +21,7 @@ original_id: api-reference
     - Type: ```number```
     - Default: ```401```
     - HTTP status code that indicates session expiry - as sent by your APIs.
-- ```sessionScope``` (Optional)
+- ```cookieDomain``` (Optional)
     - Type: ```{scope: string, authDomain: string}```
     - Default: `undefined`.
     - Set this if you want to share a session across sub domains. For example, if users login via `example.com` and are redirected to a subdomain like `xyz.example.com`, then the value of this should be `{scope: ".example.com", authDomain: "https://example.com"}`.

--- a/website/website/versioned_docs/version-8.0.X/api-reference.md
+++ b/website/website/versioned_docs/version-8.0.X/api-reference.md
@@ -9,7 +9,7 @@ original_id: api-reference
 
 <div class="divider"></div>
 
-## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, sessionScope?, autoAddCredentials?, isInIframe?, cookieDomain?, override?, onHandleEvent?, preAPIHook?})```
+## ```init({apiDomain, apiBasePath?, sessionExpiredStatusCode?, cookieDomain?, autoAddCredentials?, isInIframe?, cookieDomain?, override?, onHandleEvent?, preAPIHook?})```
 #### Parameters
 - ```apiDomain```
     - Type: ```string```
@@ -21,7 +21,7 @@ original_id: api-reference
     - Type: ```number```
     - Default: ```401```
     - HTTP status code that indicates session expiry - as sent by your APIs.
-- ```sessionScope``` (Optional)
+- ```cookieDomain``` (Optional)
     - Type: ```string```
     - Default: `undefined`.
     - Set this if you want to share a session across sub domains. For example, if users login via `example.com` and are redirected to a subdomain like `xyz.example.com`, then the value of this should be `".example.com"`.


### PR DESCRIPTION
## Summary of change


It seems `sessionScope` was replaced by `cookieDomain` at least in supertokens-node

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2