### PR TITLE
fix: third party auth setup link for nextjs

### DIFF
--- a/v2/emailpassword/nextjs/setting-up-frontend.mdx
+++ b/v2/emailpassword/nextjs/setting-up-frontend.mdx
@@ -23,7 +23,7 @@ import AppInfoForm from "/src/components/appInfoForm"
 ## 1) Create the `pages/auth/[[...path]].tsx` page
 - Be sure to create the `auth` folder in the `pages` folder.
 - `[[...path]].tsx` will contain the component for showing SuperTokens UI
-- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/pages/auth/%5B%5B...path%5D%5D.js).
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/pages/auth/%5B%5B...path%5D%5D.tsx).
 
 ## 2) Create the `Auth` component:
 

--- a/v2/passwordless/nextjs/setting-up-frontend.mdx
+++ b/v2/passwordless/nextjs/setting-up-frontend.mdx
@@ -23,7 +23,7 @@ import AppInfoForm from "/src/components/appInfoForm"
 ## 1) Create the `pages/auth/[[...path]].tsx` page
 - Be sure to create the `auth` folder in the `pages` folder.
 - `[[...path]].tsx` will contain the component for showing SuperTokens UI
-- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/pages/auth/%5B%5B...path%5D%5D.js).
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/pages/auth/%5B%5B...path%5D%5D.tsx).
 
 ## 2) Create the `Auth` component:
 

--- a/v2/thirdparty/nextjs/setting-up-frontend.mdx
+++ b/v2/thirdparty/nextjs/setting-up-frontend.mdx
@@ -23,7 +23,7 @@ import AppInfoForm from "/src/components/appInfoForm"
 ## 1) Create the `pages/auth/[[...path]].tsx` page
 - Be sure to create the `auth` folder in the `pages` folder.
 - `[[...path]].tsx` will contain the component for showing SuperTokens UI
-- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/pages/auth/%5B%5B...path%5D%5D.js).
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/pages/auth/%5B%5B...path%5D%5D.tsx).
 
 ## 2) Create the `Auth` component:
 

--- a/v2/thirdpartyemailpassword/nextjs/setting-up-frontend.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/setting-up-frontend.mdx
@@ -23,7 +23,7 @@ import AppInfoForm from "/src/components/appInfoForm"
 ## 1) Create the `pages/auth/[[...path]].tsx` page
 - Be sure to create the `auth` folder in the `pages` folder.
 - `[[...path]].tsx` will contain the component for showing SuperTokens UI
-- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/pages/auth/%5B%5B...path%5D%5D.js).
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/pages/auth/%5B%5B...path%5D%5D.tsx).
 
 ## 2) Create the `Auth` component:
 

--- a/v2/thirdpartypasswordless/nextjs/setting-up-frontend.mdx
+++ b/v2/thirdpartypasswordless/nextjs/setting-up-frontend.mdx
@@ -23,7 +23,7 @@ import AppInfoForm from "/src/components/appInfoForm"
 ## 1) Create the `pages/auth/[[...path]].tsx` page
 - Be sure to create the `auth` folder in the `pages` folder.
 - `[[...path]].tsx` will contain the component for showing SuperTokens UI
-- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/pages/auth/%5B%5B...path%5D%5D.js).
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/pages/auth/%5B%5B...path%5D%5D.tsx).
 
 ## 2) Create the `Auth` component:
 


### PR DESCRIPTION
## Summary of change

In thirdpartyemailpassword section for setting up the front end, the example code link redirecting to the nextjs example with supertokens was wrong.

## Related issues
https://github.com/supertokens/docs/issues/551
## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
