### PR TITLE
Fix issue of multiple h1 in nodejs docs v1

### DIFF
--- a/nodejs/docs/thirdparty/providers/apple.md
+++ b/nodejs/docs/thirdparty/providers/apple.md
@@ -48,7 +48,7 @@ __HIGHLIGHT__                    ThirdParty.Apple({
 });
 ```
 
-# Parameters
+## Parameters
 
 - `clientSecret`
   - type: `Object`

--- a/nodejs/docs/thirdparty/providers/facebook.md
+++ b/nodejs/docs/thirdparty/providers/facebook.md
@@ -33,7 +33,7 @@ __HIGHLIGHT__                    ThirdParty.Facebook({
 });
 ```
 
-# Parameters
+## Parameters
 
 - `clientSecret`
   - type: `String`

--- a/nodejs/docs/thirdparty/providers/github.md
+++ b/nodejs/docs/thirdparty/providers/github.md
@@ -38,7 +38,7 @@ __HIGHLIGHT__                    ThirdParty.Github({
 });
 ```
 
-# Parameters
+## Parameters
 
 - `clientSecret`
   - type: `String`

--- a/nodejs/docs/thirdparty/providers/google.md
+++ b/nodejs/docs/thirdparty/providers/google.md
@@ -38,7 +38,7 @@ __HIGHLIGHT__                    ThirdParty.Google({
 });
 ```
 
-# Parameters
+## Parameters
 
 - `clientSecret`
   - type: `String`

--- a/nodejs/website/versioned_docs/version-1.0.X/api-reference/create-new-session.md
+++ b/nodejs/website/versioned_docs/version-1.0.X/api-reference/create-new-session.md
@@ -5,9 +5,11 @@ hide_title: true
 original_id: create-new-session
 ---
 
+# `createNewSession`
+
 <!--DOCUSAURUS_CODE_TABS-->
 <!--With Express-->
-# `createNewSession(res, userId, jwtPayload?, sessionData?)`
+## `createNewSession(res, userId, jwtPayload?, sessionData?)`
 ### Parameters
 - `res`
     - **type:** `Express.Response`
@@ -31,7 +33,7 @@ original_id: create-new-session
 - Creates a new access, a new refresh and a new idRefresh token for this session. These are set in the cookies and header of the `res` object.
 
 <!--Without Express-->
-# `createNewSession(userId, jwtPayload?, sessionData?)`
+## `createNewSession(userId, jwtPayload?, sessionData?)`
 ### Parameters
 - `userId`
     - **type:** `string`

--- a/nodejs/website/versioned_docs/version-1.0.X/api-reference/get-session.md
+++ b/nodejs/website/versioned_docs/version-1.0.X/api-reference/get-session.md
@@ -5,9 +5,11 @@ hide_title: true
 original_id: get-session
 ---
 
+# `getSession`
+
 <!--DOCUSAURUS_CODE_TABS-->
 <!--With Express-->
-# `getSession(req, res, enableCsrfProtection)`
+## `getSession(req, res, enableCsrfProtection)`
 ### Parameters
 - `req`
     - **type:** `Express.Request`
@@ -37,7 +39,7 @@ original_id: get-session
 - May change the access token - but this is taken care of by this function and our frontend SDKs. You do need to worry about handling this.
 
 <!--Without Express-->
-# `getSession(accessToken, antiCsrfToken, doAntiCsrfCheck, idRefreshToken)`
+## `getSession(accessToken, antiCsrfToken, doAntiCsrfCheck, idRefreshToken)`
 ### Parameters
 - `accessToken`
     - **type:** `string`

--- a/nodejs/website/versioned_docs/version-1.0.X/api-reference/refresh-session.md
+++ b/nodejs/website/versioned_docs/version-1.0.X/api-reference/refresh-session.md
@@ -5,9 +5,11 @@ hide_title: true
 original_id: refresh-session
 ---
 
+# `refreshSession`
+
 <!--DOCUSAURUS_CODE_TABS-->
 <!--With Express-->
-# `refreshSession(req, res)`
+## `refreshSession(req, res)`
 ### Parameters
 
 - `req`
@@ -28,7 +30,7 @@ original_id: refresh-session
     - When this is thrown, all the relevant auth cookies are cleared by this function call, so you can redirect the user to a login page.
 
 <!--Without Express-->
-# `refreshSession(refreshToken)`
+## `refreshSession(refreshToken)`
 ### Parameters
 - `refreshToken`
     - **type:** `string`

--- a/nodejs/website/versioned_docs/version-2.0.X/api-reference/middleware/supertokens-error-handler.md
+++ b/nodejs/website/versioned_docs/version-2.0.X/api-reference/middleware/supertokens-error-handler.md
@@ -16,7 +16,7 @@ original_id: supertokens-error-handler
     - This middleware function will handle all errors generated from SuperTokens.
 
 
-# Callbacks
+## Callbacks
 ```js
 supertokens.errorHandler({
     onUnauthorised?: (err, req, res, next) => void,

--- a/nodejs/website/versioned_docs/version-2.3.X/api-reference/middleware/supertokens-error-handler.md
+++ b/nodejs/website/versioned_docs/version-2.3.X/api-reference/middleware/supertokens-error-handler.md
@@ -16,7 +16,7 @@ original_id: supertokens-error-handler
     - This middleware function will handle all errors generated from SuperTokens.
 
 
-# Callbacks
+## Callbacks
 ```js
 supertokens.errorHandler({
     onUnauthorised?: (err, req, res, next) => void,

--- a/nodejs/website/versioned_docs/version-4.1.X/thirdparty/providers/apple.md
+++ b/nodejs/website/versioned_docs/version-4.1.X/thirdparty/providers/apple.md
@@ -49,7 +49,7 @@ __HIGHLIGHT__                    ThirdParty.Apple({
 });
 ```
 
-# Parameters
+## Parameters
 
 - `clientSecret`
   - type: `Object`

--- a/nodejs/website/versioned_docs/version-4.1.X/thirdparty/providers/facebook.md
+++ b/nodejs/website/versioned_docs/version-4.1.X/thirdparty/providers/facebook.md
@@ -34,7 +34,7 @@ __HIGHLIGHT__                    ThirdParty.Facebook({
 });
 ```
 
-# Parameters
+## Parameters
 
 - `clientSecret`
   - type: `String`

--- a/nodejs/website/versioned_docs/version-4.1.X/thirdparty/providers/github.md
+++ b/nodejs/website/versioned_docs/version-4.1.X/thirdparty/providers/github.md
@@ -39,7 +39,7 @@ __HIGHLIGHT__                    ThirdParty.Github({
 });
 ```
 
-# Parameters
+## Parameters
 
 - `clientSecret`
   - type: `String`

--- a/nodejs/website/versioned_docs/version-4.1.X/thirdparty/providers/google.md
+++ b/nodejs/website/versioned_docs/version-4.1.X/thirdparty/providers/google.md
@@ -39,7 +39,7 @@ __HIGHLIGHT__                    ThirdParty.Google({
 });
 ```
 
-# Parameters
+## Parameters
 
 - `clientSecret`
   - type: `String`


### PR DESCRIPTION
## Summary of change
Some docs for `nodejs` sdk in v1 have multiple h1 tags.
This PR updates those docs to only have 1 h1 tag.

## Related issues
- https://github.com/supertokens/for-zenhub/issues/135

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2