### PR TITLE
Move Drift chat icon above the menu button in v2 docs tablet view

### DIFF
--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -508,3 +508,14 @@ html[data-theme="dark"] .markdown blockquote {
 html[data-theme="dark"] .markdown blockquote > *:last-child {
   margin-bottom: 0px !important;
 }
+
+/* styles for drift chat elements */
+@media screen and (max-width: 996px) {
+  #drift-frame-controller {
+    bottom: 80px !important;
+  }
+
+  #drift-frame-chat {
+    bottom: 144px !important;
+  }
+}


### PR DESCRIPTION
## Summary of change
- Show the Drift chat button above v2 docs menu button so that it does not overlap

## Related issues
- #304 

## Checklist
- [ ] ~Algolia search needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Sitemap needs to be updated? (If there is a new sub docs project, then yes)~
- [ ] ~Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)~
- [ ] ~Changes required to the demo apps corresponding to the docs?~

## Demo
- [Drive video link](https://drive.google.com/file/d/1cPYd0Qg1Zi9CAMpxC0-dYoYccUVhPxs5/view?usp=sharing)