### PR TITLE
fix: Add fullscreen support to how it works video

### DIFF
--- a/v2/community/architecture.mdx
+++ b/v2/community/architecture.mdx
@@ -14,7 +14,7 @@ import ArchitectureSignInFlowTip from "/src/components/architectureSignInFlowTip
 
 ## SuperTokens architecture & SDKs
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="true"></iframe>
 
 - You need to integrate with our frontend and backend SDKs in your application.
 - Your app's frontend doesn't talk to the SuperTokens core directly. Instead, it talks to the auth APIs exposed via our backend SDK in your API layer. Our backend SDK then talks to the SuperTokens core.

--- a/v2/emailpassword/architecture.mdx
+++ b/v2/emailpassword/architecture.mdx
@@ -14,7 +14,7 @@ import ArchitectureSignInFlowTip from "/src/components/architectureSignInFlowTip
 
 ## SuperTokens architecture & SDKs
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="true"></iframe>
 
 - You need to integrate with our frontend and backend SDKs in your application.
 - Your app's frontend doesn't talk to the SuperTokens core directly. Instead, it talks to the auth APIs exposed via our backend SDK in your API layer. Our backend SDK then talks to the SuperTokens core.

--- a/v2/passwordless/architecture.mdx
+++ b/v2/passwordless/architecture.mdx
@@ -14,7 +14,7 @@ import ArchitectureSignInFlowTip from "/src/components/architectureSignInFlowTip
 
 ## SuperTokens architecture & SDKs
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="true"></iframe>
 
 - You need to integrate with our frontend and backend SDKs in your application.
 - Your app's frontend doesn't talk to the SuperTokens core directly. Instead, it talks to the auth APIs exposed via our backend SDK in your API layer. Our backend SDK then talks to the SuperTokens core.

--- a/v2/phonepassword/architecture.mdx
+++ b/v2/phonepassword/architecture.mdx
@@ -14,7 +14,7 @@ import ArchitectureSignInFlowTip from "/src/components/architectureSignInFlowTip
 
 ## SuperTokens architecture & SDKs
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="true"></iframe>
 
 - You need to integrate with our frontend and backend SDKs in your application.
 - Your app's frontend doesn't talk to the SuperTokens core directly. Instead, it talks to the auth APIs exposed via our backend SDK in your API layer. Our backend SDK then talks to the SuperTokens core.

--- a/v2/session/architecture.mdx
+++ b/v2/session/architecture.mdx
@@ -14,7 +14,7 @@ import ArchitectureSignInFlowTip from "/src/components/architectureSignInFlowTip
 
 ## SuperTokens architecture & SDKs
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="true"></iframe>
 
 - You need to integrate with our frontend and backend SDKs in your application.
 - Your app's frontend doesn't talk to the SuperTokens core directly. Instead, it talks to the auth APIs exposed via our backend SDK in your API layer. Our backend SDK then talks to the SuperTokens core.

--- a/v2/thirdparty/architecture.mdx
+++ b/v2/thirdparty/architecture.mdx
@@ -14,7 +14,7 @@ import ArchitectureSignInFlowTip from "/src/components/architectureSignInFlowTip
 
 ## SuperTokens architecture & SDKs
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="true"></iframe>
 
 - You need to integrate with our frontend and backend SDKs in your application.
 - Your app's frontend doesn't talk to the SuperTokens core directly. Instead, it talks to the auth APIs exposed via our backend SDK in your API layer. Our backend SDK then talks to the SuperTokens core.

--- a/v2/thirdpartyemailpassword/architecture.mdx
+++ b/v2/thirdpartyemailpassword/architecture.mdx
@@ -14,7 +14,7 @@ import ArchitectureSignInFlowTip from "/src/components/architectureSignInFlowTip
 
 ## SuperTokens architecture & SDKs
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="true"></iframe>
 
 - You need to integrate with our frontend and backend SDKs in your application.
 - Your app's frontend doesn't talk to the SuperTokens core directly. Instead, it talks to the auth APIs exposed via our backend SDK in your API layer. Our backend SDK then talks to the SuperTokens core.

--- a/v2/thirdpartypasswordless/architecture.mdx
+++ b/v2/thirdpartypasswordless/architecture.mdx
@@ -14,7 +14,7 @@ import ArchitectureSignInFlowTip from "/src/components/architectureSignInFlowTip
 
 ## SuperTokens architecture & SDKs
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/lUjAx75hF8I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="true"></iframe>
 
 - You need to integrate with our frontend and backend SDKs in your application.
 - Your app's frontend doesn't talk to the SuperTokens core directly. Instead, it talks to the auth APIs exposed via our backend SDK in your API layer. Our backend SDK then talks to the SuperTokens core.


### PR DESCRIPTION
## Summary of change
- The how it works video would not allow playing in full screen mode (the only way to do that would be to open the video on youtube). This PR fixes the embed to explicitly make allowfullscreen true on the embed player

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] ...