### PR TITLE
ADR: document why createNewSession clears tokens

### DIFF
--- a/v2/contribute/decisions/session/0008-active-session-cant-change-auth-modes.mdx
+++ b/v2/contribute/decisions/session/0008-active-session-cant-change-auth-modes.mdx
@@ -50,11 +50,11 @@ As a consequence:
 |----------------------     |----------------------	|---------------------	|-----------------------------------------	|--------------  |-------------------	 |
 | *                         | none                 	| none               	| UNAUTHORISED              	            | -              | none                  |
 | any                       | none                 	| exists               	| Validate refresh token from cookie        | cookies        | none                  |
-| header                    | none                 	| exists               	| UNAUTHORISED                              | -              | cookies               |
+| header                    | none                 	| exists               	| UNAUTHORISED                              | -              | none                  |
 | cookie                    | none                 	| exists               	| Validate refresh token from cookie        | cookies        | none                  |
 | any                       | exists               	| none                 	| Validate refresh token from header        | headers        | none                  |
-| header                    | exists               	| none               	| Validate refresh token from cookie        | headers        | none                  |
-| cookie                    | exists               	| none               	| UNAUTHORISED                              | -              | headers               |
+| header                    | exists               	| none               	| Validate refresh token from header        | headers        | none                  |
+| cookie                    | exists               	| none               	| UNAUTHORISED                              | -              | none                  |
 | any                       | exists               	| exists               	| Validate refresh token from header        | headers        | cookies               |
 | header                    | exists               	| exists               	| Validate refresh token from header        | headers        | cookies               |
 | cookie                    | exists               	| exists               	| Validate refresh token from cookie        | cookies        | headers               |

--- a/v2/contribute/decisions/session/0020-validating-token-transfer-method-during-verification.mdx
+++ b/v2/contribute/decisions/session/0020-validating-token-transfer-method-during-verification.mdx
@@ -1,5 +1,5 @@
 ---
-id: "0019"
+id: "0020"
 title: Optional session verification should re-throw TRY_REFRESH_TOKEN errors
 hide_title: true
 ---
@@ -25,7 +25,7 @@ We want devs to be able to be able to specifically allow/disallow a token transf
 ## Decision Outcome
 
 Re-use `getTokenTransferMethod`. Reasons:
-- Single function override if someone wants to only allow/use a single tokenTransferMethod
+- Single function override if someone wants to only allow/use a single token transfer method
 
 ## Pros and Cons of the Options
 

--- a/v2/contribute/decisions/session/0021-clearing-session-during-create.mdx
+++ b/v2/contribute/decisions/session/0021-clearing-session-during-create.mdx
@@ -1,0 +1,34 @@
+---
+id: "0021"
+title: Delete tokens of unused token transfer methods during createNewSession
+hide_title: true
+---
+
+import DecisionHeader from "/src/components/decisionLogs/DecisionHeader"
+import ArgumentPro from "/src/components/decisionLogs/ArgumentPro"
+import ArgumentCon from "/src/components/decisionLogs/ArgumentCon"
+import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
+
+# Delete tokens of unused token transfer methods during createNewSession
+
+<DecisionHeader status="proposed" lastUpdate="2022-11-24" created="2022-11-24" deciders={["rishabhpoddar", "porcellus"]} proposedBy={["porcellus"]} />
+
+## Context and Problem Statement
+
+In some cases, createNewSession can be called while there is an active session. Normally this would overwrite the old session, but there could be tokens present in other token transfer methods. E.g.:
+- The request has an access token attached as header
+- createNewSession is called
+- getTokenTransferMethod returns cookies (for example because of a user override)
+- We would are overwriting cookies, but that leaves tokens in storage associated with headers
+
+## Considered Options
+
+* Do not clear
+* Clear other token transfer methods - if they have attached anything to the request (even invalid or expired tokens)
+
+## Decision Outcome
+
+Clear other token transfer methods. Reasons:
+- We only want the tokens of a single session present in the browser.
+- It avoids future issues/confusion by proactively cleaning up and not depending on future refresh calls.
+- We will only clear headers/cookies if they were sent to us, avoiding sending the FE unexpected headers.

--- a/v2/contribute/sidebars.js
+++ b/v2/contribute/sidebars.js
@@ -167,7 +167,9 @@ module.exports = {
             "decisions/session/0016",
             "decisions/session/0017",
             "decisions/session/0018",
-            "decisions/session/0019"
+            "decisions/session/0019",
+            "decisions/session/0020",
+            "decisions/session/0021"
           ],
         },
         {


### PR DESCRIPTION
## Summary of change
Document why `createNewSession` clears tokens
- minor cleanup in other ADRs
- fixed mistake in refresh behaviour table

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
