### PR TITLE
chore: Add docker version provider component to add version to docker snippets for core

### DIFF
--- a/v2/community/supertokens-core/self-hosted/with-docker.mdx
+++ b/v2/community/supertokens-core/self-hosted/with-docker.mdx
@@ -10,16 +10,19 @@ hide_title: true
 import DatabaseTabs from "/src/components/tabs/DatabaseTabs"
 import TabItem from '@theme/TabItem';
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";
+import DockerVersionProvider from "/src/components/dockerVersionProvider";
 
 # With Docker
 
 ## Running the docker image 🚀
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md).
@@ -31,7 +34,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
 <TabItem value="postgresql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -43,7 +46,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postg
 <TabItem value="mongodb">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb^{docker_version_mongodb}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mongodb/blob/master/README.md).
@@ -55,6 +58,8 @@ We do not offer login functionality with MongDB yet. We only offer session manag
 :::
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider> 
 
 ## Testing that the service is running 🤞
 Open a browser and visit `http://localhost:3567/hello`. If you see a page that says `Hello` back, then the container was started successfully!
@@ -142,6 +147,8 @@ There is no API key by default. Visit the "Auth flow customization" -> "SuperTok
 
 ## Docker compose file
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
@@ -167,7 +174,7 @@ services:
       retries: 10
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
       - db
     ports:
@@ -215,7 +222,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
       - db
     ports:
@@ -246,6 +253,8 @@ We are working on adding this section.
 
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider>
 
 
 ## Helm charts for Kubernetes

--- a/v2/emailpassword/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/emailpassword/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -10,16 +10,19 @@ hide_title: true
 import DatabaseTabs from "/src/components/tabs/DatabaseTabs"
 import TabItem from '@theme/TabItem';
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";
+import DockerVersionProvider from "/src/components/dockerVersionProvider";
 
 # With Docker
 
 ## Running the docker image 🚀
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md).
@@ -31,7 +34,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
 <TabItem value="postgresql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -43,7 +46,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postg
 <TabItem value="mongodb">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb^{docker_version_mongodb}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mongodb/blob/master/README.md).
@@ -55,6 +58,8 @@ We do not offer login functionality with MongDB yet. We only offer session manag
 :::
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider> 
 
 ## Testing that the service is running 🤞
 Open a browser and visit `http://localhost:3567/hello`. If you see a page that says `Hello` back, then the container was started successfully!
@@ -142,6 +147,8 @@ There is no API key by default. Visit the "Auth flow customization" -> "SuperTok
 
 ## Docker compose file
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
@@ -167,7 +174,7 @@ services:
       retries: 10
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
       - db
     ports:
@@ -215,7 +222,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
       - db
     ports:
@@ -246,6 +253,8 @@ We are working on adding this section.
 
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider>
 
 
 ## Helm charts for Kubernetes

--- a/v2/emailpassword/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/emailpassword/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -10,16 +10,19 @@ hide_title: true
 import DatabaseTabs from "/src/components/tabs/DatabaseTabs"
 import TabItem from '@theme/TabItem';
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";
+import DockerVersionProvider from "/src/components/dockerVersionProvider";
 
 # With Docker
 
 ## Running the docker image 🚀
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md).
@@ -31,7 +34,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
 <TabItem value="postgresql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -43,7 +46,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postg
 <TabItem value="mongodb">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb^{docker_version_mongodb}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mongodb/blob/master/README.md).
@@ -55,6 +58,8 @@ We do not offer login functionality with MongDB yet. We only offer session manag
 :::
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider> 
 
 ## Testing that the service is running 🤞
 Open a browser and visit `http://localhost:3567/hello`. If you see a page that says `Hello` back, then the container was started successfully!
@@ -142,6 +147,8 @@ There is no API key by default. Visit the "Auth flow customization" -> "SuperTok
 
 ## Docker compose file
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
@@ -167,7 +174,7 @@ services:
       retries: 10
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
       - db
     ports:
@@ -215,7 +222,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
       - db
     ports:
@@ -246,6 +253,8 @@ We are working on adding this section.
 
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider>
 
 
 ## Helm charts for Kubernetes

--- a/v2/passwordless/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/passwordless/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -10,16 +10,19 @@ hide_title: true
 import DatabaseTabs from "/src/components/tabs/DatabaseTabs"
 import TabItem from '@theme/TabItem';
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";
+import DockerVersionProvider from "/src/components/dockerVersionProvider";
 
 # With Docker
 
 ## Running the docker image 🚀
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md).
@@ -31,7 +34,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
 <TabItem value="postgresql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -43,7 +46,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postg
 <TabItem value="mongodb">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb^{docker_version_mongodb}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mongodb/blob/master/README.md).
@@ -55,6 +58,8 @@ We do not offer login functionality with MongDB yet. We only offer session manag
 :::
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider> 
 
 ## Testing that the service is running 🤞
 Open a browser and visit `http://localhost:3567/hello`. If you see a page that says `Hello` back, then the container was started successfully!
@@ -142,6 +147,8 @@ There is no API key by default. Visit the "Auth flow customization" -> "SuperTok
 
 ## Docker compose file
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
@@ -167,7 +174,7 @@ services:
       retries: 10
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
       - db
     ports:
@@ -215,7 +222,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
       - db
     ports:
@@ -246,6 +253,8 @@ We are working on adding this section.
 
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider>
 
 
 ## Helm charts for Kubernetes

--- a/v2/passwordless/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/passwordless/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -10,16 +10,19 @@ hide_title: true
 import DatabaseTabs from "/src/components/tabs/DatabaseTabs"
 import TabItem from '@theme/TabItem';
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";
+import DockerVersionProvider from "/src/components/dockerVersionProvider";
 
 # With Docker
 
 ## Running the docker image 🚀
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md).
@@ -31,7 +34,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
 <TabItem value="postgresql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -43,7 +46,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postg
 <TabItem value="mongodb">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb^{docker_version_mongodb}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mongodb/blob/master/README.md).
@@ -55,6 +58,8 @@ We do not offer login functionality with MongDB yet. We only offer session manag
 :::
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider> 
 
 ## Testing that the service is running 🤞
 Open a browser and visit `http://localhost:3567/hello`. If you see a page that says `Hello` back, then the container was started successfully!
@@ -142,6 +147,8 @@ There is no API key by default. Visit the "Auth flow customization" -> "SuperTok
 
 ## Docker compose file
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
@@ -167,7 +174,7 @@ services:
       retries: 10
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
       - db
     ports:
@@ -215,7 +222,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
       - db
     ports:
@@ -246,6 +253,8 @@ We are working on adding this section.
 
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider>
 
 
 ## Helm charts for Kubernetes

--- a/v2/session/quick-setup/core/self-hosted-with-docker.mdx
+++ b/v2/session/quick-setup/core/self-hosted-with-docker.mdx
@@ -10,16 +10,19 @@ hide_title: true
 import DatabaseTabs from "/src/components/tabs/DatabaseTabs"
 import TabItem from '@theme/TabItem';
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";
+import DockerVersionProvider from "/src/components/dockerVersionProvider";
 
 # With Docker
 
 ## Running the docker image 🚀
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md).
@@ -31,7 +34,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
 <TabItem value="postgresql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -43,7 +46,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postg
 <TabItem value="mongodb">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb^{docker_version_mongodb}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mongodb/blob/master/README.md).
@@ -55,6 +58,8 @@ We do not offer login functionality with MongDB yet. We only offer session manag
 :::
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider> 
 
 ## Testing that the service is running 🤞
 Open a browser and visit `http://localhost:3567/hello`. If you see a page that says `Hello` back, then the container was started successfully!
@@ -142,6 +147,8 @@ There is no API key by default. Visit the "Auth flow customization" -> "SuperTok
 
 ## Docker compose file
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
@@ -167,7 +174,7 @@ services:
       retries: 10
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
       - db
     ports:
@@ -215,7 +222,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
       - db
     ports:
@@ -246,6 +253,8 @@ We are working on adding this section.
 
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider>
 
 
 ## Helm charts for Kubernetes

--- a/v2/src/components/api/plugin/dependency/cores.ts
+++ b/v2/src/components/api/plugin/dependency/cores.ts
@@ -1,0 +1,23 @@
+import { API_URL } from "../../../constants";
+import * as httpNetworking from "../../../httpNetworking";
+
+const URL = API_URL + "/plugin/dependency/cores";
+const VERSION = 0;
+
+type Response = {
+    cores: string[],
+}
+
+export async function getCoreVersionForPlugin(plugin: string): Promise<Response> {
+    const options: httpNetworking.GETRequestConfig = {
+        timeout: 10000,
+        params: {
+            planType: "FREE",
+            mode: "PRODUCTION",
+            name: plugin,
+        }
+    };
+
+    const result = await httpNetworking.simpleGETRequest(URL, options, VERSION);
+    return result.data;
+}

--- a/v2/src/components/dockerVersionProvider/index.tsx
+++ b/v2/src/components/dockerVersionProvider/index.tsx
@@ -1,0 +1,71 @@
+/* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+*
+* This software is licensed under the Apache License, Version 2.0 (the
+* "License") as published by the Apache Software Foundation.
+*
+* You may not use this file except in compliance with the License. You may
+* obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+import React, { useCallback, useEffect, useState } from "react";
+import { getCoreVersionForPlugin } from "../api/plugin/dependency/cores";
+import { recursiveMap } from "../utils";
+
+type Props = {}
+type DockerVersions = {
+    mysql: string,
+    mongo: string,
+    postgres: string,
+}
+
+const DockerVersionProvider: React.FC<Props>  = (props) => {
+    const [dockerVersions, setDockerVersions] = useState<DockerVersions>({
+        mysql: "",
+        mongo: "",
+        postgres: "",
+    });
+    const mysqlVersionString = "^{docker_version_mysql}"
+    const mongoVersionString = "^{docker_version_mongodb}"
+    const postGresVersionString = "^{docker_version_postgresql}"
+
+    const fetchImageVersion = useCallback(async () => {
+        try {
+            const result = await Promise.all([
+                await getCoreVersionForPlugin("mysql"),
+                await getCoreVersionForPlugin("mongodb"),
+                await getCoreVersionForPlugin("postgresql"),
+            ])
+
+            setDockerVersions({
+                mysql: result[0].cores[0],
+                mongo: result[1].cores[0],
+                postgres: result[2].cores[0],
+            })
+        } catch (e) {}
+    }, [])
+
+    useEffect(() => {
+        void fetchImageVersion();
+    }, [])
+
+    return <>{recursiveMap(props.children, (c: any) => {
+        if (typeof c === "string") {
+            const mysqlReplacement = dockerVersions.mysql === "" ? ":" : `:${dockerVersions.mysql}`;
+            const mongoReplacement = dockerVersions.mongo === "" ? "" : `:${dockerVersions.mongo}`;
+            const postgresReplacement = dockerVersions.postgres === "" ? "" : `:${dockerVersions.postgres}`;
+
+            c = c.split(mysqlVersionString).join(mysqlReplacement);
+            c = c.split(mongoVersionString).join(mongoReplacement);
+            c = c.split(postGresVersionString).join(postgresReplacement);
+        }
+
+        return c;
+    })}</>;
+}
+
+export default DockerVersionProvider;

--- a/v2/thirdparty/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/thirdparty/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -10,16 +10,19 @@ hide_title: true
 import DatabaseTabs from "/src/components/tabs/DatabaseTabs"
 import TabItem from '@theme/TabItem';
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";
+import DockerVersionProvider from "/src/components/dockerVersionProvider";
 
 # With Docker
 
 ## Running the docker image 🚀
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md).
@@ -31,7 +34,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
 <TabItem value="postgresql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -43,7 +46,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postg
 <TabItem value="mongodb">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb^{docker_version_mongodb}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mongodb/blob/master/README.md).
@@ -55,6 +58,8 @@ We do not offer login functionality with MongDB yet. We only offer session manag
 :::
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider> 
 
 ## Testing that the service is running 🤞
 Open a browser and visit `http://localhost:3567/hello`. If you see a page that says `Hello` back, then the container was started successfully!
@@ -142,6 +147,8 @@ There is no API key by default. Visit the "Auth flow customization" -> "SuperTok
 
 ## Docker compose file
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
@@ -167,7 +174,7 @@ services:
       retries: 10
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
       - db
     ports:
@@ -215,7 +222,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
       - db
     ports:
@@ -246,6 +253,8 @@ We are working on adding this section.
 
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider>
 
 
 ## Helm charts for Kubernetes

--- a/v2/thirdparty/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/thirdparty/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -10,16 +10,19 @@ hide_title: true
 import DatabaseTabs from "/src/components/tabs/DatabaseTabs"
 import TabItem from '@theme/TabItem';
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";
+import DockerVersionProvider from "/src/components/dockerVersionProvider";
 
 # With Docker
 
 ## Running the docker image 🚀
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md).
@@ -31,7 +34,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
 <TabItem value="postgresql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -43,7 +46,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postg
 <TabItem value="mongodb">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb^{docker_version_mongodb}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mongodb/blob/master/README.md).
@@ -55,6 +58,8 @@ We do not offer login functionality with MongDB yet. We only offer session manag
 :::
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider> 
 
 ## Testing that the service is running 🤞
 Open a browser and visit `http://localhost:3567/hello`. If you see a page that says `Hello` back, then the container was started successfully!
@@ -142,6 +147,8 @@ There is no API key by default. Visit the "Auth flow customization" -> "SuperTok
 
 ## Docker compose file
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
@@ -167,7 +174,7 @@ services:
       retries: 10
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
       - db
     ports:
@@ -215,7 +222,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
       - db
     ports:
@@ -246,6 +253,8 @@ We are working on adding this section.
 
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider>
 
 
 ## Helm charts for Kubernetes

--- a/v2/thirdpartyemailpassword/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/thirdpartyemailpassword/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -10,16 +10,19 @@ hide_title: true
 import DatabaseTabs from "/src/components/tabs/DatabaseTabs"
 import TabItem from '@theme/TabItem';
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";
+import DockerVersionProvider from "/src/components/dockerVersionProvider";
 
 # With Docker
 
 ## Running the docker image 🚀
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md).
@@ -31,7 +34,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
 <TabItem value="postgresql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -43,7 +46,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postg
 <TabItem value="mongodb">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb^{docker_version_mongodb}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mongodb/blob/master/README.md).
@@ -55,6 +58,8 @@ We do not offer login functionality with MongDB yet. We only offer session manag
 :::
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider> 
 
 ## Testing that the service is running 🤞
 Open a browser and visit `http://localhost:3567/hello`. If you see a page that says `Hello` back, then the container was started successfully!
@@ -142,6 +147,8 @@ There is no API key by default. Visit the "Auth flow customization" -> "SuperTok
 
 ## Docker compose file
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
@@ -167,7 +174,7 @@ services:
       retries: 10
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
       - db
     ports:
@@ -215,7 +222,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
       - db
     ports:
@@ -246,6 +253,8 @@ We are working on adding this section.
 
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider>
 
 
 ## Helm charts for Kubernetes

--- a/v2/thirdpartyemailpassword/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/thirdpartyemailpassword/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -10,16 +10,19 @@ hide_title: true
 import DatabaseTabs from "/src/components/tabs/DatabaseTabs"
 import TabItem from '@theme/TabItem';
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";
+import DockerVersionProvider from "/src/components/dockerVersionProvider";
 
 # With Docker
 
 ## Running the docker image 🚀
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md).
@@ -31,7 +34,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
 <TabItem value="postgresql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -43,7 +46,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postg
 <TabItem value="mongodb">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb^{docker_version_mongodb}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mongodb/blob/master/README.md).
@@ -55,6 +58,8 @@ We do not offer login functionality with MongDB yet. We only offer session manag
 :::
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider> 
 
 ## Testing that the service is running 🤞
 Open a browser and visit `http://localhost:3567/hello`. If you see a page that says `Hello` back, then the container was started successfully!
@@ -142,6 +147,8 @@ There is no API key by default. Visit the "Auth flow customization" -> "SuperTok
 
 ## Docker compose file
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
@@ -167,7 +174,7 @@ services:
       retries: 10
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
       - db
     ports:
@@ -215,7 +222,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
       - db
     ports:
@@ -246,6 +253,8 @@ We are working on adding this section.
 
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider>
 
 
 ## Helm charts for Kubernetes

--- a/v2/thirdpartypasswordless/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/thirdpartypasswordless/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -10,16 +10,19 @@ hide_title: true
 import DatabaseTabs from "/src/components/tabs/DatabaseTabs"
 import TabItem from '@theme/TabItem';
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";
+import DockerVersionProvider from "/src/components/dockerVersionProvider";
 
 # With Docker
 
 ## Running the docker image 🚀
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md).
@@ -31,7 +34,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
 <TabItem value="postgresql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -43,7 +46,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postg
 <TabItem value="mongodb">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb^{docker_version_mongodb}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mongodb/blob/master/README.md).
@@ -55,6 +58,8 @@ We do not offer login functionality with MongDB yet. We only offer session manag
 :::
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider> 
 
 ## Testing that the service is running 🤞
 Open a browser and visit `http://localhost:3567/hello`. If you see a page that says `Hello` back, then the container was started successfully!
@@ -142,6 +147,8 @@ There is no API key by default. Visit the "Auth flow customization" -> "SuperTok
 
 ## Docker compose file
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
@@ -167,7 +174,7 @@ services:
       retries: 10
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
       - db
     ports:
@@ -215,7 +222,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
       - db
     ports:
@@ -246,6 +253,8 @@ We are working on adding this section.
 
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider>
 
 
 ## Helm charts for Kubernetes

--- a/v2/thirdpartypasswordless/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/thirdpartypasswordless/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -10,16 +10,19 @@ hide_title: true
 import DatabaseTabs from "/src/components/tabs/DatabaseTabs"
 import TabItem from '@theme/TabItem';
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";
+import DockerVersionProvider from "/src/components/dockerVersionProvider";
 
 # With Docker
 
 ## Running the docker image 🚀
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md).
@@ -31,7 +34,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mysql
 <TabItem value="postgresql">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -43,7 +46,7 @@ docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postg
 <TabItem value="mongodb">
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-mongodb^{docker_version_mongodb}
 ```
 
 - To see all the env variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-mongodb/blob/master/README.md).
@@ -55,6 +58,8 @@ We do not offer login functionality with MongDB yet. We only offer session manag
 :::
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider> 
 
 ## Testing that the service is running 🤞
 Open a browser and visit `http://localhost:3567/hello`. If you see a page that says `Hello` back, then the container was started successfully!
@@ -142,6 +147,8 @@ There is no API key by default. Visit the "Auth flow customization" -> "SuperTok
 
 ## Docker compose file
 
+<DockerVersionProvider>
+
 <DatabaseTabs>
 <TabItem value="mysql">
 
@@ -167,7 +174,7 @@ services:
       retries: 10
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-mysql
+    image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
       - db
     ports:
@@ -215,7 +222,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
       - db
     ports:
@@ -246,6 +253,8 @@ We are working on adding this section.
 
 </TabItem>
 </DatabaseTabs>
+
+</DockerVersionProvider>
 
 
 ## Helm charts for Kubernetes


### PR DESCRIPTION
## Summary of change
When adding snippets for docker (run or compose files) we now use the DockerVersionProvider component to fetch the latest core version to use

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] ...