### PR TITLE
add supertoken-python userroles docs for usage

### DIFF
--- a/v2/community/reusableMD/supported-tech-stacks-backend.mdx
+++ b/v2/community/reusableMD/supported-tech-stacks-backend.mdx
@@ -1,0 +1,28 @@
+:::important
+It is required to integrate our frontend and backend SDKs to use SuperTokens.
+:::
+
+### On the backend:
+
+- <span
+    style={{
+      color: "#31ff64",
+      fontWeight: "bold",
+    }}
+  >
+    Implemented - NodeJS, GoLang and Python (FastAPI, Django, Flask)
+  </span>
+  : We support all current functionality (signup, manage auth tokens, social
+  login etc).
+- <span
+    style={{
+      color: "#f72020",
+      fontWeight: "bold",
+    }}
+  >
+    Not supported - PHP (Laravel) and Java (Spring)
+  </span>
+  .{" "}
+
+For unsupported frameworks (such as Laravel and Spring), please submit your request on the [product roadmap page](https://supertokens.com/product-roadmap). Alternatively, you can build and contribute these SDKs with our help. Reach out to us on [Discord](https://supertokens.com/discord).
+

--- a/v2/userroles/backend/userroles-api.mdx
+++ b/v2/userroles/backend/userroles-api.mdx
@@ -1,0 +1,304 @@
+---
+title: 1) Userroles Usage
+hide_title: true
+---
+
+## Create new role or add permissions
+
+* A new role can be created with `userroles` recipe.
+* A role can have multiple permissions associated with it.
+* Permission is a list of string(s).
+
+
+```python
+from supertokens_python.recipe import userroles
+from supertokens_python.recipe.userroles import asyncio
+
+init(
+    supertokens_config=SupertokensConfig(connection_uri="https://try.supertokens.io"),
+    app_info=InputAppInfo(
+        app_name="Foo Bar",
+        api_domain="http://localhost:3000",
+        website_domain="http://localhost:8080", 
+    ),
+    framework="flask",
+    recipe_list=[
+        userroles.init()
+    ]
+)
+
+role = "role"
+permission = ["perm1", "perm2", "write"]
+result = await asyncio.create_new_role_or_add_permissions(role, [])
+print("Role Created:", result.created_new_role)
+```
+
+`result.created_new_role` is a bool which is true if the role was created.
+
+## Add role to a user
+
+* You can add new roles to a user.
+* A role must exist for it to be added to a user.
+* A role that does not exist is ignored by userroles recipe and returns an empty role.
+
+```python
+from supertokens_python.recipe import userroles
+from supertokens_python.recipe.userroles import asyncio
+
+init(
+    supertokens_config=SupertokensConfig(connection_uri="https://try.supertokens.io"),
+    app_info=InputAppInfo(
+        app_name="Foo Bar",
+        api_domain="http://localhost:3000",
+        website_domain="http://localhost:8080", 
+    ),
+    framework="flask",
+    recipe_list=[
+        userroles.init()
+    ]
+)
+
+# Get a specific user in a view. 
+user_id = "userId"
+role = "role"
+
+await asyncio.create_new_role_or_add_permissions(role, [])
+result = await asyncio.add_role_to_user(user_id, role)
+print("List of roles:", result.did_user_already_have_role)
+```
+
+Here `result.did_user_already_have_role` is a bool values, which returns false if the user didn't have the role earlier.
+
+## Get All Roles
+
+* All the roles that exist can be read.
+* It is returned as a list of strings.
+
+```python
+from supertokens_python.recipe import userroles
+from supertokens_python.recipe.userroles import asyncio
+
+init(
+    supertokens_config=SupertokensConfig(connection_uri="https://try.supertokens.io"),
+    app_info=InputAppInfo(
+        app_name="Foo Bar",
+        api_domain="http://localhost:3000",
+        website_domain="http://localhost:8080", 
+    ),
+    framework="flask",
+    recipe_list=[
+        userroles.init()
+    ]
+)
+
+result = await asyncio.get_all_roles()
+print(result.roles)
+```
+
+`result.roles` is a list of string that contains all the roles that exist.
+
+## Get Roles For a User
+
+* Get all roles for a user.
+
+```python
+from supertokens_python.recipe import userroles
+from supertokens_python.recipe.userroles import asyncio
+
+init(
+    supertokens_config=SupertokensConfig(connection_uri="https://try.supertokens.io"),
+    app_info=InputAppInfo(
+        app_name="Foo Bar",
+        api_domain="http://localhost:3000",
+        website_domain="http://localhost:8080", 
+    ),
+    framework="flask",
+    recipe_list=[
+        userroles.init()
+    ]
+)
+
+result = await asyncio.get_roles_for_user(user_id)
+print(result.roles)
+```
+
+`result.roles` is a list of string that conains all the roles that exist.
+
+## Get Users That Have Role
+
+* Get list of all users that have a specific role
+
+```python
+from supertokens_python.recipe import userroles
+from supertokens_python.recipe.userroles import asyncio
+
+init(
+    supertokens_config=SupertokensConfig(connection_uri="https://try.supertokens.io"),
+    app_info=InputAppInfo(
+        app_name="Foo Bar",
+        api_domain="http://localhost:3000",
+        website_domain="http://localhost:8080", 
+    ),
+    framework="flask",
+    recipe_list=[
+        userroles.init()
+    ]
+
+)
+role = "role"
+result = await asyncio.get_users_that_have_role(role)
+print(result.users == users)
+```
+
+`result.users` is a list of string which contains users.
+
+## Get Permissions For a Role
+
+* A role can have multiple permissions.
+
+```python
+from supertokens_python.recipe import userroles
+from supertokens_python.recipe.userroles import asyncio
+
+init(
+    supertokens_config=SupertokensConfig(connection_uri="https://try.supertokens.io"),
+    app_info=InputAppInfo(
+        app_name="Foo Bar",
+        api_domain="http://localhost:3000",
+        website_domain="http://localhost:8080", 
+    ),
+    framework="flask",
+    recipe_list=[
+        userroles.init()
+    ]
+)
+
+role = "role"
+result = await asyncio.get_permissions_for_role(role)
+print(result.permissions)
+```
+`result.permissions` is a list of string that contains permissions.
+
+## Get Roles that Have Permission
+
+* All roles can be found with a specific permission
+
+```python
+from supertokens_python.recipe import userroles
+from supertokens_python.recipe.userroles import asyncio
+
+init(
+    supertokens_config=SupertokensConfig(connection_uri="https://try.supertokens.io"),
+    app_info=InputAppInfo(
+        app_name="Foo Bar",
+        api_domain="http://localhost:3000",
+        website_domain="http://localhost:8080", 
+    ),
+    framework="flask",
+    recipe_list=[
+        userroles.init()
+    ]
+)
+
+permission = "permission"
+result = await asyncio.get_roles_that_have_permission(permission)
+print(result.roles)
+```
+`result.roles` is a list of string which contains all the roles.
+
+## Remove Permission From Role
+
+* Permissions are list of string which can be removed from a role.
+
+```python
+from supertokens_python.recipe import userroles
+from supertokens_python.recipe.userroles import asyncio
+
+init(
+    supertokens_config=SupertokensConfig(connection_uri="https://try.supertokens.io"),
+    app_info=InputAppInfo(
+        app_name="Foo Bar",
+        api_domain="http://localhost:3000",
+        website_domain="http://localhost:8080", 
+    ),
+    framework="flask",
+    recipe_list=[
+        userroles.init()
+    ]
+)
+
+permission = ["permission"]
+role = "role"
+result = await asyncio.get_roles_that_have_permission(permission)
+print(result.roles)
+```
+
+`result.roles` is a list of string which contains all the roles.
+
+## Remove User Role
+
+```python
+from supertokens_python.recipe import userroles
+from supertokens_python.recipe.userroles import asyncio
+
+init(
+    supertokens_config=SupertokensConfig(connection_uri="https://try.supertokens.io"),
+    app_info=InputAppInfo(
+        app_name="Foo Bar",
+        api_domain="http://localhost:3000",
+        website_domain="http://localhost:8080", 
+    ),
+    framework="flask",
+    recipe_list=[
+        userroles.init()
+    ]
+)
+
+user_id = "user_id"
+role = "role_a"
+
+result_role_removed = await asyncio.remove_user_role(user_id, role)
+print(result_rule_removed.did_user_have_role)
+
+result_roles = await asyncio.get_roles_for_user(user_id)
+print(result_roles.roles)
+
+```
+
+`result_rule_removed.did_user_have_role` is a bool that returns true id the user had the role?
+
+
+`result.roles` is a list of string which contains all the roles. For user `user_id` the role `role_a` does not exist.
+
+
+## Delete Role
+
+* An existing role can be deleted.
+* Once deleted it is also removed from the users from the users.
+
+```python
+from supertokens_python.recipe import userroles
+from supertokens_python.recipe.userroles import asyncio
+
+init(
+    supertokens_config=SupertokensConfig(connection_uri="https://try.supertokens.io"),
+    app_info=InputAppInfo(
+        app_name="Foo Bar",
+        api_domain="http://localhost:3000",
+        website_domain="http://localhost:8080", 
+    ),
+    framework="flask",
+    recipe_list=[
+        userroles.init()
+    ]
+)
+
+role = "role"
+
+result = await asyncio.delete_role(role)
+print(result.did_role_exist)
+
+result = await asyncio.get_all_roles()
+print(result.roles)
+```
+`result.roles` is a list of string which contains all the roles.

--- a/v2/userroles/introduction.mdx
+++ b/v2/userroles/introduction.mdx
@@ -4,4 +4,17 @@ title: Introduction
 hide_title: true
 ---
 
-# Introduction
+# Features
+
+* Create new roles and assign it to a user.
+* Remove roles from a user
+* Add or remove permissions from a role.
+* Fetch all the roles.
+* Add or remove roles.
+
+import TechStackSupport from "../community/reusableMD/supported-tech-stacks-backend.mdx"
+
+## Supported tech stacks
+
+<TechStackSupport />
+

--- a/v2/userroles/sidebars.js
+++ b/v2/userroles/sidebars.js
@@ -1,5 +1,12 @@
 module.exports = {
   sidebar: [
-    "introduction"
+    "introduction",
+    {
+      type: 'category',
+      label: 'Backend Setup',
+      items: [
+        "backend/userroles-api",
+      ],
+    },
   ]
 };


### PR DESCRIPTION
Used supertoken-python userroles tests to create usage docs

https://github.com/supertokens/supertokens-python/tree/master/tests/userroles
https://supertokens.com/docs/python/recipe/userroles/index.html

## Summary of change
This is to add usage docs in python for userroles recipe.

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes) 
- [x] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Update existing python examples with userroles.