### PR TITLE
fix: avoid run isMobile on SSG

### DIFF
--- a/v2/src/theme/NavbarItem/RecipeLabelItem.js
+++ b/v2/src/theme/NavbarItem/RecipeLabelItem.js
@@ -1,18 +1,15 @@
 import React from 'react';
-import { isMobile } from 'react-device-detect';
+import { BrowserView, isMobile } from 'react-device-detect';
 import GuidesLink from "../../components/guidesLink";
 
 export default function RecipeLabelItem(props) {
-    if (isMobile) {
-        return null;
-    }
-    return (
-        <span
-            style={{
-                fontSize: "16px",
-                fontStyle: "italic"
-            }}>{props.label}<span style={{
-                fontStyle: "normal"
-            }}>{" | "}</span><GuidesLink>See All Recipes</GuidesLink></span>
-    );
+    return <BrowserView>{
+        !isMobile && <span
+        style={{
+            fontSize: "16px",
+            fontStyle: "italic"
+        }}>{props.label}<span style={{
+            fontStyle: "normal"
+        }}>{" | "}</span><GuidesLink>See All Recipes</GuidesLink></span>
+    }</BrowserView>
 }

--- a/v2/src/theme/NavbarItem/RecipeLabelItem.js
+++ b/v2/src/theme/NavbarItem/RecipeLabelItem.js
@@ -4,7 +4,7 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
 import GuidesLink from "../../components/guidesLink";
 
 export default function RecipeLabelItem(props) {
-    return <BrowserOnly>{
+    return <BrowserOnly>{() =>
         !isMobile && <span
         style={{
             fontSize: "16px",

--- a/v2/src/theme/NavbarItem/RecipeLabelItem.js
+++ b/v2/src/theme/NavbarItem/RecipeLabelItem.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import { BrowserView, isMobile } from 'react-device-detect';
+import { isMobile } from 'react-device-detect';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import GuidesLink from "../../components/guidesLink";
 
 export default function RecipeLabelItem(props) {
-    return <BrowserView>{
+    return <BrowserOnly>{
         !isMobile && <span
         style={{
             fontSize: "16px",
@@ -11,5 +12,5 @@ export default function RecipeLabelItem(props) {
         }}>{props.label}<span style={{
             fontStyle: "normal"
         }}>{" | "}</span><GuidesLink>See All Recipes</GuidesLink></span>
-    }</BrowserView>
+    }</BrowserOnly>
 }


### PR DESCRIPTION
## Summary of change
only run `isMobile` on browser and not during SSG

## Related issues
- #450 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
NA