### PR TITLE
why we have separate API for post login account linking

### DIFF
--- a/v2/contribute/decisions/accountlinking/0004-separate-api-post-login-for-account-linking.mdx
+++ b/v2/contribute/decisions/accountlinking/0004-separate-api-post-login-for-account-linking.mdx
@@ -32,7 +32,6 @@ Chosen option: have separate API for account linking post login, because
 * The things you want to do post sign up are most likely different compared to what you want to do in the post login account linking API. Having them both as the same API, causes issues in which users might end up doing post sign up stuff even in post login account linking API (by mistake).
 
 
-Additional details, etc.
 
 
 ## Pros and Cons of the Options

--- a/v2/contribute/decisions/accountlinking/0004-separate-api-post-login-for-account-linking.mdx
+++ b/v2/contribute/decisions/accountlinking/0004-separate-api-post-login-for-account-linking.mdx
@@ -9,7 +9,7 @@ import ArgumentPro from "/src/components/decisionLogs/ArgumentPro"
 import ArgumentCon from "/src/components/decisionLogs/ArgumentCon"
 import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
 
-# Separate API post login for account linking
+# Separate API for post login account linking
 
 <DecisionHeader status="accepted" lastUpdate="2022-12-01" created="2022-11-30" deciders={["rishabhpoddar", "bhumilsarvaiya"]} proposedBy={["bhumilsarvaiya"]} />
 

--- a/v2/contribute/decisions/accountlinking/0004-separate-api-post-login-for-account-linking.mdx
+++ b/v2/contribute/decisions/accountlinking/0004-separate-api-post-login-for-account-linking.mdx
@@ -1,0 +1,50 @@
+---
+id: "0004"
+title: Separate API post login for account linking
+hide_title: true
+---
+
+import DecisionHeader from "/src/components/decisionLogs/DecisionHeader"
+import ArgumentPro from "/src/components/decisionLogs/ArgumentPro"
+import ArgumentCon from "/src/components/decisionLogs/ArgumentCon"
+import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
+
+# Separate API post login for account linking
+
+<DecisionHeader status="accepted" lastUpdate="2022-12-01" created="2022-11-30" deciders={["rishabhpoddar", "bhumilsarvaiya"]} proposedBy={["bhumilsarvaiya"]} />
+
+## Context and Problem Statement
+
+Should we use existing signup API for post login account linking or should there be a different API for the same?
+
+## Considered Options
+
+* use signup API to also do account linking post login
+* have separate API for account linking post login
+
+
+## Decision Outcome
+
+Chosen option: have separate API for account linking post login, because
+
+* Purposes are very different of the normal sign up vs post login account linking API
+* We do not want to pollute the output types of normal sign up API for people who are not using account linking
+* The things you want to do post sign up are most likely different compared to what you want to do in the post login account linking API. Having them both as the same API, causes issues in which users might end up doing post sign up stuff even in post login account linking API (by mistake).
+
+
+Additional details, etc.
+
+
+## Pros and Cons of the Options
+
+### use signup API to also do account linking post login
+
+Further details if necessary
+
+<ArgumentCon> It is not necessary that there will be a signup always. There can also be an existing account that can get linked during this API. Thus having account linking functionality in signup API is not semantically correct </ArgumentCon>
+<ArgumentCon> Purposes are very different of the normal sign up vs post login account linking API </ArgumentCon>
+<ArgumentCon> The things user may want to do post sign up are most likely different compared to what they may want to do in the post login account linking API. Having them both as the same API, causes issues in which users might end up doing post sign up stuff even in post login account linking API (by mistake).  </ArgumentCon> 
+
+### have separate API for account linking post login
+
+<ArgumentPro> We do not want to pollute the output types of normal sign up API for people who are not using account linking </ArgumentPro>

--- a/v2/contribute/decisions/accountlinking/0004-separate-api-post-login-for-account-linking.mdx
+++ b/v2/contribute/decisions/accountlinking/0004-separate-api-post-login-for-account-linking.mdx
@@ -46,4 +46,4 @@ Further details if necessary
 
 ### have separate API for account linking post login
 
-<ArgumentPro> We do not want to pollute the output types of normal sign up API for people who are not using account linking </ArgumentPro>
+See reasons listed in Decision outcome

--- a/v2/contribute/sidebars.js
+++ b/v2/contribute/sidebars.js
@@ -187,6 +187,7 @@ module.exports = {
             "decisions/accountlinking/0001",
             "decisions/accountlinking/0002",
             "decisions/accountlinking/0003",
+            "decisions/accountlinking/0004",
           ],
         },
         {


### PR DESCRIPTION
## Summary of change
- ADR: why we have separate API for post login account linking