### PR TITLE
adr: moving override config to separate component's prop

### DIFF
--- a/v2/contribute/decisions/reactsdk/0001-move-override-config-to-separate-component-prop.mdx
+++ b/v2/contribute/decisions/reactsdk/0001-move-override-config-to-separate-component-prop.mdx
@@ -15,7 +15,7 @@ import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
 
 ## Context and Problem Statement
 
-We may want to separate override config from supertokens-auth-react init, so user does have to call `init` both for `web-js` and `auth-react`. See related [issue](https://github.com/supertokens/supertokens-auth-react/issues/616)
+We may want to separate override config from supertokens-auth-react init, so user does not have to call `init` both for `web-js` and `auth-react`. See related [issue](https://github.com/supertokens/supertokens-auth-react/issues/616)
 
 ## Considered Options
 

--- a/v2/contribute/decisions/reactsdk/0001-move-override-config-to-separate-component-prop.mdx
+++ b/v2/contribute/decisions/reactsdk/0001-move-override-config-to-separate-component-prop.mdx
@@ -1,0 +1,46 @@
+---
+id: "0001"
+title: Move override config to separate component's prop
+hide_title: true
+---
+
+import DecisionHeader from "/src/components/decisionLogs/DecisionHeader"
+import ArgumentPro from "/src/components/decisionLogs/ArgumentPro"
+import ArgumentCon from "/src/components/decisionLogs/ArgumentCon"
+import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
+
+# Move override config to separate component's prop
+
+<DecisionHeader status="proposed" lastUpdate="2022-12-21" created="2022-12-21" deciders={["rishabhpoddar", "porcellus"]} proposedBy={["rishabhpoddar"]} />
+
+## Context and Problem Statement
+
+We may want to separate override config from supertokens-auth-react init, so user does have to call `init` both for `web-js` and `auth-react`. See related [issue](https://github.com/supertokens/supertokens-auth-react/issues/616)
+
+## Considered Options
+
+* Separate component that takes config prop
+* Make SupertokensWrapper take config prop
+* Pass config to route handler
+
+
+## Decision Outcome
+
+Chosen option: Separate component that takes config prop, because
+
+* Well typed interface is very important
+
+The new component will be called `ComponentsOverrideProvider`
+
+## Pros and Cons of the Options
+
+### Separate component that takes config prop
+
+<ArgumentPro> No extra code is bundled if overriding is not necessary </ArgumentPro>
+<ArgumentPro> Input for config can be typed specifically for each recipe </ArgumentPro>
+<ArgumentCon> Adds extra wrapper that complicates things for the user </ArgumentCon>
+
+### Make SupertokensWrapper take config prop
+
+<ArgumentPro> No need to manage extra component exposed from each recipe </ArgumentPro>
+<ArgumentCon> Harder to properly type the override components for each recipe </ArgumentCon>

--- a/v2/contribute/decisions/reactsdk/0001-move-override-config-to-separate-component-prop.mdx
+++ b/v2/contribute/decisions/reactsdk/0001-move-override-config-to-separate-component-prop.mdx
@@ -15,7 +15,7 @@ import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
 
 ## Context and Problem Statement
 
-We may want to separate override config from supertokens-auth-react init, so user does not have to call `init` both for `web-js` and `auth-react`. See related [issue](https://github.com/supertokens/supertokens-auth-react/issues/616)
+We may want to separate override config for components from supertokens-auth-react `init`, so initialization of `auth-react` does not depend on `react`. See related [issue](https://github.com/supertokens/supertokens-auth-react/issues/616)
 
 ## Considered Options
 

--- a/v2/contribute/sidebars.js
+++ b/v2/contribute/sidebars.js
@@ -232,6 +232,13 @@ module.exports = {
             "decisions/multitenancy/0011",
           ],
         },
+        {
+          type: "category",
+          label: "React-SDK",
+          items: [
+            "decisions/reactsdk/0001",
+          ],
+        },
       ],
     },
   ],


### PR DESCRIPTION
## Summary of change
Add discussion on moving components override config out of init call

## Related issues
- https://github.com/supertokens/supertokens-auth-react/issues/616
## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
