### PR TITLE
Fix appInfoForm error when default ports are selected for domain

### DIFF
--- a/v2/src/components/appInfoForm/normalisedURLDomain.ts
+++ b/v2/src/components/appInfoForm/normalisedURLDomain.ts
@@ -24,13 +24,18 @@ function normaliseURLDomainOrThrowError(input: string, ignoreProtocol = false): 
         }
         const urlObj: URL = new URL(input);
         if (ignoreProtocol) {
-            if (urlObj.hostname.startsWith("localhost") || isAnIpAddress(urlObj.hostname)) {
+            if (
+                (urlObj.hostname.startsWith("localhost") && urlObj.host !== "localhost:443") ||
+                isAnIpAddress(urlObj.hostname)
+            ) {
                 input = "http://" + urlObj.host + urlObj.pathname;
             } else {
                 input = "https://" + urlObj.host + urlObj.pathname;
             }
-        } else {
+        } else if (!(urlObj.protocol === "http:" && urlObj.host === "localhost:443")) {
             input = urlObj.protocol + "//" + urlObj.host + urlObj.pathname;
+        } else {
+            input = "https://localhost" + urlObj.pathname;
         }
         return input;
         // eslint-disable-next-line no-empty
@@ -51,7 +56,7 @@ function normaliseURLDomainOrThrowError(input: string, ignoreProtocol = false): 
         !input.startsWith("http://") &&
         !input.startsWith("https://")
     ) {
-        input = "https://" + input;
+        input = (input.startsWith("localhost") ? "http://" : "https://") + input;
         // at this point, it should be a valid URL. So we test that before doing a recursive call
         try {
             new URL(input);

--- a/v2/src/components/appInfoForm/normalisedURLDomain.ts
+++ b/v2/src/components/appInfoForm/normalisedURLDomain.ts
@@ -32,7 +32,7 @@ function normaliseURLDomainOrThrowError(input: string, ignoreProtocol = false): 
             } else {
                 input = "https://" + urlObj.host + urlObj.pathname;
             }
-        } else if (!(urlObj.protocol === "http:" && urlObj.host === "localhost:443")) {
+        } else if (urlObj.protocol !== "http:" || urlObj.host !== "localhost:443") {
             input = urlObj.protocol + "//" + urlObj.host + urlObj.pathname;
         } else {
             input = "https://localhost" + urlObj.pathname;


### PR DESCRIPTION
## Summary of change
- When the user inputs `localhost:443`, AppInfoForm now normalises the domain to `https://localhost` instead of `http://localhost`

## Related issues
- #278 

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Remaining TODOs for this PR
No TODOs remaining