### PR TITLE
chore: Fix variable names for session information for python docs

### DIFF
--- a/v2/emailpassword/common-customizations/sessions/update-jwt-payload.mdx
+++ b/v2/emailpassword/common-customizations/sessions/update-jwt-payload.mdx
@@ -438,11 +438,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         current_access_token_payload["newKey"] = "newValue"
         await update_access_token_payload(handle, current_access_token_payload)
 ```
@@ -457,11 +457,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     current_access_token_payload["newKey"] = "newValue"
     update_access_token_payload(handle, current_access_token_payload)
 ```

--- a/v2/emailpassword/common-customizations/sessions/update-session-data.mdx
+++ b/v2/emailpassword/common-customizations/sessions/update-session-data.mdx
@@ -443,14 +443,14 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_payload = await get_session_information(handle)
-        if current_session_payload is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_session_payload = current_session_payload.session_data
+        current_session_data = session_information.session_data
 
-        current_session_payload["newKey"] = "newValue"
-        await update_session_data(handle, current_session_payload)
+        current_session_data["newKey"] = "newValue"
+        await update_session_data(handle, current_session_data)
 ```
 
 </TabItem>
@@ -463,14 +463,14 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_payload = get_session_information(handle)
-    if current_session_payload is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_session_payload = current_session_payload.session_data
+    current_session_data = session_information.session_data
 
-    current_session_payload["newKey"] = "newValue"
-    update_session_data(handle, current_session_payload)
+    current_session_data["newKey"] = "newValue"
+    update_session_data(handle, current_session_data)
 ```
 
 </TabItem>

--- a/v2/emailpassword/common-customizations/sessions/with-jwt/read-claims.mdx
+++ b/v2/emailpassword/common-customizations/sessions/with-jwt/read-claims.mdx
@@ -378,11 +378,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         # highlight-start
         current_jwt = current_access_token_payload['jwt']
         current_role = current_jwt['role']
@@ -400,11 +400,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     # highlight-start
     current_jwt = current_access_token_payload['jwt']
     current_role = current_jwt['role']

--- a/v2/emailpassword/common-customizations/sessions/with-jwt/read-jwt.mdx
+++ b/v2/emailpassword/common-customizations/sessions/with-jwt/read-jwt.mdx
@@ -379,11 +379,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         # highlight-start
         current_jwt = current_access_token_payload['jwt']
         # highlight-end
@@ -400,11 +400,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     # highlight-start
     current_jwt = current_access_token_payload['jwt']
     # highlight-end

--- a/v2/emailpassword/common-customizations/sessions/with-jwt/update-jwt.mdx
+++ b/v2/emailpassword/common-customizations/sessions/with-jwt/update-jwt.mdx
@@ -440,11 +440,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_jwt_payload = await get_session_information(handle)
-        if current_jwt_payload is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_jwt_payload.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         current_access_token_payload["newKey"] = "newValue"
         await update_access_token_payload(handle, current_access_token_payload)
 ```

--- a/v2/passwordless/common-customizations/sessions/update-jwt-payload.mdx
+++ b/v2/passwordless/common-customizations/sessions/update-jwt-payload.mdx
@@ -438,11 +438,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         current_access_token_payload["newKey"] = "newValue"
         await update_access_token_payload(handle, current_access_token_payload)
 ```
@@ -457,11 +457,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     current_access_token_payload["newKey"] = "newValue"
     update_access_token_payload(handle, current_access_token_payload)
 ```

--- a/v2/passwordless/common-customizations/sessions/update-session-data.mdx
+++ b/v2/passwordless/common-customizations/sessions/update-session-data.mdx
@@ -443,14 +443,14 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_payload = await get_session_information(handle)
-        if current_session_payload is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_session_payload = current_session_payload.session_data
+        current_session_data = session_information.session_data
 
-        current_session_payload["newKey"] = "newValue"
-        await update_session_data(handle, current_session_payload)
+        current_session_data["newKey"] = "newValue"
+        await update_session_data(handle, current_session_data)
 ```
 
 </TabItem>
@@ -463,14 +463,14 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_payload = get_session_information(handle)
-    if current_session_payload is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_session_payload = current_session_payload.session_data
+    current_session_data = session_information.session_data
 
-    current_session_payload["newKey"] = "newValue"
-    update_session_data(handle, current_session_payload)
+    current_session_data["newKey"] = "newValue"
+    update_session_data(handle, current_session_data)
 ```
 
 </TabItem>

--- a/v2/passwordless/common-customizations/sessions/with-jwt/read-claims.mdx
+++ b/v2/passwordless/common-customizations/sessions/with-jwt/read-claims.mdx
@@ -378,11 +378,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         # highlight-start
         current_jwt = current_access_token_payload['jwt']
         current_role = current_jwt['role']
@@ -400,11 +400,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     # highlight-start
     current_jwt = current_access_token_payload['jwt']
     current_role = current_jwt['role']

--- a/v2/passwordless/common-customizations/sessions/with-jwt/read-jwt.mdx
+++ b/v2/passwordless/common-customizations/sessions/with-jwt/read-jwt.mdx
@@ -379,11 +379,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         # highlight-start
         current_jwt = current_access_token_payload['jwt']
         # highlight-end
@@ -400,11 +400,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     # highlight-start
     current_jwt = current_access_token_payload['jwt']
     # highlight-end

--- a/v2/passwordless/common-customizations/sessions/with-jwt/update-jwt.mdx
+++ b/v2/passwordless/common-customizations/sessions/with-jwt/update-jwt.mdx
@@ -440,11 +440,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_jwt_payload = await get_session_information(handle)
-        if current_jwt_payload is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_jwt_payload.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         current_access_token_payload["newKey"] = "newValue"
         await update_access_token_payload(handle, current_access_token_payload)
 ```

--- a/v2/session/common-customizations/sessions/update-jwt-payload.mdx
+++ b/v2/session/common-customizations/sessions/update-jwt-payload.mdx
@@ -438,11 +438,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         current_access_token_payload["newKey"] = "newValue"
         await update_access_token_payload(handle, current_access_token_payload)
 ```
@@ -457,11 +457,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     current_access_token_payload["newKey"] = "newValue"
     update_access_token_payload(handle, current_access_token_payload)
 ```

--- a/v2/session/common-customizations/sessions/update-session-data.mdx
+++ b/v2/session/common-customizations/sessions/update-session-data.mdx
@@ -443,14 +443,14 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_payload = await get_session_information(handle)
-        if current_session_payload is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_session_payload = current_session_payload.session_data
+        current_session_data = session_information.session_data
 
-        current_session_payload["newKey"] = "newValue"
-        await update_session_data(handle, current_session_payload)
+        current_session_data["newKey"] = "newValue"
+        await update_session_data(handle, current_session_data)
 ```
 
 </TabItem>
@@ -463,14 +463,14 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_payload = get_session_information(handle)
-    if current_session_payload is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_session_payload = current_session_payload.session_data
+    current_session_data = session_information.session_data
 
-    current_session_payload["newKey"] = "newValue"
-    update_session_data(handle, current_session_payload)
+    current_session_data["newKey"] = "newValue"
+    update_session_data(handle, current_session_data)
 ```
 
 </TabItem>

--- a/v2/session/common-customizations/sessions/with-jwt/read-claims.mdx
+++ b/v2/session/common-customizations/sessions/with-jwt/read-claims.mdx
@@ -378,11 +378,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         # highlight-start
         current_jwt = current_access_token_payload['jwt']
         current_role = current_jwt['role']
@@ -400,11 +400,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     # highlight-start
     current_jwt = current_access_token_payload['jwt']
     current_role = current_jwt['role']

--- a/v2/session/common-customizations/sessions/with-jwt/read-jwt.mdx
+++ b/v2/session/common-customizations/sessions/with-jwt/read-jwt.mdx
@@ -379,11 +379,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         # highlight-start
         current_jwt = current_access_token_payload['jwt']
         # highlight-end
@@ -400,11 +400,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     # highlight-start
     current_jwt = current_access_token_payload['jwt']
     # highlight-end

--- a/v2/session/common-customizations/sessions/with-jwt/update-jwt.mdx
+++ b/v2/session/common-customizations/sessions/with-jwt/update-jwt.mdx
@@ -440,11 +440,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_jwt_payload = await get_session_information(handle)
-        if current_jwt_payload is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_jwt_payload.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         current_access_token_payload["newKey"] = "newValue"
         await update_access_token_payload(handle, current_access_token_payload)
 ```

--- a/v2/thirdparty/common-customizations/sessions/update-jwt-payload.mdx
+++ b/v2/thirdparty/common-customizations/sessions/update-jwt-payload.mdx
@@ -438,11 +438,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         current_access_token_payload["newKey"] = "newValue"
         await update_access_token_payload(handle, current_access_token_payload)
 ```
@@ -457,11 +457,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     current_access_token_payload["newKey"] = "newValue"
     update_access_token_payload(handle, current_access_token_payload)
 ```

--- a/v2/thirdparty/common-customizations/sessions/update-session-data.mdx
+++ b/v2/thirdparty/common-customizations/sessions/update-session-data.mdx
@@ -443,14 +443,14 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_payload = await get_session_information(handle)
-        if current_session_payload is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_session_payload = current_session_payload.session_data
+        current_session_data = session_information.session_data
 
-        current_session_payload["newKey"] = "newValue"
-        await update_session_data(handle, current_session_payload)
+        current_session_data["newKey"] = "newValue"
+        await update_session_data(handle, current_session_data)
 ```
 
 </TabItem>
@@ -463,14 +463,14 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_payload = get_session_information(handle)
-    if current_session_payload is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_session_payload = current_session_payload.session_data
+    current_session_data = session_information.session_data
 
-    current_session_payload["newKey"] = "newValue"
-    update_session_data(handle, current_session_payload)
+    current_session_data["newKey"] = "newValue"
+    update_session_data(handle, current_session_data)
 ```
 
 </TabItem>

--- a/v2/thirdparty/common-customizations/sessions/with-jwt/read-claims.mdx
+++ b/v2/thirdparty/common-customizations/sessions/with-jwt/read-claims.mdx
@@ -378,11 +378,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         # highlight-start
         current_jwt = current_access_token_payload['jwt']
         current_role = current_jwt['role']
@@ -400,11 +400,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     # highlight-start
     current_jwt = current_access_token_payload['jwt']
     current_role = current_jwt['role']

--- a/v2/thirdparty/common-customizations/sessions/with-jwt/read-jwt.mdx
+++ b/v2/thirdparty/common-customizations/sessions/with-jwt/read-jwt.mdx
@@ -379,11 +379,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         # highlight-start
         current_jwt = current_access_token_payload['jwt']
         # highlight-end
@@ -400,11 +400,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     # highlight-start
     current_jwt = current_access_token_payload['jwt']
     # highlight-end

--- a/v2/thirdparty/common-customizations/sessions/with-jwt/update-jwt.mdx
+++ b/v2/thirdparty/common-customizations/sessions/with-jwt/update-jwt.mdx
@@ -440,11 +440,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_jwt_payload = await get_session_information(handle)
-        if current_jwt_payload is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_jwt_payload.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         current_access_token_payload["newKey"] = "newValue"
         await update_access_token_payload(handle, current_access_token_payload)
 ```

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/update-jwt-payload.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/update-jwt-payload.mdx
@@ -438,11 +438,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         current_access_token_payload["newKey"] = "newValue"
         await update_access_token_payload(handle, current_access_token_payload)
 ```
@@ -457,11 +457,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     current_access_token_payload["newKey"] = "newValue"
     update_access_token_payload(handle, current_access_token_payload)
 ```

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/update-session-data.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/update-session-data.mdx
@@ -443,14 +443,14 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_payload = await get_session_information(handle)
-        if current_session_payload is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_session_payload = current_session_payload.session_data
+        current_session_data = session_information.session_data
 
-        current_session_payload["newKey"] = "newValue"
-        await update_session_data(handle, current_session_payload)
+        current_session_data["newKey"] = "newValue"
+        await update_session_data(handle, current_session_data)
 ```
 
 </TabItem>
@@ -463,14 +463,14 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_payload = get_session_information(handle)
-    if current_session_payload is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_session_payload = current_session_payload.session_data
+    current_session_data = session_information.session_data
 
-    current_session_payload["newKey"] = "newValue"
-    update_session_data(handle, current_session_payload)
+    current_session_data["newKey"] = "newValue"
+    update_session_data(handle, current_session_data)
 ```
 
 </TabItem>

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/read-claims.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/read-claims.mdx
@@ -378,11 +378,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         # highlight-start
         current_jwt = current_access_token_payload['jwt']
         current_role = current_jwt['role']
@@ -400,11 +400,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     # highlight-start
     current_jwt = current_access_token_payload['jwt']
     current_role = current_jwt['role']

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/read-jwt.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/read-jwt.mdx
@@ -379,11 +379,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         # highlight-start
         current_jwt = current_access_token_payload['jwt']
         # highlight-end
@@ -400,11 +400,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     # highlight-start
     current_jwt = current_access_token_payload['jwt']
     # highlight-end

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/update-jwt.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/update-jwt.mdx
@@ -440,11 +440,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_jwt_payload = await get_session_information(handle)
-        if current_jwt_payload is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_jwt_payload.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         current_access_token_payload["newKey"] = "newValue"
         await update_access_token_payload(handle, current_access_token_payload)
 ```

--- a/v2/thirdpartypasswordless/common-customizations/sessions/update-jwt-payload.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/update-jwt-payload.mdx
@@ -438,11 +438,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         current_access_token_payload["newKey"] = "newValue"
         await update_access_token_payload(handle, current_access_token_payload)
 ```
@@ -457,11 +457,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     current_access_token_payload["newKey"] = "newValue"
     update_access_token_payload(handle, current_access_token_payload)
 ```

--- a/v2/thirdpartypasswordless/common-customizations/sessions/update-session-data.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/update-session-data.mdx
@@ -443,14 +443,14 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_payload = await get_session_information(handle)
-        if current_session_payload is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_session_payload = current_session_payload.session_data
+        current_session_data = session_information.session_data
 
-        current_session_payload["newKey"] = "newValue"
-        await update_session_data(handle, current_session_payload)
+        current_session_data["newKey"] = "newValue"
+        await update_session_data(handle, current_session_data)
 ```
 
 </TabItem>
@@ -463,14 +463,14 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_payload = get_session_information(handle)
-    if current_session_payload is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_session_payload = current_session_payload.session_data
+    current_session_data = session_information.session_data
 
-    current_session_payload["newKey"] = "newValue"
-    update_session_data(handle, current_session_payload)
+    current_session_data["newKey"] = "newValue"
+    update_session_data(handle, current_session_data)
 ```
 
 </TabItem>

--- a/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/read-claims.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/read-claims.mdx
@@ -378,11 +378,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         # highlight-start
         current_jwt = current_access_token_payload['jwt']
         current_role = current_jwt['role']
@@ -400,11 +400,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     # highlight-start
     current_jwt = current_access_token_payload['jwt']
     current_role = current_jwt['role']

--- a/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/read-jwt.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/read-jwt.mdx
@@ -379,11 +379,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_session_info = await get_session_information(handle)
-        if current_session_info is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_session_info.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         # highlight-start
         current_jwt = current_access_token_payload['jwt']
         # highlight-end
@@ -400,11 +400,11 @@ from supertokens_python.recipe.session.syncio import get_all_session_handles_for
 session_handles = get_all_session_handles_for_user("userId")
 
 for handle in session_handles:
-    current_session_info = get_session_information(handle)
-    if current_session_info is None:
+    session_information = get_session_information(handle)
+    if session_information is None:
         continue
 
-    current_access_token_payload = current_session_info.access_token_payload
+    current_access_token_payload = session_information.access_token_payload
     # highlight-start
     current_jwt = current_access_token_payload['jwt']
     # highlight-end

--- a/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/update-jwt.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/update-jwt.mdx
@@ -440,11 +440,11 @@ async def some_func():
     session_handles = await get_all_session_handles_for_user("userId")
 
     for handle in session_handles:
-        current_jwt_payload = await get_session_information(handle)
-        if current_jwt_payload is None:
+        session_information = await get_session_information(handle)
+        if session_information is None:
             continue
 
-        current_access_token_payload = current_jwt_payload.access_token_payload
+        current_access_token_payload = session_information.access_token_payload
         current_access_token_payload["newKey"] = "newValue"
         await update_access_token_payload(handle, current_access_token_payload)
 ```


### PR DESCRIPTION
## Summary of change

- Fixes variable names to be more accurate to the method calls for Python code snippets where `get_session_information` is used
- Makes variable names more consistent across different docs pages

## Related issues
- ...

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2