### PR TITLE
fix: Fix title for custom sms sending section

### DIFF
--- a/v2/passwordless/sms-delivery/about.mdx
+++ b/v2/passwordless/sms-delivery/about.mdx
@@ -43,7 +43,7 @@ This is a paid service and we charge for every SMS based on the cost we incur. W
 
 Learn more about this method in the [SuperTokens SMS service section](./supertokens-sms-service).
 
-## Method 4) Take full control of email sending
+## Method 4) Take full control of SMS sending
 This method allows you provide a callback using which you can send SMSs however you like. The input to the callback will be SMS template variables, so you can freely create the content of the SMS as well. Use this method if you are:
 - Using a third party SMS service that is **not** Twilio.
 - You want to use another delivery methog like Whatsapp or FB Messenger.

--- a/v2/thirdpartypasswordless/sms-delivery/about.mdx
+++ b/v2/thirdpartypasswordless/sms-delivery/about.mdx
@@ -43,7 +43,7 @@ This is a paid service and we charge for every SMS based on the cost we incur. W
 
 Learn more about this method in the [SuperTokens SMS service section](./supertokens-sms-service).
 
-## Method 4) Take full control of email sending
+## Method 4) Take full control of SMS sending
 This method allows you provide a callback using which you can send SMSs however you like. The input to the callback will be SMS template variables, so you can freely create the content of the SMS as well. Use this method if you are:
 - Using a third party SMS service that is **not** Twilio.
 - You want to use another delivery methog like Whatsapp or FB Messenger.


### PR DESCRIPTION
## Summary of change
Fixes the title of the custom SMS sending section of the passwordless docs to not say "email"

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] ...