### PR TITLE
adds session config  disclaimer for angular tabs

### DIFF
--- a/v2/emailpassword/common-customizations/sessions/in-iframe.mdx
+++ b/v2/emailpassword/common-customizations/sessions/in-iframe.mdx
@@ -105,11 +105,11 @@ supertokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/emailpassword/common-customizations/sessions/in-iframe.mdx
+++ b/v2/emailpassword/common-customizations/sessions/in-iframe.mdx
@@ -11,6 +11,9 @@ import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Using in an iframe
 
@@ -93,6 +96,37 @@ supertokens.init({
 </TabItem>
 </NpmOrScriptTabs>
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>
 
 ## Backend changes

--- a/v2/emailpassword/common-customizations/sessions/in-iframe.mdx
+++ b/v2/emailpassword/common-customizations/sessions/in-iframe.mdx
@@ -109,7 +109,7 @@ supertokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -12,6 +12,9 @@ import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Working with multiple API endpoints
 
@@ -192,4 +195,35 @@ SuperTokens.init({
 ```
 
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>

--- a/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -208,7 +208,7 @@ SuperTokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -204,11 +204,11 @@ SuperTokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -112,7 +112,7 @@ supertokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -10,6 +10,9 @@ hide_title: true
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Share sessions across sub domains
 
@@ -96,6 +99,37 @@ supertokens.init({
 </NpmOrScriptTabs>
 
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>
 
 :::caution

--- a/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -108,11 +108,11 @@ supertokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/passwordless/common-customizations/sessions/in-iframe.mdx
+++ b/v2/passwordless/common-customizations/sessions/in-iframe.mdx
@@ -105,11 +105,11 @@ supertokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/passwordless/common-customizations/sessions/in-iframe.mdx
+++ b/v2/passwordless/common-customizations/sessions/in-iframe.mdx
@@ -11,6 +11,9 @@ import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Using in an iframe
 
@@ -93,6 +96,37 @@ supertokens.init({
 </TabItem>
 </NpmOrScriptTabs>
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>
 
 ## Backend changes

--- a/v2/passwordless/common-customizations/sessions/in-iframe.mdx
+++ b/v2/passwordless/common-customizations/sessions/in-iframe.mdx
@@ -109,7 +109,7 @@ supertokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -12,6 +12,9 @@ import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Working with multiple API endpoints
 
@@ -192,4 +195,35 @@ SuperTokens.init({
 ```
 
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>

--- a/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -208,7 +208,7 @@ SuperTokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -204,11 +204,11 @@ SuperTokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -112,7 +112,7 @@ supertokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -10,6 +10,9 @@ hide_title: true
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Share sessions across sub domains
 
@@ -96,6 +99,37 @@ supertokens.init({
 </NpmOrScriptTabs>
 
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>
 
 :::caution

--- a/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -108,11 +108,11 @@ supertokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/session/common-customizations/sessions/in-iframe.mdx
+++ b/v2/session/common-customizations/sessions/in-iframe.mdx
@@ -105,11 +105,11 @@ supertokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/session/common-customizations/sessions/in-iframe.mdx
+++ b/v2/session/common-customizations/sessions/in-iframe.mdx
@@ -11,6 +11,9 @@ import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Using in an iframe
 
@@ -93,6 +96,37 @@ supertokens.init({
 </TabItem>
 </NpmOrScriptTabs>
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>
 
 ## Backend changes

--- a/v2/session/common-customizations/sessions/in-iframe.mdx
+++ b/v2/session/common-customizations/sessions/in-iframe.mdx
@@ -109,7 +109,7 @@ supertokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -12,6 +12,9 @@ import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Working with multiple API endpoints
 
@@ -192,4 +195,35 @@ SuperTokens.init({
 ```
 
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>

--- a/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -208,7 +208,7 @@ SuperTokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -204,11 +204,11 @@ SuperTokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -112,7 +112,7 @@ supertokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -10,6 +10,9 @@ hide_title: true
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Share sessions across sub domains
 
@@ -96,6 +99,37 @@ supertokens.init({
 </NpmOrScriptTabs>
 
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>
 
 :::caution

--- a/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -108,11 +108,11 @@ supertokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/src/components/reusableSnippets/sessionConfigDisclaimer.tsx
+++ b/v2/src/components/reusableSnippets/sessionConfigDisclaimer.tsx
@@ -1,0 +1,33 @@
+import React, { PropsWithChildren } from "react";
+
+export default function SessionConfigDisclaimer(props: PropsWithChildren<{}>) {
+  return (
+    <div>
+      <div className="admonition admonition-caution alert alert--warning">
+        <div className="admonition-heading">
+          <h5>
+            <span className="admonition-icon">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
+                ></path>
+              </svg>
+            </span>
+            Important
+          </h5>
+        </div>
+        <div className="admonition-content">
+          <code>Session</code> recipe config changes need to be reflected in
+          both <code>supertokens-auth-react</code> and <code>supertokens-web-js</code> configs.
+        </div>
+      </div>
+      <div>{props.children}</div>
+    </div>
+  );
+}

--- a/v2/thirdparty/common-customizations/sessions/in-iframe.mdx
+++ b/v2/thirdparty/common-customizations/sessions/in-iframe.mdx
@@ -105,11 +105,11 @@ supertokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdparty/common-customizations/sessions/in-iframe.mdx
+++ b/v2/thirdparty/common-customizations/sessions/in-iframe.mdx
@@ -11,6 +11,9 @@ import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Using in an iframe
 
@@ -93,6 +96,37 @@ supertokens.init({
 </TabItem>
 </NpmOrScriptTabs>
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>
 
 ## Backend changes

--- a/v2/thirdparty/common-customizations/sessions/in-iframe.mdx
+++ b/v2/thirdparty/common-customizations/sessions/in-iframe.mdx
@@ -109,7 +109,7 @@ supertokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -12,6 +12,9 @@ import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Working with multiple API endpoints
 
@@ -192,4 +195,35 @@ SuperTokens.init({
 ```
 
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>

--- a/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -208,7 +208,7 @@ SuperTokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -204,11 +204,11 @@ SuperTokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -112,7 +112,7 @@ supertokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -10,6 +10,9 @@ hide_title: true
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Share sessions across sub domains
 
@@ -96,6 +99,37 @@ supertokens.init({
 </NpmOrScriptTabs>
 
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>
 
 :::caution

--- a/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -108,11 +108,11 @@ supertokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/in-iframe.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/in-iframe.mdx
@@ -105,11 +105,11 @@ supertokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/in-iframe.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/in-iframe.mdx
@@ -11,6 +11,9 @@ import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Using in an iframe
 
@@ -93,6 +96,37 @@ supertokens.init({
 </TabItem>
 </NpmOrScriptTabs>
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>
 
 ## Backend changes

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/in-iframe.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/in-iframe.mdx
@@ -109,7 +109,7 @@ supertokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -12,6 +12,9 @@ import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Working with multiple API endpoints
 
@@ -192,4 +195,35 @@ SuperTokens.init({
 ```
 
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -208,7 +208,7 @@ SuperTokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -204,11 +204,11 @@ SuperTokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -112,7 +112,7 @@ supertokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -10,6 +10,9 @@ hide_title: true
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Share sessions across sub domains
 
@@ -96,6 +99,37 @@ supertokens.init({
 </NpmOrScriptTabs>
 
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>
 
 :::caution

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -108,11 +108,11 @@ supertokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/in-iframe.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/in-iframe.mdx
@@ -105,11 +105,11 @@ supertokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/in-iframe.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/in-iframe.mdx
@@ -11,6 +11,9 @@ import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Using in an iframe
 
@@ -93,6 +96,37 @@ supertokens.init({
 </TabItem>
 </NpmOrScriptTabs>
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>
 
 ## Backend changes

--- a/v2/thirdpartypasswordless/common-customizations/sessions/in-iframe.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/in-iframe.mdx
@@ -109,7 +109,7 @@ supertokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -12,6 +12,9 @@ import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Working with multiple API endpoints
 
@@ -192,4 +195,35 @@ SuperTokens.init({
 ```
 
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>

--- a/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -208,7 +208,7 @@ SuperTokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -204,11 +204,11 @@ SuperTokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -112,7 +112,7 @@ supertokens.init({
 
 ~COPY-TABS=reactjs
 
-**/app/auth/auth.component.ts**
+**/app/app.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -10,6 +10,9 @@ hide_title: true
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
 import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import AngularUIImplementation from "/src/components/reusableSnippets/angularUIImplementation"
+import {Answer}from "/src/components/question"
+import SessionConfigDisclaimer from "/src/components/reusableSnippets/sessionConfigDisclaimer"
 
 # Share sessions across sub domains
 
@@ -96,6 +99,37 @@ supertokens.init({
 </NpmOrScriptTabs>
 
 </TabItem>
+
+<TabItem value="angular">
+
+<AngularUIImplementation>
+
+<Answer title="Prebuilt UI"> 
+
+<SessionConfigDisclaimer>
+
+**supertokens-auth-react**
+
+~COPY-TABS=reactjs
+
+**supertokens-web-js**
+
+~COPY-TABS=npm,vanillajs
+
+</SessionConfigDisclaimer>
+
+</Answer>
+
+<Answer title="Custom UI"> 
+
+~COPY-TABS=npm,vanillajs
+
+</Answer>
+
+</AngularUIImplementation>
+
+</TabItem>
+
 </FrontendSDKTabs>
 
 :::caution

--- a/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -108,11 +108,11 @@ supertokens.init({
 
 <SessionConfigDisclaimer>
 
-**supertokens-auth-react**
+**/app/auth/supertokensAuthComponent.tsx**
 
 ~COPY-TABS=reactjs
 
-**supertokens-web-js**
+**/app/auth/auth.component.ts**
 
 ~COPY-TABS=npm,vanillajs
 


### PR DESCRIPTION
## Summary of change
Adds a disclaimer message in angular tabs where both `supertokens-auth-react` and `supertokens-web-js` need to be changed

## Related issues
- https://github.com/supertokens/docs/issues/369

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- none