### PR TITLE
Fix code type checking for swift

### DIFF
--- a/v2/src/plugins/codeTypeChecking/index.js
+++ b/v2/src/plugins/codeTypeChecking/index.js
@@ -10,7 +10,7 @@ function hash(input) {
     return crypto.createHash('md5').update(input).digest('hex');
 }
 
-async function addCodeSnippetToEnv(mdFile) {
+async function addCodeSnippetToEnv(mdFile, isSwiftEnabled) {
     if (mdFile.includes("/v2/change_me/") || mdFile.includes("/v2/contribute/") ||
         mdFile.includes("/v2/nodejs") || mdFile.includes("/v2/golang") || mdFile.includes("/v2/python") ||
         mdFile.includes("/v2/auth-react") || mdFile.includes("/v2/website") || mdFile.includes("/v2/react-native") || mdFile.includes("/codeTypeChecking/")) {
@@ -62,8 +62,7 @@ async function addCodeSnippetToEnv(mdFile) {
                         } else if (currLineTrimmed === "```kotlin" || currLineTrimmed.startsWith("```kotlin ")) {
                             currentCodeLanguage = "kotlin";
                         } else if (currLineTrimmed === "```swift" || currLineTrimmed.startsWith("```swift ")) {
-                            currentCodeLanguage = "ignore"
-                            // TODO: Nemi -> fix -> we can keep it ignore unless CODE_TYPE_CHECK=swift is given in the process env
+                            currentCodeLanguage = isSwiftEnabled ? "swift" : "ignore"
                         } else if (currLineTrimmed.includes("bash") || currLineTrimmed.includes("yaml") || currLineTrimmed.includes("cql") || currLineTrimmed.includes("sql") || currLineTrimmed.includes("batch") ||
                             currLineTrimmed.includes("text") || currLineTrimmed.includes("json")
                             || currLineTrimmed.includes("html")) {

--- a/v2/src/plugins/copyDocsAndCodeTypeChecking.js
+++ b/v2/src/plugins/copyDocsAndCodeTypeChecking.js
@@ -47,8 +47,9 @@ module.exports = function (context, opts) {
 
             if (check !== undefined && check !== "nothing") {
                 let splittedCheck = check.split(",");
+                const isSwiftEnabled = splittedCheck.filter(i => i === "swift").length >= 1;
 
-                if (splittedCheck.filter(i => i === "swift").length >= 1) {
+                if (isSwiftEnabled) {
                     // Reset iosenv
                     execSync("./src/plugins/codeTypeChecking/iosenv/resetenv.rb")
 
@@ -66,7 +67,7 @@ module.exports = function (context, opts) {
 
                 // add code snippets to their respective env..
                 for (const mdPath of origDocs) {
-                    await addCodeSnippetToEnv(mdPath);
+                    await addCodeSnippetToEnv(mdPath, isSwiftEnabled);
                 }
             }
 


### PR DESCRIPTION
## Summary of change
- Changes code type checking to generate swift code files only if swift is specifically enabled when running the start script

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2