### PR TITLE
chore: Add docs for adding content security policy headers for the dashboard feature

### DIFF
--- a/v2/emailpassword/custom-ui/init/dashboard.mdx
+++ b/v2/emailpassword/custom-ui/init/dashboard.mdx
@@ -100,3 +100,18 @@ Now, navigate to the your frontend app and create a user (via the sign up flow).
 <img src="/img/dashboard/one-user.png" alt="One user in dashboard" />
 
 </AppInfoForm>
+
+## Content Security Policy
+
+If you return a `Content-Security-Policy` header in from your backend, you will need to include the following directives for the user management dashboard to work correctly
+
+```
+script-src:
+  'self' 
+  'unsafe-inline' 
+  https://cdn.jsdelivr.net/gh/supertokens/
+
+img-src:
+  https://cdn.jsdelivr.net/gh/supertokens/ 
+  https://raw.githubusercontent.com/supertokens/
+```

--- a/v2/emailpassword/pre-built-ui/setup/dashboard.mdx
+++ b/v2/emailpassword/pre-built-ui/setup/dashboard.mdx
@@ -100,3 +100,18 @@ Now, navigate to the your frontend app and create a user (via the sign up flow).
 <img src="/img/dashboard/one-user.png" alt="One user in dashboard" />
 
 </AppInfoForm>
+
+## Content Security Policy
+
+If you return a `Content-Security-Policy` header in from your backend, you will need to include the following directives for the user management dashboard to work correctly
+
+```
+script-src:
+  'self' 
+  'unsafe-inline' 
+  https://cdn.jsdelivr.net/gh/supertokens/
+
+img-src:
+  https://cdn.jsdelivr.net/gh/supertokens/ 
+  https://raw.githubusercontent.com/supertokens/
+```

--- a/v2/passwordless/custom-ui/init/dashboard.mdx
+++ b/v2/passwordless/custom-ui/init/dashboard.mdx
@@ -100,3 +100,18 @@ Now, navigate to the your frontend app and create a user (via the sign up flow).
 <img src="/img/dashboard/one-user.png" alt="One user in dashboard" />
 
 </AppInfoForm>
+
+## Content Security Policy
+
+If you return a `Content-Security-Policy` header in from your backend, you will need to include the following directives for the user management dashboard to work correctly
+
+```
+script-src:
+  'self' 
+  'unsafe-inline' 
+  https://cdn.jsdelivr.net/gh/supertokens/
+
+img-src:
+  https://cdn.jsdelivr.net/gh/supertokens/ 
+  https://raw.githubusercontent.com/supertokens/
+```

--- a/v2/passwordless/pre-built-ui/setup/dashboard.mdx
+++ b/v2/passwordless/pre-built-ui/setup/dashboard.mdx
@@ -100,3 +100,18 @@ Now, navigate to the your frontend app and create a user (via the sign up flow).
 <img src="/img/dashboard/one-user.png" alt="One user in dashboard" />
 
 </AppInfoForm>
+
+## Content Security Policy
+
+If you return a `Content-Security-Policy` header in from your backend, you will need to include the following directives for the user management dashboard to work correctly
+
+```
+script-src:
+  'self' 
+  'unsafe-inline' 
+  https://cdn.jsdelivr.net/gh/supertokens/
+
+img-src:
+  https://cdn.jsdelivr.net/gh/supertokens/ 
+  https://raw.githubusercontent.com/supertokens/
+```

--- a/v2/thirdparty/custom-ui/init/dashboard.mdx
+++ b/v2/thirdparty/custom-ui/init/dashboard.mdx
@@ -100,3 +100,18 @@ Now, navigate to the your frontend app and create a user (via the sign up flow).
 <img src="/img/dashboard/one-user.png" alt="One user in dashboard" />
 
 </AppInfoForm>
+
+## Content Security Policy
+
+If you return a `Content-Security-Policy` header in from your backend, you will need to include the following directives for the user management dashboard to work correctly
+
+```
+script-src:
+  'self' 
+  'unsafe-inline' 
+  https://cdn.jsdelivr.net/gh/supertokens/
+
+img-src:
+  https://cdn.jsdelivr.net/gh/supertokens/ 
+  https://raw.githubusercontent.com/supertokens/
+```

--- a/v2/thirdparty/pre-built-ui/setup/dashboard.mdx
+++ b/v2/thirdparty/pre-built-ui/setup/dashboard.mdx
@@ -100,3 +100,18 @@ Now, navigate to the your frontend app and create a user (via the sign up flow).
 <img src="/img/dashboard/one-user.png" alt="One user in dashboard" />
 
 </AppInfoForm>
+
+## Content Security Policy
+
+If you return a `Content-Security-Policy` header in from your backend, you will need to include the following directives for the user management dashboard to work correctly
+
+```
+script-src:
+  'self' 
+  'unsafe-inline' 
+  https://cdn.jsdelivr.net/gh/supertokens/
+
+img-src:
+  https://cdn.jsdelivr.net/gh/supertokens/ 
+  https://raw.githubusercontent.com/supertokens/
+```

--- a/v2/thirdpartyemailpassword/custom-ui/init/dashboard.mdx
+++ b/v2/thirdpartyemailpassword/custom-ui/init/dashboard.mdx
@@ -100,3 +100,18 @@ Now, navigate to the your frontend app and create a user (via the sign up flow).
 <img src="/img/dashboard/one-user.png" alt="One user in dashboard" />
 
 </AppInfoForm>
+
+## Content Security Policy
+
+If you return a `Content-Security-Policy` header in from your backend, you will need to include the following directives for the user management dashboard to work correctly
+
+```
+script-src:
+  'self' 
+  'unsafe-inline' 
+  https://cdn.jsdelivr.net/gh/supertokens/
+
+img-src:
+  https://cdn.jsdelivr.net/gh/supertokens/ 
+  https://raw.githubusercontent.com/supertokens/
+```

--- a/v2/thirdpartyemailpassword/pre-built-ui/setup/dashboard.mdx
+++ b/v2/thirdpartyemailpassword/pre-built-ui/setup/dashboard.mdx
@@ -100,3 +100,18 @@ Now, navigate to the your frontend app and create a user (via the sign up flow).
 <img src="/img/dashboard/one-user.png" alt="One user in dashboard" />
 
 </AppInfoForm>
+
+## Content Security Policy
+
+If you return a `Content-Security-Policy` header in from your backend, you will need to include the following directives for the user management dashboard to work correctly
+
+```
+script-src:
+  'self' 
+  'unsafe-inline' 
+  https://cdn.jsdelivr.net/gh/supertokens/
+
+img-src:
+  https://cdn.jsdelivr.net/gh/supertokens/ 
+  https://raw.githubusercontent.com/supertokens/
+```

--- a/v2/thirdpartypasswordless/custom-ui/init/dashboard.mdx
+++ b/v2/thirdpartypasswordless/custom-ui/init/dashboard.mdx
@@ -100,3 +100,18 @@ Now, navigate to the your frontend app and create a user (via the sign up flow).
 <img src="/img/dashboard/one-user.png" alt="One user in dashboard" />
 
 </AppInfoForm>
+
+## Content Security Policy
+
+If you return a `Content-Security-Policy` header in from your backend, you will need to include the following directives for the user management dashboard to work correctly
+
+```
+script-src:
+  'self' 
+  'unsafe-inline' 
+  https://cdn.jsdelivr.net/gh/supertokens/
+
+img-src:
+  https://cdn.jsdelivr.net/gh/supertokens/ 
+  https://raw.githubusercontent.com/supertokens/
+```

--- a/v2/thirdpartypasswordless/pre-built-ui/setup/dashboard.mdx
+++ b/v2/thirdpartypasswordless/pre-built-ui/setup/dashboard.mdx
@@ -100,3 +100,18 @@ Now, navigate to the your frontend app and create a user (via the sign up flow).
 <img src="/img/dashboard/one-user.png" alt="One user in dashboard" />
 
 </AppInfoForm>
+
+## Content Security Policy
+
+If you return a `Content-Security-Policy` header in from your backend, you will need to include the following directives for the user management dashboard to work correctly
+
+```
+script-src:
+  'self' 
+  'unsafe-inline' 
+  https://cdn.jsdelivr.net/gh/supertokens/
+
+img-src:
+  https://cdn.jsdelivr.net/gh/supertokens/ 
+  https://raw.githubusercontent.com/supertokens/
+```


### PR DESCRIPTION
## Summary of change
- Because the dashboard is served by the backend, adding any CSP headers also affects the dashboard frontend. This PR adds the headers needed to make the dashboard work properly and without any errors

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] ...