### PR TITLE
fix: only expand the first appInfoForm

### DIFF
--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -36,11 +36,19 @@ type State = {
     // TODO: Add more fields here
 };
 
+
+const CONTAINER_ATTRIBUTE_NAME = 'display-form';
+const CONTAINER_CLASSNAME = "app-info-form-outer";
+const isAttributeDisplayChanges = (mutations: MutationRecord[]) => {
+    return mutations.some(mutation => {
+        const attributeName = mutation.attributeName;
+        return mutation.type === 'attributes' && attributeName === CONTAINER_ATTRIBUTE_NAME && (mutation.target as HTMLElement).getAttribute(attributeName) === 'true';
+    });
+}
+
 export default class AppInfoForm extends React.PureComponent<PropsWithChildren<Props>, State> {
-    private readonly containerDisplayAttrName = 'display-form';
-    private readonly containerClassName = "app-info-form-outer";
-    private readonly attributesChangesObserver = this.getAttributesChangesObserver();
-    containerRef: React.RefObject<HTMLDivElement>
+    private readonly attributesChangesObserver = new MutationObserver(this.attributeObserver.bind(this));
+    private readonly containerRef: React.RefObject<HTMLDivElement>
 
     constructor(props: PropsWithChildren<Props>) {
         super(props);
@@ -163,7 +171,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
 
     readonly resubmitFirstAppInfoForm = (event?: Pick<Event, 'preventDefault'>) => {
         event?.preventDefault()
-        document.querySelector(`.${this.containerClassName}`)?.setAttribute(this.containerDisplayAttrName, 'true')
+        document.querySelector(`.${CONTAINER_CLASSNAME}`)?.setAttribute(CONTAINER_ATTRIBUTE_NAME, 'true')
     }
 
     resubmitInfoClicked = (event?: Pick<Event, 'preventDefault'>) => {
@@ -252,8 +260,8 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     )
 
     render() {
-        const attributes = {[this.containerDisplayAttrName]: `${!this.state.formSubmitted}`}
-        return <div className={this.containerClassName} ref={this.containerRef} {...attributes}>{this.state.formSubmitted ? this.renderInfo() : this.renderForm()}</div>;        
+        const attributes = {[CONTAINER_ATTRIBUTE_NAME]: `${!this.state.formSubmitted}`}
+        return <div className={CONTAINER_CLASSNAME} ref={this.containerRef} {...attributes}>{this.state.formSubmitted ? this.renderInfo() : this.renderForm()}</div>;        
     }
 
     renderInfo() {
@@ -753,16 +761,11 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         }
     }
 
-    private getAttributesChangesObserver() {
-        return new MutationObserver((mutations, _) => {
-            const shouldDisplayForm = mutations.some(mutation => {
-                const attributeName = mutation.attributeName;
-                return mutation.type === 'attributes' && attributeName === this.containerDisplayAttrName && (mutation.target as HTMLElement).getAttribute(attributeName) === 'true';
-            });
-            if (shouldDisplayForm) {
-                this.resubmitInfoClicked();
-                this.scrollToElement();
-            }
-        });
+    private attributeObserver(mutations: MutationRecord[]) {
+        const shouldDisplayForm = isAttributeDisplayChanges(mutations);
+        if (shouldDisplayForm) {
+            this.resubmitInfoClicked();
+            this.scrollToElement();
+        }
     }
 }

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -44,7 +44,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
 
     constructor(props: PropsWithChildren<Props>) {
         super(props);
-         this.containerRef = React.createRef<HTMLDivElement>();
+        this.containerRef = React.createRef<HTMLDivElement>();
         // TODO: Add more fields here
         if (!props.askForAPIDomain && !props.askForAppName &&
             !props.askForWebsiteDomain && !props.askForWebsiteBasePath && !props.askForAPIBasePath) {

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -47,7 +47,7 @@ const isAttributeDisplayChanges = (mutations: MutationRecord[]) => {
 }
 
 export default class AppInfoForm extends React.PureComponent<PropsWithChildren<Props>, State> {
-    private readonly attributesChangesObserver = new MutationObserver(this.attributeObserver.bind(this));
+    private readonly attributesChangesObserver = new MutationObserver(this.attributeObserverCallback.bind(this));
     private readonly containerRef: React.RefObject<HTMLDivElement>
 
     constructor(props: PropsWithChildren<Props>) {
@@ -761,7 +761,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         }
     }
 
-    private attributeObserver(mutations: MutationRecord[]) {
+    private attributeObserverCallback(mutations: MutationRecord[]) {
         const shouldDisplayForm = isAttributeDisplayChanges(mutations);
         if (shouldDisplayForm) {
             this.resubmitInfoClicked();


### PR DESCRIPTION
## Summary of change
- utilizing DOM attributes and Mutation Observer
- store the `display-form` state as DOM attribute
- when user click the resubmit, it will find the first `appInfoForm`, and then update `display-form` attribute
- Mutation Observer of the  first `appInfoForm` then listen to the attribute changes, and then display the form which also scroll the form to the top
- refactor render method and break it into 2 methods

## Related issues
- https://github.com/supertokens/main-website/issues/879