### PR TITLE
Add a note about API keys when calling the JWKS endpoint

### DIFF
--- a/v2/emailpassword/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/emailpassword/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -22,7 +22,7 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
 :::info
-When calling the JWKS endpoint you also need to set the `api-key` header. For self-hosted this is only applicable if you have [added an API key to SuperTokens Core](../../../common-customizations/core/api-keys)
+When calling this API, if you get back a `401` response, that means that you have no supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
 :::
 
 The response would be similar to: 

--- a/v2/emailpassword/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/emailpassword/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -21,6 +21,10 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using our managed service use the `connectionURI` found on the supertokens.com dashboard
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
+:::info
+When calling the JWKS endpoint you also need to set the `api-key` header. For self-hosted this is only applicable if you have [added an API key to SuperTokens Core](../../../common-customizations/core/api-keys)
+:::
+
 The response would be similar to: 
 
 ```json

--- a/v2/emailpassword/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/emailpassword/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -21,8 +21,8 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using our managed service use the `connectionURI` found on the supertokens.com dashboard
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
-:::info
-When calling this API, if you get back a `401` response, that means that you have no supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
+:::important
+When calling `{connectionURI}/recipe/jwt/jwks`, if you get back a `401` response, it means that you have not supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
 :::
 
 The response would be similar to: 

--- a/v2/passwordless/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/passwordless/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -22,7 +22,7 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
 :::info
-When calling the JWKS endpoint you also need to set the `api-key` header. For self-hosted this is only applicable if you have [added an API key to SuperTokens Core](../../../common-customizations/core/api-keys)
+When calling this API, if you get back a `401` response, that means that you have no supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
 :::
 
 The response would be similar to: 

--- a/v2/passwordless/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/passwordless/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -21,6 +21,10 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using our managed service use the `connectionURI` found on the supertokens.com dashboard
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
+:::info
+When calling the JWKS endpoint you also need to set the `api-key` header. For self-hosted this is only applicable if you have [added an API key to SuperTokens Core](../../../common-customizations/core/api-keys)
+:::
+
 The response would be similar to: 
 
 ```json

--- a/v2/passwordless/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/passwordless/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -21,8 +21,8 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using our managed service use the `connectionURI` found on the supertokens.com dashboard
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
-:::info
-When calling this API, if you get back a `401` response, that means that you have no supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
+:::important
+When calling `{connectionURI}/recipe/jwt/jwks`, if you get back a `401` response, it means that you have not supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
 :::
 
 The response would be similar to: 

--- a/v2/session/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/session/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -22,7 +22,7 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
 :::info
-When calling the JWKS endpoint you also need to set the `api-key` header. For self-hosted this is only applicable if you have [added an API key to SuperTokens Core](../../../common-customizations/core/api-keys)
+When calling this API, if you get back a `401` response, that means that you have no supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
 :::
 
 The response would be similar to: 

--- a/v2/session/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/session/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -21,6 +21,10 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using our managed service use the `connectionURI` found on the supertokens.com dashboard
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
+:::info
+When calling the JWKS endpoint you also need to set the `api-key` header. For self-hosted this is only applicable if you have [added an API key to SuperTokens Core](../../../common-customizations/core/api-keys)
+:::
+
 The response would be similar to: 
 
 ```json

--- a/v2/session/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/session/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -21,8 +21,8 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using our managed service use the `connectionURI` found on the supertokens.com dashboard
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
-:::info
-When calling this API, if you get back a `401` response, that means that you have no supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
+:::important
+When calling `{connectionURI}/recipe/jwt/jwks`, if you get back a `401` response, it means that you have not supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
 :::
 
 The response would be similar to: 

--- a/v2/thirdparty/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/thirdparty/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -22,7 +22,7 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
 :::info
-When calling the JWKS endpoint you also need to set the `api-key` header. For self-hosted this is only applicable if you have [added an API key to SuperTokens Core](../../../common-customizations/core/api-keys)
+When calling this API, if you get back a `401` response, that means that you have no supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
 :::
 
 The response would be similar to: 

--- a/v2/thirdparty/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/thirdparty/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -21,6 +21,10 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using our managed service use the `connectionURI` found on the supertokens.com dashboard
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
+:::info
+When calling the JWKS endpoint you also need to set the `api-key` header. For self-hosted this is only applicable if you have [added an API key to SuperTokens Core](../../../common-customizations/core/api-keys)
+:::
+
 The response would be similar to: 
 
 ```json

--- a/v2/thirdparty/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/thirdparty/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -21,8 +21,8 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using our managed service use the `connectionURI` found on the supertokens.com dashboard
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
-:::info
-When calling this API, if you get back a `401` response, that means that you have no supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
+:::important
+When calling `{connectionURI}/recipe/jwt/jwks`, if you get back a `401` response, it means that you have not supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
 :::
 
 The response would be similar to: 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -22,7 +22,7 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
 :::info
-When calling the JWKS endpoint you also need to set the `api-key` header. For self-hosted this is only applicable if you have [added an API key to SuperTokens Core](../../../common-customizations/core/api-keys)
+When calling this API, if you get back a `401` response, that means that you have no supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
 :::
 
 The response would be similar to: 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -21,6 +21,10 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using our managed service use the `connectionURI` found on the supertokens.com dashboard
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
+:::info
+When calling the JWKS endpoint you also need to set the `api-key` header. For self-hosted this is only applicable if you have [added an API key to SuperTokens Core](../../../common-customizations/core/api-keys)
+:::
+
 The response would be similar to: 
 
 ```json

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -21,8 +21,8 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using our managed service use the `connectionURI` found on the supertokens.com dashboard
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
-:::info
-When calling this API, if you get back a `401` response, that means that you have no supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
+:::important
+When calling `{connectionURI}/recipe/jwt/jwks`, if you get back a `401` response, it means that you have not supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
 :::
 
 The response would be similar to: 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -22,7 +22,7 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
 :::info
-When calling the JWKS endpoint you also need to set the `api-key` header. For self-hosted this is only applicable if you have [added an API key to SuperTokens Core](../../../common-customizations/core/api-keys)
+When calling this API, if you get back a `401` response, that means that you have no supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
 :::
 
 The response would be similar to: 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -21,6 +21,10 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using our managed service use the `connectionURI` found on the supertokens.com dashboard
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
+:::info
+When calling the JWKS endpoint you also need to set the `api-key` header. For self-hosted this is only applicable if you have [added an API key to SuperTokens Core](../../../common-customizations/core/api-keys)
+:::
+
 The response would be similar to: 
 
 ```json

--- a/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/get-public-key.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/get-public-key.mdx
@@ -21,8 +21,8 @@ You can make a `GET` request to the SuperTokens core on `{connectionURI}/recipe/
 - If you are using our managed service use the `connectionURI` found on the supertokens.com dashboard
 - If you are using the self-hosted option, you can query any one of the SuperTokens core instances that you host
 
-:::info
-When calling this API, if you get back a `401` response, that means that you have no supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
+:::important
+When calling `{connectionURI}/recipe/jwt/jwks`, if you get back a `401` response, it means that you have not supplied the right API key for the core. You can pass the API key using the `api-key` header in the request.
 :::
 
 The response would be similar to: 


### PR DESCRIPTION
## Summary of change

- Explains that the API key needs to be set when calling the JWKS endpoint

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2