### PR TITLE
fix: Fix issue with custom/prebuilt ui selector in tablet portrait mode

### DIFF
--- a/v2/src/theme/TOC/index.js
+++ b/v2/src/theme/TOC/index.js
@@ -180,6 +180,7 @@ function TOC({ toc, showUISwitcher }) {
               fontWeight: "700",
               marginTop: 6,
               marginBottom: 6,
+              maxWidth: "calc(100% - 24px)",
             }}>
             supertokens-web-js / mobile
           </span>
@@ -206,7 +207,6 @@ function TOC({ toc, showUISwitcher }) {
           }}>
           {!isCustomSelected && <img src="/img/ui-switcher-check.svg" style={{
             marginRight: "8px",
-            marginLeft: "-18px" // 10 px is the width of the tick, and 8 is to account for marginRight
           }} />}
           <span
             style={{
@@ -214,6 +214,7 @@ function TOC({ toc, showUISwitcher }) {
               fontWeight: "700",
               marginTop: 6,
               marginBottom: 6,
+              maxWidth: "calc(100% - 24px)",
             }}>
             supertokens-auth-react
           </span>


### PR DESCRIPTION
## Summary of change

- In tablet portrait mode, the tick mark next to the sdk name would sometimes render outside of the button. This PR fixes this behaviour

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] ...