### PR TITLE
Fix: The new Single app info form branch

### DIFF
--- a/v2/emailpassword/nextjs/session-verification/in-api.mdx
+++ b/v2/emailpassword/nextjs/session-verification/in-api.mdx
@@ -36,6 +36,7 @@ supertokens.init(backendConfig())
 <AppInfoForm
     askForWebsiteDomain
     hideWebsiteBasePathField
+    showNextJSAPIRouteCheckbox
 >
 
 ```tsx title="pages/api/user.ts"

--- a/v2/emailpassword/nextjs/setting-up-backend.mdx
+++ b/v2/emailpassword/nextjs/setting-up-backend.mdx
@@ -25,6 +25,7 @@ We will add all the backend APIs for auth on `/api/auth`. This can be changed by
 <AppInfoForm
   askForWebsiteDomain
   hideWebsiteBasePathField
+  showNextJSAPIRouteCheckbox
 >
 
 ```tsx title="pages/api/auth/[[...path]].ts"

--- a/v2/passwordless/nextjs/session-verification/in-api.mdx
+++ b/v2/passwordless/nextjs/session-verification/in-api.mdx
@@ -36,6 +36,7 @@ supertokens.init(backendConfig())
 <AppInfoForm
     askForWebsiteDomain
     hideWebsiteBasePathField
+    showNextJSAPIRouteCheckbox
 >
 
 ```tsx title="pages/api/user.ts"

--- a/v2/passwordless/nextjs/setting-up-backend.mdx
+++ b/v2/passwordless/nextjs/setting-up-backend.mdx
@@ -25,6 +25,7 @@ We will add all the backend APIs for auth on `/api/auth`. This can be changed by
 <AppInfoForm
   askForWebsiteDomain
   hideWebsiteBasePathField
+  showNextJSAPIRouteCheckbox
 >
 
 ```tsx title="pages/api/auth/[[...path]].ts"

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -317,16 +317,16 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     )
 
     render() {        
-        const customAttributes: Record<string, string | undefined> = {}
+        const customAttributes: Record<string, string | undefined> = {}        
         if (this.state.firstAppInfoForm) { customAttributes[CONTAINER_ATTRIBUTE_FIRST_FORM] = undefined }
 
         return <div id={this.elementId.toString()} className={CONTAINER_CLASSNAME} ref={this.containerRef}> 
             {(!this.state.formSubmitted && this.state.firstAppInfoForm) && this.renderForm()}
-            {this.renderInfo()}
+            {this.renderResubmitAndChildren()}
         </div>;        
     }
 
-    renderSubmittedButton() {
+    renderResubmitButton() {
         return <div className="app-info-form-question-container">
             <div
                 style={{
@@ -367,10 +367,10 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         </div>;
     }
 
-    renderInfo() {
+    renderResubmitAndChildren() {
         return (
             <div>
-                {(this.state.formSubmitted || !this.state.firstAppInfoForm) && this.renderSubmittedButton()}
+                {this.state.formSubmitted && this.state.firstAppInfoForm && this.renderResubmitButton()}
                 {recursiveMap(this.props.children, (c: any) => {
                     if (typeof c === "string") {
                         // TODO: Add more fields here.

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -33,17 +33,21 @@ type State = {
     netlifyApiRouteUsed: boolean,
     showWebsiteBasePath: boolean,
     showAPIBasePath: boolean
+    /** Whether current element is the first visible AppInfoForm */
     firstAppInfoForm?: boolean
     // TODO: Add more fields here
 };
 
 type ResubmitParams = {
     event?: Pick<Event, 'preventDefault'>;
+    /** Scroll page to current form when its resubmitted */
     scrollToElement?: boolean;
 };
 
+/** attribute name that is used to trigger resubmitting the form */
 const CONTAINER_ATTRIBUTE_DISPLAY = 'display-form';
-const CONTAINER_ATTRIBUTE_FIRST_FORM = 'display-form';
+/** attribute name that is used to indicate current first form */
+const CONTAINER_ATTRIBUTE_FIRST_FORM = 'first-form';
 const CONTAINER_CLASSNAME = "app-info-form-outer";
 /**
  * Check if the mutations receive the matched attribute name & value
@@ -56,13 +60,20 @@ const isReceivingAttr = (mutations: MutationRecord[], attributeName: string, att
             && (attributeValue == null || (mutation.target as HTMLElement).getAttribute(attributeName) === attributeValue);
     });
 }
+/** Check whether it contains element attributes that triggers resubmitting the form */
 const isReceivingDisplayAttr = (mutations: MutationRecord[]) => isReceivingAttr(mutations, CONTAINER_ATTRIBUTE_DISPLAY, 'true')
+/** Check whether its contains element attributes that triggers rechecking current first form */
 const isReceivingFirstFormAttr = (mutations: MutationRecord[]) => isReceivingAttr(mutations, CONTAINER_ATTRIBUTE_FIRST_FORM)
 
 const isElementVisible = (element?: Element | null): boolean => element != null && element?.clientWidth > 0 && element.clientHeight > 0;
 const getFirstAppInfoForm = () => {
     return Array.from(document.querySelectorAll(`.${CONTAINER_CLASSNAME}`)).find(isElementVisible);
 }
+/** 
+ * Check first AppInfoForm by element's id 
+ * @param id AppInfoForm.elementId 
+ * @returns 
+ */
 const isFirstAppInfoForm = (id: string) => getFirstAppInfoForm()?.id === id
 
 export default class AppInfoForm extends React.PureComponent<PropsWithChildren<Props>, State> {

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -319,7 +319,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     render() {        
         const customAttributes: Record<string, string | undefined> = {}
         if (this.state.firstAppInfoForm) { customAttributes[CONTAINER_ATTRIBUTE_FIRST_FORM] = undefined }
-        return <div id={this.elementId.toString()} className={CONTAINER_CLASSNAME} ref={this.containerRef}>            
+        return <div id={this.elementId.toString()} className={CONTAINER_CLASSNAME} ref={this.containerRef}> 
             {(!this.state.formSubmitted && this.state.firstAppInfoForm) && this.renderForm()}
             {this.renderInfo()}
         </div>;        
@@ -634,8 +634,8 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                     appName: this.state.appName || currentLocalStorageParsedFormData.appName,
                     apiDomain: this.state.apiDomain || currentLocalStorageParsedFormData.apiDomain,
                     websiteDomain: this.state.websiteDomain || currentLocalStorageParsedFormData.websiteDomain,
-                    websiteBasePath: this.state.showWebsiteBasePath ? this.state.websiteBasePath : currentLocalStorageParsedFormData.websiteBasePath,
-                    apiBasePath: this.state.showAPIBasePath ? this.state.apiBasePath : currentLocalStorageParsedFormData.apiBasePath,
+                    websiteBasePath: this.state.websiteBasePath || currentLocalStorageParsedFormData.websiteBasePath,
+                    apiBasePath: this.state.apiBasePath || currentLocalStorageParsedFormData.apiBasePath,
                     nextJSApiRouteUsed: this.state.nextJSApiRouteUsed,
                     netlifyApiRouteUsed: this.state.netlifyApiRouteUsed,
                     formSubmitted: this.state.formSubmitted
@@ -711,7 +711,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         }
 
         // validate apiDomain field
-        if (this.props.askForAPIDomain && (!this.props.showNextJSAPIRouteCheckbox || (this.props.showNextJSAPIRouteCheckbox && !this.state.nextJSApiRouteUsed))) {
+        if ((this.props.askForAPIDomain || apiDomain) && (!this.props.showNextJSAPIRouteCheckbox || (this.props.showNextJSAPIRouteCheckbox && !this.state.nextJSApiRouteUsed))) {
             if (apiDomain.length > 0) {
                 const error = this.validateDomain(apiDomain, "apiDomain", "apiBasePath");
                 if (error.length > 0) {
@@ -723,7 +723,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         }
 
         // validate websiteDomain field
-        if (this.props.askForWebsiteDomain) {
+        if (this.props.askForWebsiteDomain || websiteDomain) {
             if (websiteDomain.length > 0) {
                 const error = this.validateDomain(websiteDomain, "websiteDomain", "websiteBasePath");
                 if (error.length > 0) {
@@ -734,7 +734,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             }
         }
 
-        if (this.state.showAPIBasePath) {
+        if (this.state.showAPIBasePath || apiBasePath) {
             const netlifyApiRouteUsed = this.props.showNetlifyAPIRouteCheckbox && this.state.netlifyApiRouteUsed;
             const nextJSApiRouteUsed = this.props.showNextJSAPIRouteCheckbox && this.state.nextJSApiRouteUsed;
 
@@ -767,7 +767,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             }
         }
 
-        if (this.state.showWebsiteBasePath) {
+        if (this.state.showWebsiteBasePath || websiteBasePath) {
             if (preventErrorUpdateInState && (!localFormDataParsed || localFormDataParsed.websiteBasePath === undefined)) {
                 // we do this check in case the user has not submitted the form
                 // in which case the base path fields will have the default '/auth'
@@ -777,7 +777,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             }
         }
 
-        if (this.state.showAPIBasePath && this.state.showWebsiteBasePath && !validationErrors.apiBasePath && !validationErrors.websiteBasePath) {
+        if ((this.state.showAPIBasePath || apiBasePath) && (this.state.showWebsiteBasePath || websiteBasePath) && !validationErrors.apiBasePath && !validationErrors.websiteBasePath) {
             const normalisedApiDomain = this.getDomainOriginOrEmptyString(apiDomain);
             const normalisedWebsiteDomain = this.getDomainOriginOrEmptyString(websiteDomain);
             const normalisedApiBasePath = this.getNormalisedBasePath(apiBasePath);
@@ -804,7 +804,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 ...oldState,
                 fieldErrors: validationErrors
             }))
-        }
+        }        
 
         return Object.keys(validationErrors).length === 0;
     }

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -165,7 +165,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     }
 
     setDefaultApiBasePathBasedOnToggles = () => {
-        let defaultApiBasePath = this.state.apiBasePath;
+        let defaultApiBasePath = this.state.apiBasePath;        
 
         if (defaultApiBasePath === "/auth") {
             if (this.props.showNextJSAPIRouteCheckbox && this.state.nextJSApiRouteUsed) {
@@ -182,7 +182,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             } else if (this.props.showNetlifyAPIRouteCheckbox && this.state.netlifyApiRouteUsed && !defaultApiBasePath.startsWith(netlifyPrefix)) {
                 defaultApiBasePath = this.replacePathPrefixWithNewPrefix(defaultApiBasePath, "/api", "/.netlify/functions");
             }
-        }
+        }   
 
         this.setState({
             apiBasePath: defaultApiBasePath
@@ -375,13 +375,13 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                     if (typeof c === "string") {
                         // TODO: Add more fields here.
                         if (this.props.askForAppName) {
-                            c = c.split("^{form_appName}").join(this.state.appName || 'YOUR_APP_NAME');
+                            c = c.split("^{form_appName}").join(this.state.appName || '<YOUR_APP_NAME>');
                         }
                         if (this.props.askForAPIDomain) {
-                            c = c.split("^{form_apiDomain}").join(this.state.apiDomain || `YOUR_API_DOMAIN`);
+                            c = c.split("^{form_apiDomain}").join(this.state.apiDomain || `<YOUR_API_DOMAIN>`);
                         }
                         if (this.props.askForWebsiteDomain) {
-                            c = c.split("^{form_websiteDomain}").join(this.state.websiteDomain|| `YOUR_WEB_DOMAIN`);
+                            c = c.split("^{form_websiteDomain}").join(this.state.websiteDomain|| `<YOUR_WEB_DOMAIN>`);
                         }
                         if (this.state.showAPIBasePath) {
                             c = c.split("^{form_apiBasePath}").join(this.state.apiBasePath);
@@ -482,7 +482,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                         value={this.state.websiteDomain}
                         error={this.state.fieldErrors.websiteDomain}
                     />
-                    {(this.state.showWebsiteBasePath) && <FormItem
+                    <FormItem
                         index={4}
                         title="Website Base Path"
                         placeholder="e.g. /auth"
@@ -490,7 +490,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                         explanation="SuperTokens UI will be shown on this website route."
                         value={this.state.websiteBasePath}
                         error={this.state.fieldErrors.websiteBasePath}
-                    />}
+                    />
 
                     {this.props.showNextJSAPIRouteCheckbox && (
                         <label style={{
@@ -595,7 +595,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         }
 
         this.setState(oldState => {
-            const websiteDomain = this.state.showWebsiteBasePath ? this.getDomainOriginOrEmptyString(this.state.websiteDomain) : oldState.websiteDomain;
+            const websiteDomain = this.getDomainOriginOrEmptyString(this.state.websiteDomain);
             let apiDomain = oldState.apiDomain;
 
             // if the nextjs route is set to true
@@ -606,10 +606,10 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 apiDomain = this.getDomainOriginOrEmptyString(this.state.apiDomain);
             }
 
-            let apiBasePath = this.state.showAPIBasePath ? this.getNormalisedBasePath(this.state.apiBasePath.trim()) : oldState.apiBasePath;
+            let apiBasePath = this.getNormalisedBasePath(this.state.apiBasePath.trim());
 
             // if the websiteBasePath is an empty string, we set it to the default value '/auth'
-            let websiteBasePath = this.state.showWebsiteBasePath ? this.getNormalisedBasePath(this.state.websiteBasePath.trim()) : oldState.websiteBasePath;
+            let websiteBasePath = this.getNormalisedBasePath(this.state.websiteBasePath.trim());
 
             return {
                 // TODO: Add more fields here.
@@ -631,11 +631,11 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 }
 
                 const newLocalStorageFormData = {
-                    appName: this.state.appName || currentLocalStorageParsedFormData.appName,
-                    apiDomain: this.state.apiDomain || currentLocalStorageParsedFormData.apiDomain,
-                    websiteDomain: this.state.websiteDomain || currentLocalStorageParsedFormData.websiteDomain,
-                    websiteBasePath: this.state.showWebsiteBasePath ? this.state.websiteBasePath : currentLocalStorageParsedFormData.websiteBasePath,
-                    apiBasePath: this.state.showAPIBasePath ? this.state.apiBasePath : currentLocalStorageParsedFormData.apiBasePath,
+                    appName: this.state.appName,
+                    apiDomain: this.state.apiDomain,
+                    websiteDomain: this.state.websiteDomain,
+                    websiteBasePath: this.state.websiteBasePath,
+                    apiBasePath: this.state.apiBasePath,
                     nextJSApiRouteUsed: this.state.nextJSApiRouteUsed,
                     netlifyApiRouteUsed: this.state.netlifyApiRouteUsed,
                     formSubmitted: this.state.formSubmitted
@@ -765,15 +765,13 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 }
             }
         }
-
-        if (this.state.showWebsiteBasePath) {
-            if (preventErrorUpdateInState && (!localFormDataParsed || localFormDataParsed.websiteBasePath === undefined)) {
-                // we do this check in case the user has not submitted the form
-                // in which case the base path fields will have the default '/auth'
-                validationErrors.websiteBasePath = "Please enter a valid path.";
-            } else if (!this.isBasePathValid(websiteBasePath)) {
-                validationErrors.websiteBasePath = "Please enter a valid path."
-            }
+    
+        if (preventErrorUpdateInState && (!localFormDataParsed || localFormDataParsed.websiteBasePath === undefined)) {
+            // we do this check in case the user has not submitted the form
+            // in which case the base path fields will have the default '/auth'
+            validationErrors.websiteBasePath = "Please enter a valid path.";
+        } else if (!this.isBasePathValid(websiteBasePath)) {
+            validationErrors.websiteBasePath = "Please enter a valid path."
         }
 
         if (this.state.showAPIBasePath && this.state.showWebsiteBasePath && !validationErrors.apiBasePath && !validationErrors.websiteBasePath) {
@@ -804,10 +802,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 fieldErrors: validationErrors
             }))
         }    
-        
-        console.log(this.elementId,validationErrors);
-        
-
+                    
         return Object.keys(validationErrors).length === 0;
     }
 

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -99,12 +99,16 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     private attributeObserver?: MutationObserver;
     private visibilityObserver?: IntersectionObserver;
 
+    get allQuestionsProps(): PropsWithChildren<Props> {
+        return { ...this.props, askForAPIDomain: true, askForWebsiteDomain: true, askForAPIBasePath: true, askForAppName: true, askForWebsiteBasePath: true } 
+    }
+
     constructor(props: PropsWithChildren<Props>) {
         super(props);
         // TODO: Add more fields here
         this.containerRef = React.createRef<HTMLDivElement>();
-        if (!props.askForAPIDomain && !props.askForAppName &&
-            !props.askForWebsiteDomain && !props.askForWebsiteBasePath && !props.askForAPIBasePath) {
+        if (!this.allQuestionsProps.askForAPIDomain && !this.allQuestionsProps.askForAppName &&
+            !this.allQuestionsProps.askForWebsiteDomain && !this.allQuestionsProps.askForWebsiteBasePath && !this.allQuestionsProps.askForAPIBasePath) {
             throw new Error("You must ask for at least one item in the form")
         }
         this.state = {
@@ -117,8 +121,8 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             fieldErrors: {},
             nextJSApiRouteUsed: true,
             netlifyApiRouteUsed: true,
-            showWebsiteBasePath: (props.askForWebsiteDomain || props.askForWebsiteBasePath) && !props.hideWebsiteBasePathField,
-            showAPIBasePath: (props.askForAPIDomain || props.askForAPIBasePath)
+            showWebsiteBasePath: (this.allQuestionsProps.askForWebsiteDomain || this.allQuestionsProps.askForWebsiteBasePath) && !props.hideWebsiteBasePathField,
+            showAPIBasePath: (this.allQuestionsProps.askForAPIDomain || this.allQuestionsProps.askForAPIBasePath)
         }
 
         if (typeof window !== 'undefined') {
@@ -319,7 +323,9 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     render() {        
         const customAttributes: Record<string, string | undefined> = {}
         if (this.state.firstAppInfoForm) { customAttributes[CONTAINER_ATTRIBUTE_FIRST_FORM] = undefined }
+
         return <div id={this.elementId.toString()} className={CONTAINER_CLASSNAME} ref={this.containerRef}> 
+            <b>{this.elementId}</b>
             {(!this.state.formSubmitted && this.state.firstAppInfoForm) && this.renderForm()}
             {this.renderInfo()}
         </div>;        
@@ -439,7 +445,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                         display: "flex",
                         flexDirection: "column"
                     }}>
-                    {(this.props.askForAppName || this.state.firstAppInfoForm) && <FormItem
+                    {(this.allQuestionsProps.askForAppName) && <FormItem
                         required
                         index={0}
                         title="Your app's name"
@@ -451,7 +457,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                     />}
                     {/* show apiDomain field if it is not a NextJS form */}
                     {/* show apiDomain field if it is a nextJS form and the `nextJS api route used` checkbox is not checked */}
-                    {(this.props.askForAPIDomain || this.state.firstAppInfoForm)
+                    {(this.allQuestionsProps.askForAPIDomain)
                         && (!this.props.showNextJSAPIRouteCheckbox || (this.props.showNextJSAPIRouteCheckbox && !this.state.nextJSApiRouteUsed))
                         && <FormItem
                         required
@@ -463,7 +469,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                         value={this.state.apiDomain}
                         error={this.state.fieldErrors.apiDomain}
                     />}
-                    {(this.state.showAPIBasePath || this.state.firstAppInfoForm) && <FormItem
+                    {(this.state.showAPIBasePath) && <FormItem
                         index={3}
                         title="API Base Path"
                         placeholder="e.g. /auth"
@@ -472,7 +478,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                         value={this.state.apiBasePath}
                         error={this.state.fieldErrors.apiBasePath}
                         />}
-                    {(this.props.askForWebsiteDomain || this.state.firstAppInfoForm) && <FormItem
+                    {(this.allQuestionsProps.askForWebsiteDomain) && <FormItem
                         required
                         index={2}
                         title="Website Domain"
@@ -482,7 +488,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                         value={this.state.websiteDomain}
                         error={this.state.fieldErrors.websiteDomain}
                     />}
-                    {(this.state.showWebsiteBasePath || this.state.firstAppInfoForm) && <FormItem
+                    {(this.state.showWebsiteBasePath) && <FormItem
                         index={4}
                         title="Website Base Path"
                         placeholder="e.g. /auth"
@@ -600,9 +606,9 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
 
             // if the nextjs route is set to true
             // then we set apiDomain to the same value as website domain
-            if (this.props.askForAPIDomain && this.props.showNextJSAPIRouteCheckbox && oldState.nextJSApiRouteUsed) {
+            if (this.allQuestionsProps.askForAPIDomain && this.props.showNextJSAPIRouteCheckbox && oldState.nextJSApiRouteUsed) {
                 apiDomain = websiteDomain;
-            } else if (this.props.askForAPIDomain) {
+            } else if (this.allQuestionsProps.askForAPIDomain) {
                 apiDomain = this.getDomainOriginOrEmptyString(this.state.apiDomain);
             }
 
@@ -618,7 +624,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 websiteDomain,
                 apiBasePath,
                 websiteBasePath,
-                appName: this.props.askForAppName ? this.state.appName.trim() : oldState.appName,
+                appName: this.allQuestionsProps.askForAppName ? this.state.appName.trim() : oldState.appName,
                 formSubmitted: true
             }
         }, () => {
@@ -631,11 +637,11 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 }
 
                 const newLocalStorageFormData = {
-                    appName: this.state.appName || currentLocalStorageParsedFormData.appName,
-                    apiDomain: this.state.apiDomain || currentLocalStorageParsedFormData.apiDomain,
-                    websiteDomain: this.state.websiteDomain || currentLocalStorageParsedFormData.websiteDomain,
-                    websiteBasePath: this.state.websiteBasePath || currentLocalStorageParsedFormData.websiteBasePath,
-                    apiBasePath: this.state.apiBasePath || currentLocalStorageParsedFormData.apiBasePath,
+                    appName: this.allQuestionsProps.askForAppName ? this.state.appName : currentLocalStorageParsedFormData.appName,
+                    apiDomain: this.allQuestionsProps.askForAPIDomain ? this.state.apiDomain : currentLocalStorageParsedFormData.apiDomain,
+                    websiteDomain: this.allQuestionsProps.askForWebsiteDomain ? this.state.websiteDomain : currentLocalStorageParsedFormData.websiteDomain,
+                    websiteBasePath: this.state.showWebsiteBasePath ? this.state.websiteBasePath : currentLocalStorageParsedFormData.websiteBasePath,
+                    apiBasePath: this.state.showAPIBasePath ? this.state.apiBasePath : currentLocalStorageParsedFormData.apiBasePath,
                     nextJSApiRouteUsed: this.state.nextJSApiRouteUsed,
                     netlifyApiRouteUsed: this.state.netlifyApiRouteUsed,
                     formSubmitted: this.state.formSubmitted
@@ -706,12 +712,12 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         }
 
         // validate appName field
-        if (this.props.askForAppName && appName.length === 0) {
+        if (this.allQuestionsProps.askForAppName && appName.length === 0) {
             validationErrors.appName = "appName cannot be empty.";
         }
 
         // validate apiDomain field
-        if ((this.props.askForAPIDomain || apiDomain) && (!this.props.showNextJSAPIRouteCheckbox || (this.props.showNextJSAPIRouteCheckbox && !this.state.nextJSApiRouteUsed))) {
+        if ((this.allQuestionsProps.askForAPIDomain) && (!this.props.showNextJSAPIRouteCheckbox || (this.props.showNextJSAPIRouteCheckbox && !this.state.nextJSApiRouteUsed))) {
             if (apiDomain.length > 0) {
                 const error = this.validateDomain(apiDomain, "apiDomain", "apiBasePath");
                 if (error.length > 0) {
@@ -723,7 +729,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         }
 
         // validate websiteDomain field
-        if (this.props.askForWebsiteDomain || websiteDomain) {
+        if (this.allQuestionsProps.askForWebsiteDomain) {
             if (websiteDomain.length > 0) {
                 const error = this.validateDomain(websiteDomain, "websiteDomain", "websiteBasePath");
                 if (error.length > 0) {
@@ -734,7 +740,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             }
         }
 
-        if (this.state.showAPIBasePath || apiBasePath) {
+        if (this.state.showAPIBasePath) {
             const netlifyApiRouteUsed = this.props.showNetlifyAPIRouteCheckbox && this.state.netlifyApiRouteUsed;
             const nextJSApiRouteUsed = this.props.showNextJSAPIRouteCheckbox && this.state.nextJSApiRouteUsed;
 
@@ -767,7 +773,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             }
         }
 
-        if (this.state.showWebsiteBasePath || websiteBasePath) {
+        if (this.state.showWebsiteBasePath) {
             if (preventErrorUpdateInState && (!localFormDataParsed || localFormDataParsed.websiteBasePath === undefined)) {
                 // we do this check in case the user has not submitted the form
                 // in which case the base path fields will have the default '/auth'
@@ -777,7 +783,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             }
         }
 
-        if ((this.state.showAPIBasePath || apiBasePath) && (this.state.showWebsiteBasePath || websiteBasePath) && !validationErrors.apiBasePath && !validationErrors.websiteBasePath) {
+        if (this.state.showAPIBasePath && this.state.showWebsiteBasePath && !validationErrors.apiBasePath && !validationErrors.websiteBasePath) {
             const normalisedApiDomain = this.getDomainOriginOrEmptyString(apiDomain);
             const normalisedWebsiteDomain = this.getDomainOriginOrEmptyString(websiteDomain);
             const normalisedApiBasePath = this.getNormalisedBasePath(apiBasePath);
@@ -804,7 +810,10 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 ...oldState,
                 fieldErrors: validationErrors
             }))
-        }        
+        }    
+        
+        console.log(this.elementId,validationErrors);
+        
 
         return Object.keys(validationErrors).length === 0;
     }

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -463,7 +463,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                         value={this.state.apiDomain}
                         error={this.state.fieldErrors.apiDomain}
                     />}
-                    {(this.state.showAPIBasePath) && <FormItem
+                    <FormItem
                         index={3}
                         title="API Base Path"
                         placeholder="e.g. /auth"
@@ -471,7 +471,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                         explanation="SuperTokens will expose it's APIs scoped by this base API path."
                         value={this.state.apiBasePath}
                         error={this.state.fieldErrors.apiBasePath}
-                        />}
+                    />
                     <FormItem
                         required
                         index={2}

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -45,6 +45,9 @@ type ResubmitParams = {
 const CONTAINER_ATTRIBUTE_DISPLAY = 'display-form';
 const CONTAINER_ATTRIBUTE_FIRST_FORM = 'display-form';
 const CONTAINER_CLASSNAME = "app-info-form-outer";
+/**
+ * Check if the mutations receive the matched attribute name & value
+ */
 const isReceivingAttr = (mutations: MutationRecord[], attributeName: string, attributeValue?: string) => {
     return mutations.some(mutation => {
         const mutationAttributeName = mutation.attributeName;
@@ -193,9 +196,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
 
     readonly resubmitFirstAppInfoForm = (event?: ResubmitParams['event']) => {
         event?.preventDefault()
-        document.querySelectorAll(`.${CONTAINER_CLASSNAME}[${CONTAINER_ATTRIBUTE_FIRST_FORM}]`).forEach(element => {
-            element.setAttribute(CONTAINER_ATTRIBUTE_FIRST_FORM, '')
-        })
+        this.recheckCurrentFirstAppInfoForm();
         getFirstAppInfoForm()?.setAttribute(CONTAINER_ATTRIBUTE_DISPLAY, 'true')
     }
 
@@ -796,9 +797,11 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     }
 
     private onReceiveAttribute(mutations: MutationRecord[]) {
+        // listen event triggered by recheckCurrentFirstAppInfoForm()
         if (isReceivingFirstFormAttr(mutations)) {
             this.setState({ firstAppInfoForm: this.isFirstVisibleAppInfoForm() })
         }
+        // listen event triggered by resubmitFirstAppInfoForm()
         if (isReceivingDisplayAttr(mutations)) {
             this.resubmitInfoClicked({scrollToElement: true});
         }
@@ -806,5 +809,16 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
 
     private isFirstVisibleAppInfoForm(): boolean {
         return Boolean(isElementVisible(this.containerRef?.current) && isFirstAppInfoForm(`${this.elementId}`));
+    }
+
+    /**
+     * Trigger rechecking on current first app info form
+     ** This is to solve when there is form is inside a details element, 
+     and then there is another form that share same parent with the details 
+     */
+    private recheckCurrentFirstAppInfoForm() {
+        document.querySelectorAll(`.${CONTAINER_CLASSNAME}[${CONTAINER_ATTRIBUTE_FIRST_FORM}]`).forEach(element => {
+            element.setAttribute(CONTAINER_ATTRIBUTE_FIRST_FORM, '');
+        });
     }
 }

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -97,18 +97,14 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     private readonly elementId = (new Date()).getTime()
     private readonly containerRef: React.RefObject<HTMLDivElement>
     private attributeObserver?: MutationObserver;
-    private visibilityObserver?: IntersectionObserver;
-
-    get allQuestionsProps(): PropsWithChildren<Props> {
-        return { ...this.props, askForAPIDomain: true, askForWebsiteDomain: true, askForAPIBasePath: true, askForAppName: true, askForWebsiteBasePath: true } 
-    }
+    private visibilityObserver?: IntersectionObserver;  
 
     constructor(props: PropsWithChildren<Props>) {
         super(props);
         // TODO: Add more fields here
         this.containerRef = React.createRef<HTMLDivElement>();
-        if (!this.allQuestionsProps.askForAPIDomain && !this.allQuestionsProps.askForAppName &&
-            !this.allQuestionsProps.askForWebsiteDomain && !this.allQuestionsProps.askForWebsiteBasePath && !this.allQuestionsProps.askForAPIBasePath) {
+        if (!props.askForAPIDomain && !props.askForAppName &&
+            !props.askForWebsiteDomain && !props.askForWebsiteBasePath && !props.askForAPIBasePath) {
             throw new Error("You must ask for at least one item in the form")
         }
         this.state = {
@@ -121,8 +117,8 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
             fieldErrors: {},
             nextJSApiRouteUsed: true,
             netlifyApiRouteUsed: true,
-            showWebsiteBasePath: (this.allQuestionsProps.askForWebsiteDomain || this.allQuestionsProps.askForWebsiteBasePath) && !props.hideWebsiteBasePathField,
-            showAPIBasePath: (this.allQuestionsProps.askForAPIDomain || this.allQuestionsProps.askForAPIBasePath)
+            showWebsiteBasePath: true,
+            showAPIBasePath: true
         }
 
         if (typeof window !== 'undefined') {
@@ -325,7 +321,6 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         if (this.state.firstAppInfoForm) { customAttributes[CONTAINER_ATTRIBUTE_FIRST_FORM] = undefined }
 
         return <div id={this.elementId.toString()} className={CONTAINER_CLASSNAME} ref={this.containerRef}> 
-            <b>{this.elementId}</b>
             {(!this.state.formSubmitted && this.state.firstAppInfoForm) && this.renderForm()}
             {this.renderInfo()}
         </div>;        
@@ -445,7 +440,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                         display: "flex",
                         flexDirection: "column"
                     }}>
-                    {(this.allQuestionsProps.askForAppName) && <FormItem
+                    <FormItem
                         required
                         index={0}
                         title="Your app's name"
@@ -454,11 +449,10 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                         explanation="This is the name of your application"
                         value={this.state.appName}
                         error={this.state.fieldErrors.appName}
-                    />}
+                    />
                     {/* show apiDomain field if it is not a NextJS form */}
                     {/* show apiDomain field if it is a nextJS form and the `nextJS api route used` checkbox is not checked */}
-                    {(this.allQuestionsProps.askForAPIDomain)
-                        && (!this.props.showNextJSAPIRouteCheckbox || (this.props.showNextJSAPIRouteCheckbox && !this.state.nextJSApiRouteUsed))
+                    {(!this.props.showNextJSAPIRouteCheckbox || (this.props.showNextJSAPIRouteCheckbox && !this.state.nextJSApiRouteUsed))
                         && <FormItem
                         required
                         index={1}
@@ -478,7 +472,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                         value={this.state.apiBasePath}
                         error={this.state.fieldErrors.apiBasePath}
                         />}
-                    {(this.allQuestionsProps.askForWebsiteDomain) && <FormItem
+                    <FormItem
                         required
                         index={2}
                         title="Website Domain"
@@ -487,7 +481,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                         explanation="This is the URL of your website."
                         value={this.state.websiteDomain}
                         error={this.state.fieldErrors.websiteDomain}
-                    />}
+                    />
                     {(this.state.showWebsiteBasePath) && <FormItem
                         index={4}
                         title="Website Base Path"
@@ -606,9 +600,9 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
 
             // if the nextjs route is set to true
             // then we set apiDomain to the same value as website domain
-            if (this.allQuestionsProps.askForAPIDomain && this.props.showNextJSAPIRouteCheckbox && oldState.nextJSApiRouteUsed) {
+            if (this.props.showNextJSAPIRouteCheckbox && oldState.nextJSApiRouteUsed) {
                 apiDomain = websiteDomain;
-            } else if (this.allQuestionsProps.askForAPIDomain) {
+            } else {
                 apiDomain = this.getDomainOriginOrEmptyString(this.state.apiDomain);
             }
 
@@ -624,7 +618,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 websiteDomain,
                 apiBasePath,
                 websiteBasePath,
-                appName: this.allQuestionsProps.askForAppName ? this.state.appName.trim() : oldState.appName,
+                appName: this.state.appName.trim(),
                 formSubmitted: true
             }
         }, () => {
@@ -637,9 +631,9 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 }
 
                 const newLocalStorageFormData = {
-                    appName: this.allQuestionsProps.askForAppName ? this.state.appName : currentLocalStorageParsedFormData.appName,
-                    apiDomain: this.allQuestionsProps.askForAPIDomain ? this.state.apiDomain : currentLocalStorageParsedFormData.apiDomain,
-                    websiteDomain: this.allQuestionsProps.askForWebsiteDomain ? this.state.websiteDomain : currentLocalStorageParsedFormData.websiteDomain,
+                    appName: this.state.appName || currentLocalStorageParsedFormData.appName,
+                    apiDomain: this.state.apiDomain || currentLocalStorageParsedFormData.apiDomain,
+                    websiteDomain: this.state.websiteDomain || currentLocalStorageParsedFormData.websiteDomain,
                     websiteBasePath: this.state.showWebsiteBasePath ? this.state.websiteBasePath : currentLocalStorageParsedFormData.websiteBasePath,
                     apiBasePath: this.state.showAPIBasePath ? this.state.apiBasePath : currentLocalStorageParsedFormData.apiBasePath,
                     nextJSApiRouteUsed: this.state.nextJSApiRouteUsed,
@@ -712,12 +706,12 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         }
 
         // validate appName field
-        if (this.allQuestionsProps.askForAppName && appName.length === 0) {
+        if (appName.length === 0) {
             validationErrors.appName = "appName cannot be empty.";
         }
 
         // validate apiDomain field
-        if ((this.allQuestionsProps.askForAPIDomain) && (!this.props.showNextJSAPIRouteCheckbox || (this.props.showNextJSAPIRouteCheckbox && !this.state.nextJSApiRouteUsed))) {
+        if ((!this.props.showNextJSAPIRouteCheckbox || (this.props.showNextJSAPIRouteCheckbox && !this.state.nextJSApiRouteUsed))) {
             if (apiDomain.length > 0) {
                 const error = this.validateDomain(apiDomain, "apiDomain", "apiBasePath");
                 if (error.length > 0) {
@@ -729,16 +723,15 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         }
 
         // validate websiteDomain field
-        if (this.allQuestionsProps.askForWebsiteDomain) {
-            if (websiteDomain.length > 0) {
-                const error = this.validateDomain(websiteDomain, "websiteDomain", "websiteBasePath");
-                if (error.length > 0) {
-                    validationErrors.websiteDomain = error;
-                }
-            } else {
-                validationErrors.websiteDomain = "websiteDomain cannot be empty.";
+        if (websiteDomain.length > 0) {
+            const error = this.validateDomain(websiteDomain, "websiteDomain", "websiteBasePath");
+            if (error.length > 0) {
+                validationErrors.websiteDomain = error;
             }
+        } else {
+            validationErrors.websiteDomain = "websiteDomain cannot be empty.";
         }
+        
 
         if (this.state.showAPIBasePath) {
             const netlifyApiRouteUsed = this.props.showNetlifyAPIRouteCheckbox && this.state.netlifyApiRouteUsed;

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -79,10 +79,8 @@ const isFirstAppInfoForm = (id: string) => getFirstAppInfoForm()?.id === id
 export default class AppInfoForm extends React.PureComponent<PropsWithChildren<Props>, State> {
     private readonly elementId = (new Date()).getTime()
     private readonly containerRef: React.RefObject<HTMLDivElement>
-    private readonly attributeObserver = new MutationObserver(this.onReceiveAttribute.bind(this));
-    private readonly visibilityObserver = new IntersectionObserver(() => this.setState({ 
-        firstAppInfoForm: this.isFirstVisibleAppInfoForm()
-    }))
+    private attributeObserver?: MutationObserver;
+    private visibilityObserver?: IntersectionObserver;
 
     constructor(props: PropsWithChildren<Props>) {
         super(props);
@@ -125,6 +123,10 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         const canContinue = this.canContinue(true)
 
         // listen to DOM changes 
+        this.attributeObserver = new MutationObserver(this.onReceiveAttribute.bind(this));
+        this.visibilityObserver = new IntersectionObserver(() => this.setState({ 
+            firstAppInfoForm: this.isFirstVisibleAppInfoForm()
+        }))
         this.attributeObserver.observe(this.containerRef.current!, { attributes: true });
         this.visibilityObserver.observe(this.containerRef.current!);
 
@@ -201,8 +203,8 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
         if (typeof window !== 'undefined') {
             window.removeEventListener("appInfoFormFilled", this.anotherFormFilled);
         }
-        this.attributeObserver.disconnect()
-        this.visibilityObserver.disconnect()
+        this.attributeObserver?.disconnect()
+        this.visibilityObserver?.disconnect()
     }
 
     readonly resubmitFirstAppInfoForm = (event?: ResubmitParams['event']) => {

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -404,21 +404,13 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                     color: "#ffffff",
                 }}
                 className="app-info-form-container"
-            >
+            >                
                 <div
+                    className="app-info-form-container-link"
                     style={{
                         fontSize: "14px",
                         fontWeight: 600,
-                        textTransform: "uppercase"
-                    }}>
-                    Please fill the form below to see the code snippet <span
-                        style={{
-                            color: "#ff6161"
-                        }}>(* = Required)</span>
-                </div>
-                <div
-                    className="app-info-form-container-link"
-                    style={{ marginTop: "10px" }}
+                    }}
                 >
                     To learn more about what these properties mean read <a href="/docs/thirdpartyemailpassword/appinfo">here</a>.
                 </div>
@@ -801,9 +793,10 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     }
 
     scrollToElement() {
-        if (Boolean(this.containerRef.current)) {
+        if (Boolean(this.containerRef.current)) {            
+            const topPositionAfterNavbar = window.scrollY + (this.containerRef.current?.getBoundingClientRect().top ?? 0) - (document.querySelector('nav.navbar')?.clientHeight ?? 0);
             window.scrollTo({
-                top: window.scrollY + (this.containerRef.current?.parentElement?.getBoundingClientRect().top ?? 0),
+                top: topPositionAfterNavbar,
                 behavior: 'smooth'
             });
         }

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -5,6 +5,23 @@ import NormalisedURLDomain from "./normalisedURLDomain";
 import NormalisedURLPath from "./normalisedURLPath";
 import { recursiveMap } from "../utils";
 
+/**
+ * The AppInfoForm component is now designed to allow only open the first visible form on the page. 
+ * When a user tried to resubmit a second, third or fourth form, then it will not open the selected AppInfoForm. Instead, it will open the first AppInfoFormand scroll to it.
+ * We use DOM attribute CONTAINER_ATTRIBUTE_DISPLAY as the way to communicate to the first AppInfoForm. This is done by calling AppInfoForm.resubmitFirstAppInfoForm().
+ * When a form is receiving "CONTAINER_ATTRIBUTE_DISPLAY=true", then it will open the form.
+ * The form is listening to this attribute's changes by using `AppInfoForm.attributeObserver:MutationObserver` that is utilizing isReceivingFirstFormAttr() and AppInfoForm.onReceiveAttribute().
+ * 
+ * Beside the above event, we also have a way to recognize which is the first visible form. The form considered to be the first visible form when its height and width are not zero(function isElementVisible()). 
+ * Then, we use isFirstAppInfoForm() and getFirstAppInfoForm() to indicate whether a form is a first visible one. The first form will also have attribut CONTAINER_ATTRIBUTE_FIRST_FORM attached in the DOM.
+ * 
+ * There is also case when user switches between tabs, which will affect the visibility of the form.
+ * We expect this will triggers re-updating which one is the first visible form. Therefore, `AppInfoForm.visibilityObserver: IntersectionObserver` is created to listen to any visibility changes on the form.
+ * 
+ * There is also an edge case where a form is located inside a `details` element. When `details` opens or closes, it will not notify the IntersectionObserver. 
+ * So, we add AppInfoForm.recheckCurrentFirstAppInfoForm() to trigger the visibilty status update by sending an event to element that has CONTAINER_ATTRIBUTE_FIRST_FORM attribute.
+ */
+
 type Props = {
     askForAppName: boolean,
     askForAPIDomain: boolean,
@@ -614,9 +631,9 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
                 }
 
                 const newLocalStorageFormData = {
-                    appName: this.props.askForAppName ? this.state.appName : currentLocalStorageParsedFormData.appName,
-                    apiDomain: this.props.askForAPIDomain ? this.state.apiDomain : currentLocalStorageParsedFormData.apiDomain,
-                    websiteDomain: this.props.askForWebsiteDomain ? this.state.websiteDomain : currentLocalStorageParsedFormData.websiteDomain,
+                    appName: this.state.appName || currentLocalStorageParsedFormData.appName,
+                    apiDomain: this.state.apiDomain || currentLocalStorageParsedFormData.apiDomain,
+                    websiteDomain: this.state.websiteDomain || currentLocalStorageParsedFormData.websiteDomain,
                     websiteBasePath: this.state.showWebsiteBasePath ? this.state.websiteBasePath : currentLocalStorageParsedFormData.websiteBasePath,
                     apiBasePath: this.state.showAPIBasePath ? this.state.apiBasePath : currentLocalStorageParsedFormData.apiBasePath,
                     nextJSApiRouteUsed: this.state.nextJSApiRouteUsed,

--- a/v2/src/components/appInfoForm/index.tsx
+++ b/v2/src/components/appInfoForm/index.tsx
@@ -276,8 +276,7 @@ export default class AppInfoForm extends React.PureComponent<PropsWithChildren<P
     )
 
     render() {        
-        return <div id={this.elementId.toString()} className={CONTAINER_CLASSNAME} ref={this.containerRef}>
-            <b>{this.elementId}</b>
+        return <div id={this.elementId.toString()} className={CONTAINER_CLASSNAME} ref={this.containerRef}>            
             {(!this.state.formSubmitted && this.state.firstAppInfoForm) && this.renderForm()}
             {this.renderInfo()}
         </div>;        

--- a/v2/src/components/appInfoForm/style.css
+++ b/v2/src/components/appInfoForm/style.css
@@ -14,6 +14,7 @@
   border: 0.0625rem solid #404040;
   color: white;
   border-radius: 0.375rem;
+  margin-bottom: 1.25rem;
 }
 
 .question {

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -551,9 +551,7 @@ html[data-theme="dark"] .markdown blockquote>*:last-child {
 details {
   position: relative;
   border-top: 1px solid var(--ifm-toc-border-color);
-  ;
   border-bottom: 1px solid var(--ifm-toc-border-color);
-  ;
 }
 
 details>summary {

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -481,7 +481,7 @@ html[data-theme='dark'] .tabs-container .app-info-form-question-container {
 }
 
 html[data-theme='dark'] .tabs-container .app-info-form-container {
-  margin-bottom: 0px;
+  margin-bottom: 1.25rem;
   border: 0px;
 }
 

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -489,7 +489,6 @@ html[data-theme='dark'] .tabs-container .app-info-form-question-container {
 }
 
 html[data-theme='dark'] .tabs-container .app-info-form-container {
-  margin-bottom: 1.25rem;
   border: 0px;
 }
 

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -562,3 +562,7 @@ details[open] > summary {
 details[open] > summary::before {
   transform: rotate(45deg);  
 }
+
+details:not([open]) > *:not(summary) { /* Workaround to make the details' content have zero height & width */
+  display: none;
+}

--- a/v2/thirdparty/nextjs/session-verification/in-api.mdx
+++ b/v2/thirdparty/nextjs/session-verification/in-api.mdx
@@ -36,6 +36,7 @@ supertokens.init(backendConfig())
 <AppInfoForm
     askForWebsiteDomain
     hideWebsiteBasePathField
+    showNextJSAPIRouteCheckbox
 >
 
 ```tsx title="pages/api/user.ts"

--- a/v2/thirdparty/nextjs/setting-up-backend.mdx
+++ b/v2/thirdparty/nextjs/setting-up-backend.mdx
@@ -25,6 +25,7 @@ We will add all the backend APIs for auth on `/api/auth`. This can be changed by
 <AppInfoForm
   askForWebsiteDomain
   hideWebsiteBasePathField
+  showNextJSAPIRouteCheckbox
 >
 
 ```tsx title="pages/api/auth/[[...path]].ts"

--- a/v2/thirdpartyemailpassword/nextjs/session-verification/in-api.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/session-verification/in-api.mdx
@@ -36,6 +36,7 @@ supertokens.init(backendConfig())
 <AppInfoForm
     askForWebsiteDomain
     hideWebsiteBasePathField
+    showNextJSAPIRouteCheckbox
 >
 
 ```tsx title="pages/api/user.ts"

--- a/v2/thirdpartyemailpassword/nextjs/setting-up-backend.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/setting-up-backend.mdx
@@ -25,6 +25,7 @@ We will add all the backend APIs for auth on `/api/auth`. This can be changed by
 <AppInfoForm
   askForWebsiteDomain
   hideWebsiteBasePathField
+  showNextJSAPIRouteCheckbox
 >
 
 ```tsx title="pages/api/auth/[[...path]].ts"

--- a/v2/thirdpartypasswordless/nextjs/session-verification/in-api.mdx
+++ b/v2/thirdpartypasswordless/nextjs/session-verification/in-api.mdx
@@ -36,6 +36,7 @@ supertokens.init(backendConfig())
 <AppInfoForm
     askForWebsiteDomain
     hideWebsiteBasePathField
+    showNextJSAPIRouteCheckbox
 >
 
 ```tsx title="pages/api/user.ts"

--- a/v2/thirdpartypasswordless/nextjs/setting-up-backend.mdx
+++ b/v2/thirdpartypasswordless/nextjs/setting-up-backend.mdx
@@ -25,6 +25,7 @@ We will add all the backend APIs for auth on `/api/auth`. This can be changed by
 <AppInfoForm
   askForWebsiteDomain
   hideWebsiteBasePathField
+  showNextJSAPIRouteCheckbox
 >
 
 ```tsx title="pages/api/auth/[[...path]].ts"


### PR DESCRIPTION
## Summary of change
- utilizing DOM attributes, Mutation Observer & InterractionObserver
- when user click the resubmit, it will find the first `appInfoForm`, and then update `display-form` DOM attribute
- Mutation Observer that listen to the attribute changes
- refactor render method and break it into 2 methods
- workaround on details element

## Related issues
- https://github.com/supertokens/main-website/issues/879
- #408 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
NA