### PR TITLE
Fix reference docs links for supertokens-golang

### DIFF
--- a/v2/emailpassword/advanced-customizations/apis-override/usage.mdx
+++ b/v2/emailpassword/advanced-customizations/apis-override/usage.mdx
@@ -90,7 +90,7 @@ SuperTokens.init({
 <TabItem value="go">
 
 :::info
-See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/emailpassword/epmodels#APIInterface)
+See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/emailpassword/epmodels#APIInterface)
 :::
 
 ```go
@@ -300,7 +300,7 @@ SuperTokens.init({
 ### Step 1: Copy the API code from the SDK.
 
 You first need to find the implementation for the API you would like to change in the backend SDK.
-- All the APIs you can override can be found [here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/emailpassword/epmodels#APIInterface), copy the name of the function you would like to override.
+- All the APIs you can override can be found [here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/emailpassword/epmodels#APIInterface), copy the name of the function you would like to override.
 - You can find the API code for this recipe [here](https://github.com/supertokens/supertokens-golang/blob/master/recipe/emailpassword/api/implementation.go).
 - In this example we want to override the `SignInPOST` API, so we can search for a function with that name in the page mentioned above and copy the code.
 

--- a/v2/emailpassword/advanced-customizations/backend-functions-override/usage.mdx
+++ b/v2/emailpassword/advanced-customizations/backend-functions-override/usage.mdx
@@ -82,7 +82,7 @@ SuperTokens.init({
 <TabItem value="go">
 
 :::info
-See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/emailpassword/epmodels#RecipeInterface)
+See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/emailpassword/epmodels#RecipeInterface)
 :::
 
 ```go

--- a/v2/passwordless/advanced-customizations/apis-override/usage.mdx
+++ b/v2/passwordless/advanced-customizations/apis-override/usage.mdx
@@ -66,7 +66,7 @@ SuperTokens.init({
 <TabItem value="go">
 
 :::info
-See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/passwordless/plessmodels#APIInterface)
+See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/passwordless/plessmodels#APIInterface)
 :::
 
 ```go

--- a/v2/passwordless/advanced-customizations/backend-functions-override/usage.mdx
+++ b/v2/passwordless/advanced-customizations/backend-functions-override/usage.mdx
@@ -66,7 +66,7 @@ SuperTokens.init({
 <TabItem value="go">
 
 :::info
-See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/passwordless/plessmodels#RecipeInterface)
+See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/passwordless/plessmodels#RecipeInterface)
 :::
 
 ```go

--- a/v2/session/advanced-customizations/apis-override/usage.mdx
+++ b/v2/session/advanced-customizations/apis-override/usage.mdx
@@ -70,7 +70,7 @@ SuperTokens.init({
 <TabItem value="go">
 
 :::info
-See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/session/sessmodels#APIInterface)
+See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/session/sessmodels#APIInterface)
 :::
 
 ```go
@@ -239,7 +239,7 @@ SuperTokens.init({
 ### Step 1: Copy the API code from the SDK.
 
 You first need to find the implementation for the API you would like to change in the backend SDK.
-- All the APIs you can override can be found [here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/session/sessmodels#APIInterface), copy the name of the function you would like to override.
+- All the APIs you can override can be found [here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/session/sessmodels#APIInterface), copy the name of the function you would like to override.
 - You can find the API code for this recipe [here](https://github.com/supertokens/supertokens-golang/blob/master/recipe/session/api/implementation.go).
 - In this example we want to override the `SignOutPOST` API, so we can search for a function with that name in the page mentioned above and copy the code.
 

--- a/v2/session/common-customizations/sessions/new-session.mdx
+++ b/v2/session/common-customizations/sessions/new-session.mdx
@@ -381,7 +381,7 @@ type createNewSession = (
 </TabItem>
 <TabItem value="go">
 
-The full signature of [`createNewSession`](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/session#CreateNewSession) is:
+The full signature of [`createNewSession`](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/session#CreateNewSession) is:
 ```text
 CreateNewSession(responseWriter, userId, accessTokenPayload, sessionData, userContext)
 ```

--- a/v2/thirdparty/advanced-customizations/apis-override/usage.mdx
+++ b/v2/thirdparty/advanced-customizations/apis-override/usage.mdx
@@ -95,7 +95,7 @@ SuperTokens.init({
 <TabItem value="go">
 
 :::info
-See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/thirdparty/tpmodels#APIInterface)
+See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/thirdparty/tpmodels#APIInterface)
 :::
 
 ```go
@@ -351,7 +351,7 @@ SuperTokens.init({
 ### Step 1: Copy the API code from the SDK.
 
 You first need to find the implementation for the API you would like to change in the backend SDK.
-- All the APIs you can override can be found [here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/thirdparty/tpmodels#APIInterface), copy the name of the function you would like to override.
+- All the APIs you can override can be found [here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/thirdparty/tpmodels#APIInterface), copy the name of the function you would like to override.
 - You can find the API code for this recipe [here](https://github.com/supertokens/supertokens-golang/blob/master/recipe/thirdparty/api/implementation.go).
 - In this example we want to override the `SignInUpPOST` API, so we can search for a function with that name in the page mentioned above and copy the code.
 

--- a/v2/thirdparty/advanced-customizations/backend-functions-override/usage.mdx
+++ b/v2/thirdparty/advanced-customizations/backend-functions-override/usage.mdx
@@ -84,7 +84,7 @@ SuperTokens.init({
 <TabItem value="go">
 
 :::info
-See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/thirdparty/tpmodels#RecipeInterface)
+See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/thirdparty/tpmodels#RecipeInterface)
 :::
 
 ```go

--- a/v2/thirdpartyemailpassword/advanced-customizations/apis-override/usage.mdx
+++ b/v2/thirdpartyemailpassword/advanced-customizations/apis-override/usage.mdx
@@ -97,7 +97,7 @@ SuperTokens.init({
 <TabItem value="go">
 
 :::info
-See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/emailpassword/epmodels#APIInterface)
+See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/emailpassword/epmodels#APIInterface)
 :::
 
 ```go
@@ -309,7 +309,7 @@ SuperTokens.init({
 ### Step 1: Copy the API code from the SDK.
 
 You first need to find the implementation for the API you would like to change in the backend SDK.
-- All the APIs you can override can be found [here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/emailpassword/epmodels#APIInterface), copy the name of the function you would like to override.
+- All the APIs you can override can be found [here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/emailpassword/epmodels#APIInterface), copy the name of the function you would like to override.
 - You can find the API code for this recipe [here](https://github.com/supertokens/supertokens-golang/blob/master/recipe/thirdpartyemailpassword/api/implementation.go).
 - In this example we want to override the `PasswordResetPOST` API, so we can search for a function with that name in the page mentioned above.
 - Since this API uses EmailPassword recipe's `PasswordResetPOST` API, make sure to copy the code from [here](https://github.com/supertokens/supertokens-golang/blob/master/recipe/emailpassword/api/implementation.go#L58)

--- a/v2/thirdpartyemailpassword/advanced-customizations/backend-functions-override/usage.mdx
+++ b/v2/thirdpartyemailpassword/advanced-customizations/backend-functions-override/usage.mdx
@@ -82,7 +82,7 @@ SuperTokens.init({
 <TabItem value="go">
 
 :::info
-See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/thirdpartyemailpassword/tpepmodels#RecipeInterface)
+See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/thirdpartyemailpassword/tpepmodels#RecipeInterface)
 :::
 
 ```go

--- a/v2/thirdpartypasswordless/advanced-customizations/apis-override/usage.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/apis-override/usage.mdx
@@ -66,7 +66,7 @@ SuperTokens.init({
 <TabItem value="go">
 
 :::info
-See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/thirdpartypasswordless/plessmodels#APIInterface)
+See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/thirdpartypasswordless/tplmodels#APIInterface)
 :::
 
 ```go

--- a/v2/thirdpartypasswordless/advanced-customizations/backend-functions-override/usage.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/backend-functions-override/usage.mdx
@@ -66,7 +66,7 @@ SuperTokens.init({
 <TabItem value="go">
 
 :::info
-See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang@v0.0.6/recipe/thirdpartypasswordless/tplmodels#RecipeInterface)
+See all the [functions that can be overrided here](https://pkg.go.dev/github.com/supertokens/supertokens-golang/recipe/thirdpartypasswordless/tplmodels#RecipeInterface)
 :::
 
 ```go


### PR DESCRIPTION
## Summary of change
- Modifies the links for golang reference docs to remove the package version (this makes it point to the latest version by default) to solve 404s. 
- Fixes some links for golang that gave a 400

## Related issues
- ...

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
None