### PR TITLE
fix: Single app info form 

### DIFF
--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -33,17 +33,21 @@ type State = {
     netlifyApiRouteUsed: boolean,
     showWebsiteBasePath: boolean,
     showAPIBasePath: boolean
+    /** Whether current element is the first visible AppInfoForm */
     firstAppInfoForm?: boolean
     // TODO: Add more fields here
 };
 
 type ResubmitParams = {
     event?: Pick<Event, 'preventDefault'>;
+    /** Scroll page to current form when its resubmitted */
     scrollToElement?: boolean;
 };
 
+/** attribute name that is used to trigger resubmitting the form */
 const CONTAINER_ATTRIBUTE_DISPLAY = 'display-form';
-const CONTAINER_ATTRIBUTE_FIRST_FORM = 'display-form';
+/** attribute name that is used to indicate current first form */
+const CONTAINER_ATTRIBUTE_FIRST_FORM = 'first-form';
 const CONTAINER_CLASSNAME = "app-info-form-outer";
 /**
  * Check if the mutations receive the matched attribute name & value
@@ -56,13 +60,20 @@ const isReceivingAttr = (mutations: MutationRecord[], attributeName: string, att
             && (attributeValue == null || (mutation.target as HTMLElement).getAttribute(attributeName) === attributeValue);
     });
 }
+/** Check whether it contains element attributes that triggers resubmitting the form */
 const isReceivingDisplayAttr = (mutations: MutationRecord[]) => isReceivingAttr(mutations, CONTAINER_ATTRIBUTE_DISPLAY, 'true')
+/** Check whether its contains element attributes that triggers rechecking current first form */
 const isReceivingFirstFormAttr = (mutations: MutationRecord[]) => isReceivingAttr(mutations, CONTAINER_ATTRIBUTE_FIRST_FORM)
 
 const isElementVisible = (element?: Element | null): boolean => element != null && element?.clientWidth > 0 && element.clientHeight > 0;
 const getFirstAppInfoForm = () => {
     return Array.from(document.querySelectorAll(`.${CONTAINER_CLASSNAME}`)).find(isElementVisible);
 }
+/** 
+ * Check first AppInfoForm by element's id 
+ * @param id AppInfoForm.elementId 
+ * @returns 
+ */
 const isFirstAppInfoForm = (id: string) => getFirstAppInfoForm()?.id === id
 
 export default class AppInfoForm extends React.PureComponent<PropsWithChildren<Props>, State> {

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -319,7 +319,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     render() {        
         const customAttributes: Record<string, string | undefined> = {}
         if (this.state.firstAppInfoForm) { customAttributes[CONTAINER_ATTRIBUTE_FIRST_FORM] = undefined }
-        return <div id={this.elementId.toString()} className={CONTAINER_CLASSNAME} ref={this.containerRef}>            
+        return <div id={this.elementId.toString()} className={CONTAINER_CLASSNAME} ref={this.containerRef}> 
             {(!this.state.formSubmitted && this.state.firstAppInfoForm) && this.renderForm()}
             {this.renderInfo()}
         </div>;        
@@ -634,8 +634,8 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                     appName: this.state.appName || currentLocalStorageParsedFormData.appName,
                     apiDomain: this.state.apiDomain || currentLocalStorageParsedFormData.apiDomain,
                     websiteDomain: this.state.websiteDomain || currentLocalStorageParsedFormData.websiteDomain,
-                    websiteBasePath: this.state.showWebsiteBasePath ? this.state.websiteBasePath : currentLocalStorageParsedFormData.websiteBasePath,
-                    apiBasePath: this.state.showAPIBasePath ? this.state.apiBasePath : currentLocalStorageParsedFormData.apiBasePath,
+                    websiteBasePath: this.state.websiteBasePath || currentLocalStorageParsedFormData.websiteBasePath,
+                    apiBasePath: this.state.apiBasePath || currentLocalStorageParsedFormData.apiBasePath,
                     nextJSApiRouteUsed: this.state.nextJSApiRouteUsed,
                     netlifyApiRouteUsed: this.state.netlifyApiRouteUsed,
                     formSubmitted: this.state.formSubmitted
@@ -711,7 +711,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         }
 
         // validate apiDomain field
-        if (this.props.askForAPIDomain && (!this.props.showNextJSAPIRouteCheckbox || (this.props.showNextJSAPIRouteCheckbox && !this.state.nextJSApiRouteUsed))) {
+        if ((this.props.askForAPIDomain || apiDomain) && (!this.props.showNextJSAPIRouteCheckbox || (this.props.showNextJSAPIRouteCheckbox && !this.state.nextJSApiRouteUsed))) {
             if (apiDomain.length > 0) {
                 const error = this.validateDomain(apiDomain, "apiDomain", "apiBasePath");
                 if (error.length > 0) {
@@ -723,7 +723,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         }
 
         // validate websiteDomain field
-        if (this.props.askForWebsiteDomain) {
+        if (this.props.askForWebsiteDomain || websiteDomain) {
             if (websiteDomain.length > 0) {
                 const error = this.validateDomain(websiteDomain, "websiteDomain", "websiteBasePath");
                 if (error.length > 0) {
@@ -734,7 +734,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             }
         }
 
-        if (this.state.showAPIBasePath) {
+        if (this.state.showAPIBasePath || apiBasePath) {
             const netlifyApiRouteUsed = this.props.showNetlifyAPIRouteCheckbox && this.state.netlifyApiRouteUsed;
             const nextJSApiRouteUsed = this.props.showNextJSAPIRouteCheckbox && this.state.nextJSApiRouteUsed;
 
@@ -767,7 +767,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             }
         }
 
-        if (this.state.showWebsiteBasePath) {
+        if (this.state.showWebsiteBasePath || websiteBasePath) {
             if (preventErrorUpdateInState && (!localFormDataParsed || localFormDataParsed.websiteBasePath === undefined)) {
                 // we do this check in case the user has not submitted the form
                 // in which case the base path fields will have the default '/auth'
@@ -777,7 +777,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             }
         }
 
-        if (this.state.showAPIBasePath && this.state.showWebsiteBasePath && !validationErrors.apiBasePath && !validationErrors.websiteBasePath) {
+        if ((this.state.showAPIBasePath || apiBasePath) && (this.state.showWebsiteBasePath || websiteBasePath) && !validationErrors.apiBasePath && !validationErrors.websiteBasePath) {
             const normalisedApiDomain = this.getDomainOriginOrEmptyString(apiDomain);
             const normalisedWebsiteDomain = this.getDomainOriginOrEmptyString(websiteDomain);
             const normalisedApiBasePath = this.getNormalisedBasePath(apiBasePath);
@@ -804,7 +804,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 ...oldState,
                 fieldErrors: validationErrors
             }))
-        }
+        }        
 
         return Object.keys(validationErrors).length === 0;
     }

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -45,6 +45,9 @@ type ResubmitParams = {
 const CONTAINER_ATTRIBUTE_DISPLAY = 'display-form';
 const CONTAINER_ATTRIBUTE_FIRST_FORM = 'display-form';
 const CONTAINER_CLASSNAME = "app-info-form-outer";
+/**
+ * Check if the mutations receive the matched attribute name & value
+ */
 const isReceivingAttr = (mutations: MutationRecord[], attributeName: string, attributeValue?: string) => {
     return mutations.some(mutation => {
         const mutationAttributeName = mutation.attributeName;
@@ -193,9 +196,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
 
     readonly resubmitFirstAppInfoForm = (event?: ResubmitParams['event']) => {
         event?.preventDefault()
-        document.querySelectorAll(`.${CONTAINER_CLASSNAME}[${CONTAINER_ATTRIBUTE_FIRST_FORM}]`).forEach(element => {
-            element.setAttribute(CONTAINER_ATTRIBUTE_FIRST_FORM, '')
-        })
+        this.recheckCurrentFirstAppInfoForm();
         getFirstAppInfoForm()?.setAttribute(CONTAINER_ATTRIBUTE_DISPLAY, 'true')
     }
 
@@ -796,9 +797,11 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     }
 
     private onReceiveAttribute(mutations: MutationRecord[]) {
+        // listen event triggered by recheckCurrentFirstAppInfoForm()
         if (isReceivingFirstFormAttr(mutations)) {
             this.setState({ firstAppInfoForm: this.isFirstVisibleAppInfoForm() })
         }
+        // listen event triggered by resubmitFirstAppInfoForm()
         if (isReceivingDisplayAttr(mutations)) {
             this.resubmitInfoClicked({scrollToElement: true});
         }
@@ -806,5 +809,16 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
 
     private isFirstVisibleAppInfoForm(): boolean {
         return Boolean(isElementVisible(this.containerRef?.current) && isFirstAppInfoForm(`${this.elementId}`));
+    }
+
+    /**
+     * Trigger rechecking on current first app info form
+     ** This is to solve when there is form is inside a details element, 
+     and then there is another form that share same parent with the details 
+     */
+    private recheckCurrentFirstAppInfoForm() {
+        document.querySelectorAll(`.${CONTAINER_CLASSNAME}[${CONTAINER_ATTRIBUTE_FIRST_FORM}]`).forEach(element => {
+            element.setAttribute(CONTAINER_ATTRIBUTE_FIRST_FORM, '');
+        });
     }
 }

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -79,10 +79,8 @@ const isFirstAppInfoForm = (id: string) => getFirstAppInfoForm()?.id === id
 export default class AppInfoForm extends React.PureComponent<PropsWithChildren<Props>, State> {
     private readonly elementId = (new Date()).getTime()
     private readonly containerRef: React.RefObject<HTMLDivElement>
-    private readonly attributeObserver = new MutationObserver(this.onReceiveAttribute.bind(this));
-    private readonly visibilityObserver = new IntersectionObserver(() => this.setState({ 
-        firstAppInfoForm: this.isFirstVisibleAppInfoForm()
-    }))
+    private attributeObserver?: MutationObserver;
+    private visibilityObserver?: IntersectionObserver;
 
     constructor(props: PropsWithChildren<Props>) {
         super(props);
@@ -125,6 +123,10 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         const canContinue = this.canContinue(true)
 
         // listen to DOM changes 
+        this.attributeObserver = new MutationObserver(this.onReceiveAttribute.bind(this));
+        this.visibilityObserver = new IntersectionObserver(() => this.setState({ 
+            firstAppInfoForm: this.isFirstVisibleAppInfoForm()
+        }))
         this.attributeObserver.observe(this.containerRef.current!, { attributes: true });
         this.visibilityObserver.observe(this.containerRef.current!);
 
@@ -201,8 +203,8 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         if (typeof window !== 'undefined') {
             window.removeEventListener("appInfoFormFilled", this.anotherFormFilled);
         }
-        this.attributeObserver.disconnect()
-        this.visibilityObserver.disconnect()
+        this.attributeObserver?.disconnect()
+        this.visibilityObserver?.disconnect()
     }
 
     readonly resubmitFirstAppInfoForm = (event?: ResubmitParams['event']) => {

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -404,21 +404,13 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                     color: "#ffffff",
                 }}
                 className="app-info-form-container"
-            >
+            >                
                 <div
+                    className="app-info-form-container-link"
                     style={{
                         fontSize: "14px",
                         fontWeight: 600,
-                        textTransform: "uppercase"
-                    }}>
-                    Please fill the form below to see the code snippet <span
-                        style={{
-                            color: "#ff6161"
-                        }}>(* = Required)</span>
-                </div>
-                <div
-                    className="app-info-form-container-link"
-                    style={{ marginTop: "10px" }}
+                    }}
                 >
                     To learn more about what these properties mean read <a href="/docs/thirdpartyemailpassword/appinfo">here</a>.
                 </div>
@@ -801,9 +793,10 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     }
 
     scrollToElement() {
-        if (Boolean(this.containerRef.current)) {
+        if (Boolean(this.containerRef.current)) {            
+            const topPositionAfterNavbar = window.scrollY + (this.containerRef.current?.getBoundingClientRect().top ?? 0) - (document.querySelector('nav.navbar')?.clientHeight ?? 0);
             window.scrollTo({
-                top: window.scrollY + (this.containerRef.current?.parentElement?.getBoundingClientRect().top ?? 0),
+                top: topPositionAfterNavbar,
                 behavior: 'smooth'
             });
         }

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -5,6 +5,23 @@ import NormalisedURLDomain from "./normalisedURLDomain";
 import NormalisedURLPath from "./normalisedURLPath";
 import { recursiveMap } from "../utils";
 
+/**
+ * The AppInfoForm component is now designed to allow only open the first visible form on the page. 
+ * When a user tried to resubmit a second, third or fourth form, then it will not open the selected AppInfoForm. Instead, it will open the first AppInfoFormand scroll to it.
+ * We use DOM attribute CONTAINER_ATTRIBUTE_DISPLAY as the way to communicate to the first AppInfoForm. This is done by calling AppInfoForm.resubmitFirstAppInfoForm().
+ * When a form is receiving "CONTAINER_ATTRIBUTE_DISPLAY=true", then it will open the form.
+ * The form is listening to this attribute's changes by using `AppInfoForm.attributeObserver:MutationObserver` that is utilizing isReceivingFirstFormAttr() and AppInfoForm.onReceiveAttribute().
+ * 
+ * Beside the above event, we also have a way to recognize which is the first visible form. The form considered to be the first visible form when its height and width are not zero(function isElementVisible()). 
+ * Then, we use isFirstAppInfoForm() and getFirstAppInfoForm() to indicate whether a form is a first visible one. The first form will also have attribut CONTAINER_ATTRIBUTE_FIRST_FORM attached in the DOM.
+ * 
+ * There is also case when user switches between tabs, which will affect the visibility of the form.
+ * We expect this will triggers re-updating which one is the first visible form. Therefore, `AppInfoForm.visibilityObserver: IntersectionObserver` is created to listen to any visibility changes on the form.
+ * 
+ * There is also an edge case where a form is located inside a `details` element. When `details` opens or closes, it will not notify the IntersectionObserver. 
+ * So, we add AppInfoForm.recheckCurrentFirstAppInfoForm() to trigger the visibilty status update by sending an event to element that has CONTAINER_ATTRIBUTE_FIRST_FORM attribute.
+ */
+
 type Props = {
     askForAppName: boolean,
     askForAPIDomain: boolean,
@@ -614,9 +631,9 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 }
 
                 const newLocalStorageFormData = {
-                    appName: this.props.askForAppName ? this.state.appName : currentLocalStorageParsedFormData.appName,
-                    apiDomain: this.props.askForAPIDomain ? this.state.apiDomain : currentLocalStorageParsedFormData.apiDomain,
-                    websiteDomain: this.props.askForWebsiteDomain ? this.state.websiteDomain : currentLocalStorageParsedFormData.websiteDomain,
+                    appName: this.state.appName || currentLocalStorageParsedFormData.appName,
+                    apiDomain: this.state.apiDomain || currentLocalStorageParsedFormData.apiDomain,
+                    websiteDomain: this.state.websiteDomain || currentLocalStorageParsedFormData.websiteDomain,
                     websiteBasePath: this.state.showWebsiteBasePath ? this.state.websiteBasePath : currentLocalStorageParsedFormData.websiteBasePath,
                     apiBasePath: this.state.showAPIBasePath ? this.state.apiBasePath : currentLocalStorageParsedFormData.apiBasePath,
                     nextJSApiRouteUsed: this.state.nextJSApiRouteUsed,

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -276,8 +276,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     )
 
     render() {        
-        return <div id={this.elementId.toString()} className={CONTAINER_CLASSNAME} ref={this.containerRef}>
-            <b>{this.elementId}</b>
+        return <div id={this.elementId.toString()} className={CONTAINER_CLASSNAME} ref={this.containerRef}>            
             {(!this.state.formSubmitted && this.state.firstAppInfoForm) && this.renderForm()}
             {this.renderInfo()}
         </div>;        

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -551,9 +551,7 @@ html[data-theme="dark"] .markdown blockquote>*:last-child {
 details {
   position: relative;
   border-top: 1px solid var(--ifm-toc-border-color);
-  ;
   border-bottom: 1px solid var(--ifm-toc-border-color);
-  ;
 }
 
 details>summary {

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -481,7 +481,7 @@ html[data-theme='dark'] .tabs-container .app-info-form-question-container {
 }
 
 html[data-theme='dark'] .tabs-container .app-info-form-container {
-  margin-bottom: 0px;
+  margin-bottom: 1.25rem;
   border: 0px;
 }
 

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -562,3 +562,7 @@ details[open] > summary {
 details[open] > summary::before {
   transform: rotate(45deg);  
 }
+
+details:not([open]) > *:not(summary) { /* Workaround to make the details' content have zero height & width */
+  display: none;
+}


### PR DESCRIPTION
## Summary of change
- utilizing DOM attributes, Mutation Observer & InterractionObserver
- when user click the resubmit, it will find the first `appInfoForm`, and then update `display-form` DOM attribute
- Mutation Observer that listen to the attribute changes
- refactor render method and break it into 2 methods
- workaround on details element

## Related issues
- https://github.com/supertokens/main-website/issues/879
- #408 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
NA