### PR TITLE
Re-add respecting getTokenTransferMethod into verify and refreshSession

### DIFF
--- a/v2/contribute/decisions/session/0007-session-verification-should-allow-fallback.mdx
+++ b/v2/contribute/decisions/session/0007-session-verification-should-allow-fallback.mdx
@@ -11,7 +11,7 @@ import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
 
 # Session verification should check headers then cookies
 
-<DecisionHeader status="proposed" lastUpdate="2022-10-25" created="2022-10-25" deciders={["rishabhpoddar", "porcellus"]} proposedBy={["porcellus"]} />
+<DecisionHeader status="proposed" lastUpdate="2022-11-24" created="2022-10-25" deciders={["rishabhpoddar", "porcellus"]} proposedBy={["porcellus"]} />
 
 ## Context and Problem Statement
 
@@ -61,13 +61,21 @@ Session verification should check headers then cookies:
 
 ### Expected behaviour as a table
 
-| sessionRequired 	| Authorization header 	| Access token cookie 	| Output                    	            |
-|-----------------	|----------------------	|---------------------	|-----------------------------------------	|
-| true           	| none                 	| none                 	| UNAUTHORISED            	            |
-| false           	| none                 	| none                 	| undefined                   	            |
-| *             	| exists               	| exist                 | Based on session validation of header 	|
-| *             	| exists               	| none                 	| Based on session validation of header 	|
-| *             	| none                 	| exists               	| Based on session validation of cookie 	|
+| getTokenTransferMethod    | sessionRequired 	| Authorization header 	| Access token cookie 	| Output                    	            |
+|----------------------     |-----------------	|----------------------	|---------------------	|-----------------------------------------	|
+| *                         | false           	| none                 	| none                 	| undefined                   	            |
+| cookie                    | false            	| exists               	| none                 	| undefined                   	            |
+| header                    | false            	| none                 	| exists               	| undefined                   	            |
+| *                         | true           	| none                 	| none                 	| UNAUTHORISED            	                |
+| cookie                    | true          	| exists               	| none                 	| UNAUTHORISED                           	|
+| header                    | true          	| none                 	| exists               	| UNAUTHORISED                           	|
+| any                       | *             	| exists               	| exist                 | Based on session validation of header 	|
+| header                    | *             	| exists               	| exist                 | Based on session validation of header 	|
+| cookie                    | *             	| exists               	| exist                 | Based on session validation of cookie 	|
+| any                       | *             	| exists               	| none                 	| Based on session validation of header 	|
+| header                    | *             	| exists               	| none                 	| Based on session validation of header 	|
+| any                       | *             	| none                 	| exists               	| Based on session validation of cookie 	|
+| cookie                    | *             	| none                 	| exists               	| Based on session validation of cookie 	|
 
 - Also check [this decision](./0013): Treat Authorization header as empty if it doesn't contain a SuperTokens token
 - Also check [this decision](./0019): Optional session verification should throw TRY_REFRESH_TOKEN errors

--- a/v2/contribute/decisions/session/0008-active-session-cant-change-auth-modes.mdx
+++ b/v2/contribute/decisions/session/0008-active-session-cant-change-auth-modes.mdx
@@ -11,7 +11,7 @@ import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
 
 # Active session can't change auth-modes
 
-<DecisionHeader status="proposed" lastUpdate="2022-11-22" created="2022-10-25" deciders={["rishabhpoddar", "porcellus"]} proposedBy={["porcellus"]} />
+<DecisionHeader status="proposed" lastUpdate="2022-11-24" created="2022-10-25" deciders={["rishabhpoddar", "porcellus"]} proposedBy={["porcellus"]} />
 
 ## Context and Problem Statement
 
@@ -46,9 +46,15 @@ As a consequence:
 
 ### Expected behaviour of refreshSession as a table
 
-| Authorization header 	| Refresh token cookie 	| Output                    	            | Set tokens in  | Cleared tokens        |
-|----------------------	|---------------------	|-----------------------------------------	|--------------  |-------------------	 |
-| none                 	| none               	| UNAUTHORISED              	            | -              | none                  |
-| none                 	| exists               	| Validate refresh token from cookie        | cookies        | none                  |
-| exists               	| none                 	| Validate refresh token from header        | headers        | none                  |
-| exists               	| exists               	| Validate refresh token from header        | headers        | cookies               |
+| getTokenTransferMethod    | Authorization header 	| Refresh token cookie 	| Output                    	            | Set tokens in  | Cleared tokens        |
+|----------------------     |----------------------	|---------------------	|-----------------------------------------	|--------------  |-------------------	 |
+| *                         | none                 	| none               	| UNAUTHORISED              	            | -              | none                  |
+| any                       | none                 	| exists               	| Validate refresh token from cookie        | cookies        | none                  |
+| header                    | none                 	| exists               	| UNAUTHORISED                              | -              | cookies               |
+| cookie                    | none                 	| exists               	| Validate refresh token from cookie        | cookies        | none                  |
+| any                       | exists               	| none                 	| Validate refresh token from header        | headers        | none                  |
+| header                    | exists               	| none               	| Validate refresh token from cookie        | headers        | none                  |
+| cookie                    | exists               	| none               	| UNAUTHORISED                              | -              | headers               |
+| any                       | exists               	| exists               	| Validate refresh token from header        | headers        | cookies               |
+| header                    | exists               	| exists               	| Validate refresh token from header        | headers        | cookies               |
+| cookie                    | exists               	| exists               	| Validate refresh token from cookie        | cookies        | headers               |

--- a/v2/contribute/decisions/session/0020-validating-token-transfer-method-during-verification.mdx
+++ b/v2/contribute/decisions/session/0020-validating-token-transfer-method-during-verification.mdx
@@ -1,0 +1,39 @@
+---
+id: "0019"
+title: Optional session verification should re-throw TRY_REFRESH_TOKEN errors
+hide_title: true
+---
+
+import DecisionHeader from "/src/components/decisionLogs/DecisionHeader"
+import ArgumentPro from "/src/components/decisionLogs/ArgumentPro"
+import ArgumentCon from "/src/components/decisionLogs/ArgumentCon"
+import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
+
+# Optional session verification should re-throw TRY_REFRESH_TOKEN errors
+
+<DecisionHeader status="proposed" lastUpdate="2022-11-24" created="2022-11-24" deciders={["rishabhpoddar", "porcellus"]} proposedBy={["porcellus"]} />
+
+## Context and Problem Statement
+
+We want devs to be able to be able to specifically allow/disallow a token transfer method in `verifySession` and `refreshSession`. E.g.: A web only application wants to only ever want to use cookie based sessions (and httpOnly cookies), so they want to disable header based sessions.
+
+## Considered Options
+
+* Re-use `getTokenTransferMethod`
+* Add a new `allowTokenTransferMethod`
+
+## Decision Outcome
+
+Re-use `getTokenTransferMethod`. Reasons:
+- Single function override if someone wants to only allow/use a single tokenTransferMethod
+
+## Pros and Cons of the Options
+
+### Re-use `getTokenTransferMethod`
+
+<ArgumentPro> Single configuration if you want to only allow a single token transfer method </ArgumentPro>
+
+### Add a new `allowTokenTransferMethod`
+
+<ArgumentPro> Very verbose and specific, making it easy to explain </ArgumentPro>
+<ArgumentCon> If you only want to allow a single token transfer method you'd have to override `getTokenTransferMethod` anyway </ArgumentCon>


### PR DESCRIPTION
## Summary of change
Re-add respecting getTokenTransferMethod into verify and refreshSession

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
