### PR TITLE
Copytab enhancements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ We welcome contributions of all kinds (discussions, bug fixes, features, design 
 ### Using Copy tabs
 - If your tabs have the same content as another tab you can use the copy tabs feature to copy the contents of one tab to another.
 - Add `~COPY-TAB=TAB_ID` to your snippet. This will copy the contents of the tab with id `TAB_ID` to your tab.
+- You can add multiple `,` seperated `TAB_ID` like `~COPY-TAB=TAB_ID_1,TAB_ID_2,TAB_ID_3` so that if the first tab id does not exist it will move on to the next one until it finds a match.
 
 ### Swizzling components:
 - Docusaurus allows "swizzling" of their components so that they can be modified as per our needs. Once a component is swizzled, it's placed in the v2 > src > theme folder, and can be edited freely.

--- a/v2/src/components/tabs/FrontendSDKTabs.tsx
+++ b/v2/src/components/tabs/FrontendSDKTabs.tsx
@@ -35,16 +35,18 @@ function applyCopyTabs(children: any): any {
     (child: any) => {
       if (!React.isValidElement(child.props.children) && typeof child.props.children === "string" &&
       child.props.children.startsWith(copyTabIdentifier)) {
-        let tabToCopyIdentifier = child.props.children.split(copyTabIdentifier)[1].trim();
-        let result = undefined;
-        recursiveMapAllChildren(children, (child: any) => {
-          if (child.props && (child.props.mdxType === "TabItem" || (child.type && child.type.name === "TabItem")) && child.props.value === tabToCopyIdentifier) {
-            result = child.props.children
+        let tabToCopyIdentifiers = child.props.children.split(copyTabIdentifier)[1].trim().split(",");
+        for(let i = 0; i < tabToCopyIdentifiers.length ; i++){  
+          let result = undefined;
+          recursiveMapAllChildren(children, (child: any) => {
+            if (child.props && (child.props.mdxType === "TabItem" || (child.type && child.type.name === "TabItem")) && child.props.value === tabToCopyIdentifiers[i]) {
+              result = child.props.children
+            }
+            return child
+          })
+          if (result !== undefined) {
+            return result;
           }
-          return child
-        })
-        if (result !== undefined) {
-          return result;
         }
       }
       return child;


### PR DESCRIPTION
## Summary of change
You can now add multiple `,` separated tabIds with copy tabs so if the first one doesn't exist, it will keep searching for a match

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
none