### PR TITLE
fix injection error in the AuthGuard of the nest.js guide

### DIFF
--- a/v2/emailpassword/common-customizations/get-user-info.mdx
+++ b/v2/emailpassword/common-customizations/get-user-info.mdx
@@ -287,7 +287,7 @@ import { SessionRequest } from "supertokens-node/framework/express";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Request() req: SessionRequest, @Session() session: Session, @Response({passthrough: true}) res: Response): Promise<boolean> {
     let userId = session.getUserId();
     // You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki

--- a/v2/emailpassword/common-customizations/sessions/revoke-session.mdx
+++ b/v2/emailpassword/common-customizations/sessions/revoke-session.mdx
@@ -200,7 +200,7 @@ import { AuthGuard } from './auth/auth.guard';
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post('logout')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postLogout(@Session() session: SessionContainer): Promise<string> {
     await session.revokeSession();
 

--- a/v2/emailpassword/common-customizations/sessions/session-verification-in-api/get-session.mdx
+++ b/v2/emailpassword/common-customizations/sessions/session-verification-in-api/get-session.mdx
@@ -208,7 +208,7 @@ import Session from "supertokens-node/recipe/session";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Req() req: Request, @Res({passthrough: true}) res: Response): Promise<boolean> {
     //highlight-start
     // This should be done inside a parameter decorator, for more information please read our NestJS guide.
@@ -513,7 +513,7 @@ import Session from "supertokens-node/recipe/session";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Req() req: Request, @Res({ passthrough: true }) res: Response): Promise<boolean> {
     //highlight-start
     // This should be done inside a parameter decorator, for more information please read our NestJS guide.

--- a/v2/emailpassword/common-customizations/sessions/session-verification-in-api/verify-session.mdx
+++ b/v2/emailpassword/common-customizations/sessions/session-verification-in-api/verify-session.mdx
@@ -177,7 +177,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     let userId = session.getUserId();
@@ -596,7 +596,7 @@ import { OptionalAuthGuard } from './auth/optionalAuth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new OptionalAuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     if (session !== undefined) {

--- a/v2/emailpassword/common-customizations/sessions/update-jwt-payload.mdx
+++ b/v2/emailpassword/common-customizations/sessions/update-jwt-payload.mdx
@@ -212,7 +212,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     //highlight-start
     // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.

--- a/v2/emailpassword/common-customizations/sessions/update-session-data.mdx
+++ b/v2/emailpassword/common-customizations/sessions/update-session-data.mdx
@@ -225,7 +225,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/emailpassword/common-customizations/sessions/with-jwt/read-claims.mdx
+++ b/v2/emailpassword/common-customizations/sessions/with-jwt/read-claims.mdx
@@ -202,7 +202,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Get('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ role: string }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/emailpassword/common-customizations/sessions/with-jwt/read-jwt.mdx
+++ b/v2/emailpassword/common-customizations/sessions/with-jwt/read-jwt.mdx
@@ -204,7 +204,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Get('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ token: any }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/emailpassword/common-customizations/sessions/with-jwt/update-jwt.mdx
+++ b/v2/emailpassword/common-customizations/sessions/with-jwt/update-jwt.mdx
@@ -215,7 +215,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     //highlight-start
     // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.

--- a/v2/emailpassword/common-customizations/usermetadata/clear-data.mdx
+++ b/v2/emailpassword/common-customizations/usermetadata/clear-data.mdx
@@ -247,7 +247,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const userId = session.getUserId();
 
@@ -522,7 +522,7 @@ import { AuthGuard } from "./auth/auth.guard";
 @Controller()
 export class ExampleController {
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ success: boolean }> {
     const userId = session.getUserId();
 

--- a/v2/emailpassword/common-customizations/usermetadata/get-data.mdx
+++ b/v2/emailpassword/common-customizations/usermetadata/get-data.mdx
@@ -214,7 +214,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ preferences: any }> {
     const userId = session.getUserId();
 

--- a/v2/emailpassword/common-customizations/usermetadata/store-data.mdx
+++ b/v2/emailpassword/common-customizations/usermetadata/store-data.mdx
@@ -260,7 +260,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const userId = session.getUserId();
 

--- a/v2/emailpassword/common-customizations/verify-session.mdx
+++ b/v2/emailpassword/common-customizations/verify-session.mdx
@@ -177,7 +177,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     let userId = session.getUserId();
@@ -596,7 +596,7 @@ import { OptionalAuthGuard } from './auth/optionalAuth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new OptionalAuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     if (session !== undefined) {

--- a/v2/emailpassword/nestjs/guide.mdx
+++ b/v2/emailpassword/nestjs/guide.mdx
@@ -459,7 +459,7 @@ import { Session } from './auth/session.decorator';
 export class AppController {
   // ...
   @Get('test')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async getTest(@Session() session: SessionContainer): Promise<string> {
     // TODO: magic
     return "magic";

--- a/v2/emailpassword/user-roles/protecting-routes.mdx
+++ b/v2/emailpassword/user-roles/protecting-routes.mdx
@@ -683,7 +683,7 @@ import { Error as STError } from "supertokens-node/recipe/session"
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     // highlight-start
     const roles = await session.getClaimValue(UserRoles.UserRoleClaim);

--- a/v2/passwordless/common-customizations/get-user-info.mdx
+++ b/v2/passwordless/common-customizations/get-user-info.mdx
@@ -339,7 +339,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     let userId = session.getUserId();
     //highlight-next-line

--- a/v2/passwordless/common-customizations/sessions/revoke-session.mdx
+++ b/v2/passwordless/common-customizations/sessions/revoke-session.mdx
@@ -200,7 +200,7 @@ import { AuthGuard } from './auth/auth.guard';
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post('logout')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postLogout(@Session() session: SessionContainer): Promise<string> {
     await session.revokeSession();
 

--- a/v2/passwordless/common-customizations/sessions/session-verification-in-api/get-session.mdx
+++ b/v2/passwordless/common-customizations/sessions/session-verification-in-api/get-session.mdx
@@ -208,7 +208,7 @@ import Session from "supertokens-node/recipe/session";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Req() req: Request, @Res({passthrough: true}) res: Response): Promise<boolean> {
     //highlight-start
     // This should be done inside a parameter decorator, for more information please read our NestJS guide.
@@ -513,7 +513,7 @@ import Session from "supertokens-node/recipe/session";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Req() req: Request, @Res({ passthrough: true }) res: Response): Promise<boolean> {
     //highlight-start
     // This should be done inside a parameter decorator, for more information please read our NestJS guide.

--- a/v2/passwordless/common-customizations/sessions/session-verification-in-api/verify-session.mdx
+++ b/v2/passwordless/common-customizations/sessions/session-verification-in-api/verify-session.mdx
@@ -177,7 +177,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     let userId = session.getUserId();
@@ -596,7 +596,7 @@ import { OptionalAuthGuard } from './auth/optionalAuth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new OptionalAuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     if (session !== undefined) {

--- a/v2/passwordless/common-customizations/sessions/update-jwt-payload.mdx
+++ b/v2/passwordless/common-customizations/sessions/update-jwt-payload.mdx
@@ -212,7 +212,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     //highlight-start
     // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.

--- a/v2/passwordless/common-customizations/sessions/update-session-data.mdx
+++ b/v2/passwordless/common-customizations/sessions/update-session-data.mdx
@@ -225,7 +225,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/passwordless/common-customizations/sessions/with-jwt/read-claims.mdx
+++ b/v2/passwordless/common-customizations/sessions/with-jwt/read-claims.mdx
@@ -202,7 +202,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Get('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ role: string }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/passwordless/common-customizations/sessions/with-jwt/read-jwt.mdx
+++ b/v2/passwordless/common-customizations/sessions/with-jwt/read-jwt.mdx
@@ -204,7 +204,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Get('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ token: any }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/passwordless/common-customizations/sessions/with-jwt/update-jwt.mdx
+++ b/v2/passwordless/common-customizations/sessions/with-jwt/update-jwt.mdx
@@ -215,7 +215,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     //highlight-start
     // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.

--- a/v2/passwordless/common-customizations/usermetadata/clear-data.mdx
+++ b/v2/passwordless/common-customizations/usermetadata/clear-data.mdx
@@ -247,7 +247,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const userId = session.getUserId();
 
@@ -522,7 +522,7 @@ import { AuthGuard } from "./auth/auth.guard";
 @Controller()
 export class ExampleController {
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ success: boolean }> {
     const userId = session.getUserId();
 

--- a/v2/passwordless/common-customizations/usermetadata/get-data.mdx
+++ b/v2/passwordless/common-customizations/usermetadata/get-data.mdx
@@ -214,7 +214,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ preferences: any }> {
     const userId = session.getUserId();
 

--- a/v2/passwordless/common-customizations/usermetadata/store-data.mdx
+++ b/v2/passwordless/common-customizations/usermetadata/store-data.mdx
@@ -260,7 +260,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const userId = session.getUserId();
 

--- a/v2/passwordless/common-customizations/verify-session.mdx
+++ b/v2/passwordless/common-customizations/verify-session.mdx
@@ -177,7 +177,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     let userId = session.getUserId();
@@ -596,7 +596,7 @@ import { OptionalAuthGuard } from './auth/optionalAuth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new OptionalAuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     if (session !== undefined) {

--- a/v2/passwordless/nestjs/guide.mdx
+++ b/v2/passwordless/nestjs/guide.mdx
@@ -472,7 +472,7 @@ import { Session } from './auth/session.decorator';
 export class AppController {
   // ...
   @Get('test')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async getTest(@Session() session: SessionContainer): Promise<string> {
     // TODO: magic
     return "magic";

--- a/v2/passwordless/user-roles/protecting-routes.mdx
+++ b/v2/passwordless/user-roles/protecting-routes.mdx
@@ -683,7 +683,7 @@ import { Error as STError } from "supertokens-node/recipe/session"
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     // highlight-start
     const roles = await session.getClaimValue(UserRoles.UserRoleClaim);

--- a/v2/session/common-customizations/sessions/revoke-session.mdx
+++ b/v2/session/common-customizations/sessions/revoke-session.mdx
@@ -200,7 +200,7 @@ import { AuthGuard } from './auth/auth.guard';
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post('logout')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postLogout(@Session() session: SessionContainer): Promise<string> {
     await session.revokeSession();
 

--- a/v2/session/common-customizations/sessions/session-verification-in-api/get-session.mdx
+++ b/v2/session/common-customizations/sessions/session-verification-in-api/get-session.mdx
@@ -208,7 +208,7 @@ import Session from "supertokens-node/recipe/session";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Req() req: Request, @Res({passthrough: true}) res: Response): Promise<boolean> {
     //highlight-start
     // This should be done inside a parameter decorator, for more information please read our NestJS guide.
@@ -513,7 +513,7 @@ import Session from "supertokens-node/recipe/session";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Req() req: Request, @Res({ passthrough: true }) res: Response): Promise<boolean> {
     //highlight-start
     // This should be done inside a parameter decorator, for more information please read our NestJS guide.

--- a/v2/session/common-customizations/sessions/session-verification-in-api/verify-session.mdx
+++ b/v2/session/common-customizations/sessions/session-verification-in-api/verify-session.mdx
@@ -177,7 +177,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     let userId = session.getUserId();
@@ -596,7 +596,7 @@ import { OptionalAuthGuard } from './auth/optionalAuth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new OptionalAuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     if (session !== undefined) {

--- a/v2/session/common-customizations/sessions/update-jwt-payload.mdx
+++ b/v2/session/common-customizations/sessions/update-jwt-payload.mdx
@@ -212,7 +212,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     //highlight-start
     // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.

--- a/v2/session/common-customizations/sessions/update-session-data.mdx
+++ b/v2/session/common-customizations/sessions/update-session-data.mdx
@@ -225,7 +225,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/session/common-customizations/sessions/with-jwt/read-claims.mdx
+++ b/v2/session/common-customizations/sessions/with-jwt/read-claims.mdx
@@ -202,7 +202,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Get('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ role: string }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/session/common-customizations/sessions/with-jwt/read-jwt.mdx
+++ b/v2/session/common-customizations/sessions/with-jwt/read-jwt.mdx
@@ -204,7 +204,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Get('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ token: any }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/session/common-customizations/sessions/with-jwt/update-jwt.mdx
+++ b/v2/session/common-customizations/sessions/with-jwt/update-jwt.mdx
@@ -215,7 +215,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     //highlight-start
     // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.

--- a/v2/session/nestjs/guide.mdx
+++ b/v2/session/nestjs/guide.mdx
@@ -457,7 +457,7 @@ import { Session } from './auth/session.decorator';
 export class AppController {
   // ...
   @Get('test')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async getTest(@Session() session: SessionContainer): Promise<string> {
     // TODO: magic
     return "magic";

--- a/v2/thirdparty/common-customizations/get-user-info.mdx
+++ b/v2/thirdparty/common-customizations/get-user-info.mdx
@@ -287,7 +287,7 @@ import { SessionRequest } from "supertokens-node/framework/express";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Request() req: SessionRequest, @Session() session: Session, @Response({passthrough: true}) res: Response): Promise<boolean> {
     let userId = session.getUserId();
     // You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki

--- a/v2/thirdparty/common-customizations/sessions/revoke-session.mdx
+++ b/v2/thirdparty/common-customizations/sessions/revoke-session.mdx
@@ -200,7 +200,7 @@ import { AuthGuard } from './auth/auth.guard';
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post('logout')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postLogout(@Session() session: SessionContainer): Promise<string> {
     await session.revokeSession();
 

--- a/v2/thirdparty/common-customizations/sessions/session-verification-in-api/get-session.mdx
+++ b/v2/thirdparty/common-customizations/sessions/session-verification-in-api/get-session.mdx
@@ -208,7 +208,7 @@ import Session from "supertokens-node/recipe/session";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Req() req: Request, @Res({passthrough: true}) res: Response): Promise<boolean> {
     //highlight-start
     // This should be done inside a parameter decorator, for more information please read our NestJS guide.
@@ -513,7 +513,7 @@ import Session from "supertokens-node/recipe/session";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Req() req: Request, @Res({ passthrough: true }) res: Response): Promise<boolean> {
     //highlight-start
     // This should be done inside a parameter decorator, for more information please read our NestJS guide.

--- a/v2/thirdparty/common-customizations/sessions/session-verification-in-api/verify-session.mdx
+++ b/v2/thirdparty/common-customizations/sessions/session-verification-in-api/verify-session.mdx
@@ -177,7 +177,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     let userId = session.getUserId();
@@ -596,7 +596,7 @@ import { OptionalAuthGuard } from './auth/optionalAuth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new OptionalAuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     if (session !== undefined) {

--- a/v2/thirdparty/common-customizations/sessions/update-jwt-payload.mdx
+++ b/v2/thirdparty/common-customizations/sessions/update-jwt-payload.mdx
@@ -212,7 +212,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     //highlight-start
     // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.

--- a/v2/thirdparty/common-customizations/sessions/update-session-data.mdx
+++ b/v2/thirdparty/common-customizations/sessions/update-session-data.mdx
@@ -225,7 +225,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/thirdparty/common-customizations/sessions/with-jwt/read-claims.mdx
+++ b/v2/thirdparty/common-customizations/sessions/with-jwt/read-claims.mdx
@@ -202,7 +202,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Get('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ role: string }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/thirdparty/common-customizations/sessions/with-jwt/read-jwt.mdx
+++ b/v2/thirdparty/common-customizations/sessions/with-jwt/read-jwt.mdx
@@ -204,7 +204,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Get('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ token: any }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/thirdparty/common-customizations/sessions/with-jwt/update-jwt.mdx
+++ b/v2/thirdparty/common-customizations/sessions/with-jwt/update-jwt.mdx
@@ -215,7 +215,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     //highlight-start
     // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.

--- a/v2/thirdparty/common-customizations/usermetadata/clear-data.mdx
+++ b/v2/thirdparty/common-customizations/usermetadata/clear-data.mdx
@@ -247,7 +247,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const userId = session.getUserId();
 
@@ -522,7 +522,7 @@ import { AuthGuard } from "./auth/auth.guard";
 @Controller()
 export class ExampleController {
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ success: boolean }> {
     const userId = session.getUserId();
 

--- a/v2/thirdparty/common-customizations/usermetadata/get-data.mdx
+++ b/v2/thirdparty/common-customizations/usermetadata/get-data.mdx
@@ -214,7 +214,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ preferences: any }> {
     const userId = session.getUserId();
 

--- a/v2/thirdparty/common-customizations/usermetadata/store-data.mdx
+++ b/v2/thirdparty/common-customizations/usermetadata/store-data.mdx
@@ -260,7 +260,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const userId = session.getUserId();
 

--- a/v2/thirdparty/common-customizations/verify-session.mdx
+++ b/v2/thirdparty/common-customizations/verify-session.mdx
@@ -177,7 +177,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     let userId = session.getUserId();
@@ -596,7 +596,7 @@ import { OptionalAuthGuard } from './auth/optionalAuth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new OptionalAuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     if (session !== undefined) {

--- a/v2/thirdparty/nestjs/guide.mdx
+++ b/v2/thirdparty/nestjs/guide.mdx
@@ -531,7 +531,7 @@ import { Session } from './auth/session.decorator';
 export class AppController {
   // ...
   @Get('test')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async getTest(@Session() session: SessionContainer): Promise<string> {
     // TODO: magic
     return "magic";

--- a/v2/thirdparty/user-roles/protecting-routes.mdx
+++ b/v2/thirdparty/user-roles/protecting-routes.mdx
@@ -683,7 +683,7 @@ import { Error as STError } from "supertokens-node/recipe/session"
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     // highlight-start
     const roles = await session.getClaimValue(UserRoles.UserRoleClaim);

--- a/v2/thirdpartyemailpassword/common-customizations/get-user-info.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/get-user-info.mdx
@@ -287,7 +287,7 @@ import { SessionRequest } from "supertokens-node/framework/express";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Request() req: SessionRequest, @Session() session: Session, @Response({passthrough: true}) res: Response): Promise<boolean> {
     let userId = session.getUserId();
     // You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/revoke-session.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/revoke-session.mdx
@@ -200,7 +200,7 @@ import { AuthGuard } from './auth/auth.guard';
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post('logout')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postLogout(@Session() session: SessionContainer): Promise<string> {
     await session.revokeSession();
 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/session-verification-in-api/get-session.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/session-verification-in-api/get-session.mdx
@@ -208,7 +208,7 @@ import Session from "supertokens-node/recipe/session";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Req() req: Request, @Res({passthrough: true}) res: Response): Promise<boolean> {
     //highlight-start
     // This should be done inside a parameter decorator, for more information please read our NestJS guide.
@@ -513,7 +513,7 @@ import Session from "supertokens-node/recipe/session";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Req() req: Request, @Res({ passthrough: true }) res: Response): Promise<boolean> {
     //highlight-start
     // This should be done inside a parameter decorator, for more information please read our NestJS guide.

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/session-verification-in-api/verify-session.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/session-verification-in-api/verify-session.mdx
@@ -177,7 +177,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     let userId = session.getUserId();
@@ -596,7 +596,7 @@ import { OptionalAuthGuard } from './auth/optionalAuth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new OptionalAuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     if (session !== undefined) {

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/update-jwt-payload.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/update-jwt-payload.mdx
@@ -212,7 +212,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     //highlight-start
     // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/update-session-data.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/update-session-data.mdx
@@ -225,7 +225,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/read-claims.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/read-claims.mdx
@@ -202,7 +202,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Get('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ role: string }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/read-jwt.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/read-jwt.mdx
@@ -204,7 +204,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Get('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ token: any }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/update-jwt.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/with-jwt/update-jwt.mdx
@@ -215,7 +215,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     //highlight-start
     // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.

--- a/v2/thirdpartyemailpassword/common-customizations/usermetadata/clear-data.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/usermetadata/clear-data.mdx
@@ -247,7 +247,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const userId = session.getUserId();
 
@@ -522,7 +522,7 @@ import { AuthGuard } from "./auth/auth.guard";
 @Controller()
 export class ExampleController {
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ success: boolean }> {
     const userId = session.getUserId();
 

--- a/v2/thirdpartyemailpassword/common-customizations/usermetadata/get-data.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/usermetadata/get-data.mdx
@@ -214,7 +214,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ preferences: any }> {
     const userId = session.getUserId();
 

--- a/v2/thirdpartyemailpassword/common-customizations/usermetadata/store-data.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/usermetadata/store-data.mdx
@@ -260,7 +260,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const userId = session.getUserId();
 

--- a/v2/thirdpartyemailpassword/common-customizations/verify-session.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/verify-session.mdx
@@ -177,7 +177,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     let userId = session.getUserId();
@@ -596,7 +596,7 @@ import { OptionalAuthGuard } from './auth/optionalAuth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new OptionalAuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     if (session !== undefined) {

--- a/v2/thirdpartyemailpassword/nestjs/guide.mdx
+++ b/v2/thirdpartyemailpassword/nestjs/guide.mdx
@@ -529,7 +529,7 @@ import { Session } from './auth/session.decorator';
 export class AppController {
   // ...
   @Get('test')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async getTest(@Session() session: SessionContainer): Promise<string> {
     // TODO: magic
     return "magic";

--- a/v2/thirdpartyemailpassword/user-roles/protecting-routes.mdx
+++ b/v2/thirdpartyemailpassword/user-roles/protecting-routes.mdx
@@ -683,7 +683,7 @@ import { Error as STError } from "supertokens-node/recipe/session"
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     // highlight-start
     const roles = await session.getClaimValue(UserRoles.UserRoleClaim);

--- a/v2/thirdpartypasswordless/common-customizations/get-user-info.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/get-user-info.mdx
@@ -337,7 +337,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     let userId = session.getUserId();
     //highlight-next-line

--- a/v2/thirdpartypasswordless/common-customizations/sessions/revoke-session.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/revoke-session.mdx
@@ -200,7 +200,7 @@ import { AuthGuard } from './auth/auth.guard';
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post('logout')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postLogout(@Session() session: SessionContainer): Promise<string> {
     await session.revokeSession();
 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/session-verification-in-api/get-session.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/session-verification-in-api/get-session.mdx
@@ -208,7 +208,7 @@ import Session from "supertokens-node/recipe/session";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Req() req: Request, @Res({passthrough: true}) res: Response): Promise<boolean> {
     //highlight-start
     // This should be done inside a parameter decorator, for more information please read our NestJS guide.
@@ -513,7 +513,7 @@ import Session from "supertokens-node/recipe/session";
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Req() req: Request, @Res({ passthrough: true }) res: Response): Promise<boolean> {
     //highlight-start
     // This should be done inside a parameter decorator, for more information please read our NestJS guide.

--- a/v2/thirdpartypasswordless/common-customizations/sessions/session-verification-in-api/verify-session.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/session-verification-in-api/verify-session.mdx
@@ -177,7 +177,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     let userId = session.getUserId();
@@ -596,7 +596,7 @@ import { OptionalAuthGuard } from './auth/optionalAuth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new OptionalAuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     if (session !== undefined) {

--- a/v2/thirdpartypasswordless/common-customizations/sessions/update-jwt-payload.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/update-jwt-payload.mdx
@@ -212,7 +212,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     //highlight-start
     // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.

--- a/v2/thirdpartypasswordless/common-customizations/sessions/update-session-data.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/update-session-data.mdx
@@ -225,7 +225,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/read-claims.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/read-claims.mdx
@@ -202,7 +202,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Get('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ role: string }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/read-jwt.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/read-jwt.mdx
@@ -204,7 +204,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Get('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ token: any }> {
     const currAccessTokenPayload = session.getAccessTokenPayload();
 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/update-jwt.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/with-jwt/update-jwt.mdx
@@ -215,7 +215,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     //highlight-start
     // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.

--- a/v2/thirdpartypasswordless/common-customizations/usermetadata/clear-data.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/usermetadata/clear-data.mdx
@@ -247,7 +247,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const userId = session.getUserId();
 
@@ -522,7 +522,7 @@ import { AuthGuard } from "./auth/auth.guard";
 @Controller()
 export class ExampleController {
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ success: boolean }> {
     const userId = session.getUserId();
 

--- a/v2/thirdpartypasswordless/common-customizations/usermetadata/get-data.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/usermetadata/get-data.mdx
@@ -214,7 +214,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ preferences: any }> {
     const userId = session.getUserId();
 

--- a/v2/thirdpartypasswordless/common-customizations/usermetadata/store-data.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/usermetadata/store-data.mdx
@@ -260,7 +260,7 @@ import { AuthGuard } from "./auth/auth.guard";
 export class ExampleController {
   // For more information about "AuthGuard" and the "Session" decorator please read our NestJS guide.
   @Post("example")
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<{ message: string }> {
     const userId = session.getUserId();
 

--- a/v2/thirdpartypasswordless/common-customizations/verify-session.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/verify-session.mdx
@@ -177,7 +177,7 @@ import { AuthGuard } from './auth/auth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     let userId = session.getUserId();
@@ -596,7 +596,7 @@ import { OptionalAuthGuard } from './auth/optionalAuth.guard';
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(OptionalAuthGuard) // For more information about this guard please read our NestJS guide.
+  @UseGuards(new OptionalAuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     //highlight-start
     if (session !== undefined) {

--- a/v2/thirdpartypasswordless/nestjs/guide.mdx
+++ b/v2/thirdpartypasswordless/nestjs/guide.mdx
@@ -472,7 +472,7 @@ import { Session } from './auth/session.decorator';
 export class AppController {
   // ...
   @Get('test')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async getTest(@Session() session: SessionContainer): Promise<string> {
     // TODO: magic
     return "magic";

--- a/v2/thirdpartypasswordless/user-roles/protecting-routes.mdx
+++ b/v2/thirdpartypasswordless/user-roles/protecting-routes.mdx
@@ -683,7 +683,7 @@ import { Error as STError } from "supertokens-node/recipe/session"
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     // highlight-start
     const roles = await session.getClaimValue(UserRoles.UserRoleClaim);

--- a/v2/userroles/protecting-routes.mdx
+++ b/v2/userroles/protecting-routes.mdx
@@ -683,7 +683,7 @@ import { Error as STError } from "supertokens-node/recipe/session"
 @Controller()
 export class ExampleController {
   @Post('example')
-  @UseGuards(AuthGuard)
+  @UseGuards(new AuthGuard())
   async postExample(@Session() session: SessionContainer): Promise<boolean> {
     // highlight-start
     const roles = await session.getClaimValue(UserRoles.UserRoleClaim);


### PR DESCRIPTION
## Summary of change

Changed the NestJs related code snippets to add an instance of the auth guard instead of injecting it.

## Related issues


## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
