### PR TITLE
Add code code for moving nestjs service

### DIFF
--- a/v2/emailpassword/nestjs/guide.mdx
+++ b/v2/emailpassword/nestjs/guide.mdx
@@ -153,9 +153,56 @@ You can scaffold this service using the nest CLI by running this in the root fol
 ```bash
 nest g service supertokens auth
 ```
-:::important
-The nest CLI will add this service to the normal module providers, which you should move to the `providers` prop of the module returned in `forRoot`.
-:::
+
+### Move the new service into the dynamic module
+
+```ts
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  DynamicModule,
+} from '@nestjs/common';
+
+// @ts-ignore
+import { AuthMiddleware } from './auth.middleware';
+// @ts-ignore
+import { ConfigInjectionToken, AuthModuleConfig } from './config.interface';
+// @ts-ignore
+import { SupertokensService } from './supertokens/supertokens.service';
+
+@Module({
+  providers: [],
+  exports: [],
+  controllers: [],
+})
+export class AuthModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
+
+  static forRoot({ connectionURI, apiKey, appInfo }: AuthModuleConfig): DynamicModule {
+    return {
+      providers: [
+        {
+          useValue: {
+            appInfo,
+            connectionURI,
+            apiKey,
+          },
+          provide: ConfigInjectionToken,
+        },
+        SupertokensService,
+      ],
+      exports: [],
+      imports: [],
+      module: AuthModule,
+    };
+  }
+}
+```
+
+### Add service code
 
 We initialize the SDK in a service so that you can have access to injected services in event handlers. Edit the `supertokens.service.ts` to match:
 

--- a/v2/emailpassword/nestjs/guide.mdx
+++ b/v2/emailpassword/nestjs/guide.mdx
@@ -192,6 +192,7 @@ export class AuthModule implements NestModule {
           },
           provide: ConfigInjectionToken,
         },
+        // highlight-next-line
         SupertokensService,
       ],
       exports: [],

--- a/v2/passwordless/nestjs/guide.mdx
+++ b/v2/passwordless/nestjs/guide.mdx
@@ -153,9 +153,56 @@ You can scaffold this service using the nest CLI by running this in the root fol
 ```bash
 nest g service supertokens auth
 ```
-:::important
-The nest CLI will add this service to the normal module providers, which you should move to the `providers` prop of the module returned in `forRoot`.
-:::
+
+### Move the new service into the dynamic module
+
+```ts
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  DynamicModule,
+} from '@nestjs/common';
+
+// @ts-ignore
+import { AuthMiddleware } from './auth.middleware';
+// @ts-ignore
+import { ConfigInjectionToken, AuthModuleConfig } from './config.interface';
+// @ts-ignore
+import { SupertokensService } from './supertokens/supertokens.service';
+
+@Module({
+  providers: [],
+  exports: [],
+  controllers: [],
+})
+export class AuthModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
+
+  static forRoot({ connectionURI, apiKey, appInfo }: AuthModuleConfig): DynamicModule {
+    return {
+      providers: [
+        {
+          useValue: {
+            appInfo,
+            connectionURI,
+            apiKey,
+          },
+          provide: ConfigInjectionToken,
+        },
+        SupertokensService,
+      ],
+      exports: [],
+      imports: [],
+      module: AuthModule,
+    };
+  }
+}
+```
+
+### Add service code
 
 We initialize the SDK in a service so that you can have access to injected services in event handlers. Edit the `supertokens.service.ts` to match:
 

--- a/v2/passwordless/nestjs/guide.mdx
+++ b/v2/passwordless/nestjs/guide.mdx
@@ -192,6 +192,7 @@ export class AuthModule implements NestModule {
           },
           provide: ConfigInjectionToken,
         },
+        // highlight-next-line
         SupertokensService,
       ],
       exports: [],

--- a/v2/session/nestjs/guide.mdx
+++ b/v2/session/nestjs/guide.mdx
@@ -154,9 +154,56 @@ You can scaffold this service using the nest CLI by running this in the root fol
 ```bash
 nest g service supertokens auth
 ```
-:::important
-The nest CLI will add this service to the normal module providers, which you should move to the `providers` prop of the module returned in `forRoot`.
-:::
+
+### Move the new service into the dynamic module
+
+```ts
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  DynamicModule,
+} from '@nestjs/common';
+
+// @ts-ignore
+import { AuthMiddleware } from './auth.middleware';
+// @ts-ignore
+import { ConfigInjectionToken, AuthModuleConfig } from './config.interface';
+// @ts-ignore
+import { SupertokensService } from './supertokens/supertokens.service';
+
+@Module({
+  providers: [],
+  exports: [],
+  controllers: [],
+})
+export class AuthModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
+
+  static forRoot({ connectionURI, apiKey, appInfo }: AuthModuleConfig): DynamicModule {
+    return {
+      providers: [
+        {
+          useValue: {
+            appInfo,
+            connectionURI,
+            apiKey,
+          },
+          provide: ConfigInjectionToken,
+        },
+        SupertokensService,
+      ],
+      exports: [],
+      imports: [],
+      module: AuthModule,
+    };
+  }
+}
+```
+
+### Add service code
 
 We initialize the SDK in a service so that you can have access to injected services in event handlers. Edit the `supertokens.service.ts` to match:
 

--- a/v2/session/nestjs/guide.mdx
+++ b/v2/session/nestjs/guide.mdx
@@ -193,6 +193,7 @@ export class AuthModule implements NestModule {
           },
           provide: ConfigInjectionToken,
         },
+        // highlight-next-line
         SupertokensService,
       ],
       exports: [],

--- a/v2/thirdparty/nestjs/guide.mdx
+++ b/v2/thirdparty/nestjs/guide.mdx
@@ -197,6 +197,7 @@ export class AuthModule implements NestModule {
           },
           provide: ConfigInjectionToken,
         },
+        // highlight-next-line
         SupertokensService,
       ],
       exports: [],

--- a/v2/thirdparty/nestjs/guide.mdx
+++ b/v2/thirdparty/nestjs/guide.mdx
@@ -158,9 +158,56 @@ You can scaffold this service using the nest CLI by running this in the root fol
 ```bash
 nest g service supertokens auth
 ```
-:::important
-The nest CLI will add this service to the normal module providers, which you should move to the `providers` prop of the module returned in `forRoot`.
-:::
+
+### Move the new service into the dynamic module
+
+```ts
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  DynamicModule,
+} from '@nestjs/common';
+
+// @ts-ignore
+import { AuthMiddleware } from './auth.middleware';
+// @ts-ignore
+import { ConfigInjectionToken, AuthModuleConfig } from './config.interface';
+// @ts-ignore
+import { SupertokensService } from './supertokens/supertokens.service';
+
+@Module({
+  providers: [],
+  exports: [],
+  controllers: [],
+})
+export class AuthModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
+
+  static forRoot({ connectionURI, apiKey, appInfo }: AuthModuleConfig): DynamicModule {
+    return {
+      providers: [
+        {
+          useValue: {
+            appInfo,
+            connectionURI,
+            apiKey,
+          },
+          provide: ConfigInjectionToken,
+        },
+        SupertokensService,
+      ],
+      exports: [],
+      imports: [],
+      module: AuthModule,
+    };
+  }
+}
+```
+
+### Add service code
 
 We initialize the SDK in a service so that you can have access to injected services in event handlers. Edit the `supertokens.service.ts` to match:
 

--- a/v2/thirdpartyemailpassword/nestjs/guide.mdx
+++ b/v2/thirdpartyemailpassword/nestjs/guide.mdx
@@ -196,6 +196,7 @@ export class AuthModule implements NestModule {
           },
           provide: ConfigInjectionToken,
         },
+        // highlight-next-line
         SupertokensService,
       ],
       exports: [],

--- a/v2/thirdpartyemailpassword/nestjs/guide.mdx
+++ b/v2/thirdpartyemailpassword/nestjs/guide.mdx
@@ -157,9 +157,56 @@ You can scaffold this service using the nest CLI by running this in the root fol
 ```bash
 nest g service supertokens auth
 ```
-:::important
-The nest CLI will add this service to the normal module providers, which you should move to the `providers` prop of the module returned in `forRoot`.
-:::
+
+### Move the new service into the dynamic module
+
+```ts
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  DynamicModule,
+} from '@nestjs/common';
+
+// @ts-ignore
+import { AuthMiddleware } from './auth.middleware';
+// @ts-ignore
+import { ConfigInjectionToken, AuthModuleConfig } from './config.interface';
+// @ts-ignore
+import { SupertokensService } from './supertokens/supertokens.service';
+
+@Module({
+  providers: [],
+  exports: [],
+  controllers: [],
+})
+export class AuthModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
+
+  static forRoot({ connectionURI, apiKey, appInfo }: AuthModuleConfig): DynamicModule {
+    return {
+      providers: [
+        {
+          useValue: {
+            appInfo,
+            connectionURI,
+            apiKey,
+          },
+          provide: ConfigInjectionToken,
+        },
+        SupertokensService,
+      ],
+      exports: [],
+      imports: [],
+      module: AuthModule,
+    };
+  }
+}
+```
+
+### Add service code
 
 We initialize the SDK in a service so that you can have access to injected services in event handlers. Edit the `supertokens.service.ts` to match:
 

--- a/v2/thirdpartypasswordless/nestjs/guide.mdx
+++ b/v2/thirdpartypasswordless/nestjs/guide.mdx
@@ -153,9 +153,56 @@ You can scaffold this service using the nest CLI by running this in the root fol
 ```bash
 nest g service supertokens auth
 ```
-:::important
-The nest CLI will add this service to the normal module providers, which you should move to the `providers` prop of the module returned in `forRoot`.
-:::
+
+### Move the new service into the dynamic module
+
+```ts
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  DynamicModule,
+} from '@nestjs/common';
+
+// @ts-ignore
+import { AuthMiddleware } from './auth.middleware';
+// @ts-ignore
+import { ConfigInjectionToken, AuthModuleConfig } from './config.interface';
+// @ts-ignore
+import { SupertokensService } from './supertokens/supertokens.service';
+
+@Module({
+  providers: [],
+  exports: [],
+  controllers: [],
+})
+export class AuthModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
+
+  static forRoot({ connectionURI, apiKey, appInfo }: AuthModuleConfig): DynamicModule {
+    return {
+      providers: [
+        {
+          useValue: {
+            appInfo,
+            connectionURI,
+            apiKey,
+          },
+          provide: ConfigInjectionToken,
+        },
+        SupertokensService,
+      ],
+      exports: [],
+      imports: [],
+      module: AuthModule,
+    };
+  }
+}
+```
+
+### Add service code
 
 We initialize the SDK in a service so that you can have access to injected services in event handlers. Edit the `supertokens.service.ts` to match:
 

--- a/v2/thirdpartypasswordless/nestjs/guide.mdx
+++ b/v2/thirdpartypasswordless/nestjs/guide.mdx
@@ -192,6 +192,7 @@ export class AuthModule implements NestModule {
           },
           provide: ConfigInjectionToken,
         },
+        // highlight-next-line
         SupertokensService,
       ],
       exports: [],


### PR DESCRIPTION
## Summary of change
In nestJS guide, give code snippet for "The nest CLI will add this service to the normal module providers, which you should move to the `providers` prop of the module returned in `forRoot`." step.

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
