### PR TITLE
docs: move components override config for auth react

### DIFF
--- a/v2/contribute/decisions/multitenancy/0011-using-provider-input-instead-of-provider-init.mdx
+++ b/v2/contribute/decisions/multitenancy/0011-using-provider-input-instead-of-provider-init.mdx
@@ -15,7 +15,7 @@ import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
 
 ## Context and Problem Statement
 
-Currently the the providers list in the thirdparty.init() is populated with the providers implementations using the appropriate provider.init() function, such as Google.init(), Facebook.init(), etc.
+Currently the providers list in the thirdparty.init() is populated with the providers implementations using the appropriate provider.init() function, such as Google.init(), Facebook.init(), etc.
 
 Instead, should we just accept the thirdparty config as a ProviderInput and then create implementations at runtime?
 

--- a/v2/emailpassword/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/emailpassword/advanced-customizations/react-component-override/usage.mdx
@@ -20,26 +20,33 @@ import TabItem from '@theme/TabItem';
 
 ```tsx
 import React from "react";
-import EmailPassword from "supertokens-auth-react/recipe/emailpassword";
+import { SuperTokensWrapper } from "supertokens-auth-react";
+import { EmailPasswordComponentsOverrideProvider } from "supertokens-auth-react/recipe/emailpassword";
 
-EmailPassword.init({
-    override: {
-        components: {
-            /**
-             * In this case, the <EmailPasswordSignIn_Override> will render the original component
-             * wrapped in a div with an octocat picture above it.
-             */
-            EmailPasswordSignIn_Override: ({ DefaultComponent, ...props }) => {
-                return (
-                    <div>
-                        <img src="octocat.jpg" />
-                        <DefaultComponent {...props} />
-                    </div>
-                );
-            },
-        }
-    }
-});
+function App() {
+    return (
+        <SuperTokensWrapper>
+            <EmailPasswordComponentsOverrideProvider
+                components={{
+                    // In this case, the <EmailPasswordSignIn_Override> 
+                    // will render the original component
+                    // wrapped in a div with an octocat picture above it.
+                    EmailPasswordSignIn_Override: ({ DefaultComponent, ...props }) => {
+                        return (
+                            <div>
+                                <img src="octocat.jpg" />
+                                <DefaultComponent {...props} />
+                            </div>
+                        );
+                    },
+                }}>
+                {/* Rest of the JSX */}
+            </EmailPasswordComponentsOverrideProvider>
+        </SuperTokensWrapper>
+    );
+}
+export default App;
+
 ```
 
 <img alt="Prebuilt sign in UI with custom image" src="/img/emailpassword/react-override-octocat.png" />

--- a/v2/emailpassword/email-delivery/smtp/configure-smtp.mdx
+++ b/v2/emailpassword/email-delivery/smtp/configure-smtp.mdx
@@ -103,9 +103,9 @@ func main() {
 		RecipeList: []supertokens.Recipe{
 			^{codeImportRecipeName}.Init(^{goModelNameForInit}.TypeInput{
 				^{goRecipeInitDefault} // typecheck-only, removed from output
-					// highlight-start
-					EmailDelivery: &emaildelivery.TypeInput{
-						Service: ^{codeImportRecipeName}.MakeSMTPService(emaildelivery.SMTPServiceConfig{
+				// highlight-start
+				EmailDelivery: &emaildelivery.TypeInput{
+					Service: ^{codeImportRecipeName}.MakeSMTPService(emaildelivery.SMTPServiceConfig{
 						Settings: smtpSettings,
 					}),
 				},

--- a/v2/emailpassword/supabase-intergration/backend-signup-override.mdx
+++ b/v2/emailpassword/supabase-intergration/backend-signup-override.mdx
@@ -83,4 +83,4 @@ let backendConfig = (): TypeInput => {
 
 ```
 
-We will be changing the the Email-Password signup flow by overriding the `signUpPOST` api. When a user signs up we will retrieve the `supabase_token` from the user's `accessTokenPayload`(this was added in the previous step where we changed the `createNewSession` function) and use it to query Supabase to insert the new user's information.
+We will be changing the Email-Password signup flow by overriding the `signUpPOST` api. When a user signs up we will retrieve the `supabase_token` from the user's `accessTokenPayload`(this was added in the previous step where we changed the `createNewSession` function) and use it to query Supabase to insert the new user's information.

--- a/v2/mfa/pre-built-ui/showing-login-ui.mdx
+++ b/v2/mfa/pre-built-ui/showing-login-ui.mdx
@@ -125,8 +125,8 @@ This component customises the `Passwordless.SignInUpTheme` component to:
 Copy / Paste the following override customisations in the `Passwordless.init` function call:
 
 ```tsx
-import SuperTokens, {SuperTokensWrapper} from "supertokens-auth-react";
-import Passwordless, {PasswordlessComponentsOverrideProvider} from "supertokens-auth-react/recipe/passwordless";
+import SuperTokens, { SuperTokensWrapper } from "supertokens-auth-react";
+import Passwordless, { PasswordlessComponentsOverrideProvider } from "supertokens-auth-react/recipe/passwordless";
 import { useSessionContext } from "supertokens-auth-react/recipe/session";
 
 SuperTokens.init({

--- a/v2/mfa/pre-built-ui/showing-login-ui.mdx
+++ b/v2/mfa/pre-built-ui/showing-login-ui.mdx
@@ -125,8 +125,8 @@ This component customises the `Passwordless.SignInUpTheme` component to:
 Copy / Paste the following override customisations in the `Passwordless.init` function call:
 
 ```tsx
-import SuperTokens from "supertokens-auth-react";
-import Passwordless from "supertokens-auth-react/recipe/passwordless";
+import SuperTokens, {SuperTokensWrapper} from "supertokens-auth-react";
+import Passwordless, {PasswordlessComponentsOverrideProvider} from "supertokens-auth-react/recipe/passwordless";
 import { useSessionContext } from "supertokens-auth-react/recipe/session";
 
 SuperTokens.init({
@@ -145,9 +145,16 @@ SuperTokens.init({
                 // visit ^{form_websiteDomain}^{form_websiteBasePath}?rid=passwordless
                 disableDefaultUI: true,
             },
-            // highlight-start
-            override: {
-                components: {
+        })
+    ],
+})
+
+function App() {
+    return (
+        <SuperTokensWrapper>
+            <PasswordlessComponentsOverrideProvider
+                // highlight-start
+                components={{
                     PasswordlessSignInUpHeader_Override: () => {
                         return (
                             <div
@@ -171,12 +178,14 @@ SuperTokens.init({
                         // this will hide the change phone number button
                         return null;
                     },
-                },
-            },
-            // highlight-end
-        })
-    ],
-})
+                }}>
+                // highlight-end
+                {/* Rest of the JSX */}
+            </PasswordlessComponentsOverrideProvider>
+        </SuperTokensWrapper>
+    );
+}
+export default App;
 ```
 
 </AppInfoForm>

--- a/v2/passwordless/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/passwordless/advanced-customizations/react-component-override/usage.mdx
@@ -21,14 +21,10 @@ import TabItem from '@theme/TabItem';
 ```tsx
 import React from "react";
 import { SuperTokensWrapper } from "supertokens-auth-react";
-import {PasswordlessComponentsOverrideProvider} from "supertokens-auth-react/recipe/passwordless";
+import { PasswordlessComponentsOverrideProvider } from "supertokens-auth-react/recipe/passwordless";
 
 // @ts-ignore
 import octocat from "./octocat.png";
-
-Passwordless.init({
-    contactMethod: "EMAIL", // This example will work with any contactMethod.
-});
 
 function App() {
     return (
@@ -89,10 +85,6 @@ import Passwordless, {PasswordlessComponentsOverrideProvider} from "supertokens-
 
 // @ts-ignore
 import octocat from "./octocat.png";
-
-Passwordless.init({
-    contactMethod: "EMAIL", // This example will work with any contactMethod.
-});
 
 function App() {
     return (

--- a/v2/passwordless/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/passwordless/advanced-customizations/react-component-override/usage.mdx
@@ -81,7 +81,7 @@ by spreading them.
 ```tsx
 import React from "react";
 import { SuperTokensWrapper } from "supertokens-auth-react";
-import Passwordless, {PasswordlessComponentsOverrideProvider} from "supertokens-auth-react/recipe/passwordless";
+import { PasswordlessComponentsOverrideProvider } from "supertokens-auth-react/recipe/passwordless";
 
 // @ts-ignore
 import octocat from "./octocat.png";

--- a/v2/passwordless/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/passwordless/advanced-customizations/react-component-override/usage.mdx
@@ -20,30 +20,40 @@ import TabItem from '@theme/TabItem';
 
 ```tsx
 import React from "react";
-import Passwordless from "supertokens-auth-react/recipe/passwordless";
+import { SuperTokensWrapper } from "supertokens-auth-react";
+import {PasswordlessComponentsOverrideProvider} from "supertokens-auth-react/recipe/passwordless";
 
 // @ts-ignore
 import octocat from "./octocat.png";
 
- Passwordless.init({
+Passwordless.init({
     contactMethod: "EMAIL", // This example will work with any contactMethod.
-    override: {
-        components: {
-            PasswordlessSignInUpHeader_Override: ({ DefaultComponent, ...props }) => {
-                /**
-                * In this case, the <PasswordlessSignInUpHeader_Override> will render the original component
-                * wrapped in a div with an octocat picture above it.
-                */
-                return (
-                    <div>
-                        <img src={octocat} />
-                        <DefaultComponent {...props} />
-                    </div>
-                );
-            }
-        }
-    }
 });
+
+function App() {
+    return (
+        <SuperTokensWrapper>
+            <PasswordlessComponentsOverrideProvider
+                components={{
+                    PasswordlessSignInUpHeader_Override: ({ DefaultComponent, ...props }) => {
+                        // In this case, the <PasswordlessSignInUpHeader_Override> 
+                        // will render the original component
+                        // wrapped in a div with an octocat picture above it.
+                        return (
+                            <div>
+                                <img src={octocat} />
+                                <DefaultComponent {...props} />
+                            </div>
+                        );
+                    }
+                }}>
+                {/* Rest of the JSX */}
+            </PasswordlessComponentsOverrideProvider>
+        </SuperTokensWrapper>
+    );
+}
+export default App;
+
 ```
 
 <img alt="Prebuilt sign in UI with custom image" src="/img/passwordless/react-override-octocat.png" style={{
@@ -74,24 +84,34 @@ by spreading them.
 
 ```tsx
 import React from "react";
-import Passwordless from "supertokens-auth-react/recipe/passwordless";
+import { SuperTokensWrapper } from "supertokens-auth-react";
+import Passwordless, {PasswordlessComponentsOverrideProvider} from "supertokens-auth-react/recipe/passwordless";
 
 // @ts-ignore
 import octocat from "./octocat.png";
 
- Passwordless.init({
+Passwordless.init({
     contactMethod: "EMAIL", // This example will work with any contactMethod.
-    override: {
-        components: {
-            PasswordlessSignInUpHeader_Override: ({ DefaultComponent, ...props }) => {
-                return (
-                    <>
-                        <h1>I'm a header that you added above original component</h1>
-                        <DefaultComponent {...props} />
-                    </>
-                )
-            }
-        }
-    }
 });
+
+function App() {
+    return (
+        <SuperTokensWrapper>
+            <PasswordlessComponentsOverrideProvider
+                components={{
+                    PasswordlessSignInUpHeader_Override: ({ DefaultComponent, ...props }) => {
+                        return (
+                            <>
+                                <h1>I'm a header that you added above original component</h1>
+                                <DefaultComponent {...props} />
+                            </>
+                        )
+                    }
+                }}>
+                {/* Rest of the JSX */}
+            </PasswordlessComponentsOverrideProvider>
+        </SuperTokensWrapper>
+    );
+}
+export default App;
 ```

--- a/v2/passwordless/supabase-intergration/backend-signup-override.mdx
+++ b/v2/passwordless/supabase-intergration/backend-signup-override.mdx
@@ -83,5 +83,5 @@ let backendConfig = (): TypeInput => {
 
 ```
 
-We will be changing the the Passwordless flow by overriding the `consumeCodePOST` api. When a user signs up we will retrieve the `supabase_token` from the user's `accessTokenPayload`(this was added in the previous step where we changed the `createNewSession` function) and use it to query Supabase to insert the new user's information.
+We will be changing the Passwordless flow by overriding the `consumeCodePOST` api. When a user signs up we will retrieve the `supabase_token` from the user's `accessTokenPayload`(this was added in the previous step where we changed the `createNewSession` function) and use it to query Supabase to insert the new user's information.
 // take a look at the Create Supabase Client section to see how to define getSupabase

--- a/v2/src/plugins/codeTypeChecking/jsEnv/package.json
+++ b/v2/src/plugins/codeTypeChecking/jsEnv/package.json
@@ -48,7 +48,7 @@
     "nextjs-cors": "^2.1.0",
     "react-router-dom": "^6.2.1",
     "react-router-dom5": "npm:react-router-dom@^5.3.0",
-    "supertokens-auth-react": "^0.26.2",
+    "supertokens-auth-react": "^0.29.0",
     "supertokens-node": "^12.0.0",
     "supertokens-node7": "npm:supertokens-node@7.3",
     "supertokens-react-native": "^3.1.0",

--- a/v2/thirdparty/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/thirdparty/advanced-customizations/react-component-override/usage.mdx
@@ -22,7 +22,7 @@ import TabItem from '@theme/TabItem';
 ```tsx
 import React from 'react';
 import { SuperTokensWrapper } from "supertokens-auth-react";
-import {ThirdpartyComponentsOverrideProvider} from "supertokens-auth-react/recipe/thirdparty";
+import { ThirdpartyComponentsOverrideProvider } from "supertokens-auth-react/recipe/thirdparty";
 
 // @ts-ignore
 import octocat from "./octocat.png";

--- a/v2/thirdparty/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/thirdparty/advanced-customizations/react-component-override/usage.mdx
@@ -21,26 +21,35 @@ import TabItem from '@theme/TabItem';
 
 ```tsx
 import React from 'react';
-import ThirdParty from "supertokens-auth-react/recipe/thirdparty";
+import { SuperTokensWrapper } from "supertokens-auth-react";
+import {ThirdpartyComponentsOverrideProvider} from "supertokens-auth-react/recipe/thirdparty";
 
-ThirdParty.init({
-    override: {
-        components: {
-            /**
-             * In this case, the <ThirdPartySignUpFooter_Override> will render the original component
-             * wrapped in a div with an octocat picture above it.
-             */
-            ThirdPartySignUpFooter_Override: ({ DefaultComponent, ...props }) => {
-                return (
-                    <div>
-                        <img src="octocat.jpg" />
-                        <DefaultComponent {...props} />
-                    </div>
-                );
-            },
-        }
-    }
-});
+// @ts-ignore
+import octocat from "./octocat.png";
+
+function App() {
+    return (
+        <SuperTokensWrapper>
+            <ThirdpartyComponentsOverrideProvider
+                components={{
+                    // In this case, the <ThirdPartySignUpFooter_Override> 
+                    // will render the original component
+                    // wrapped in a div with an octocat picture above it.
+                    ThirdPartySignUpFooter_Override: ({ DefaultComponent, ...props }) => {
+                        return (
+                            <div>
+                                <img src="octocat.jpg" />
+                                <DefaultComponent {...props} />
+                            </div>
+                        );
+                    },
+                }}>
+                {/* Rest of the JSX */}
+            </ThirdpartyComponentsOverrideProvider>
+        </SuperTokensWrapper>
+    );
+}
+export default App;
 ```
 
 <img alt="Prebuilt sign in UI with custom image" src="/img/thirdparty/react-override-octocat.png" />

--- a/v2/thirdpartyemailpassword/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/thirdpartyemailpassword/advanced-customizations/react-component-override/usage.mdx
@@ -20,26 +20,34 @@ import TabItem from '@theme/TabItem';
 
 ```tsx
 import React from "react";
-import ThirdPartyEmailPassword from "supertokens-auth-react/recipe/thirdpartyemailpassword";
+import { SuperTokensWrapper } from "supertokens-auth-react";
+import {ThirdPartyEmailPasswordComponentsOverrideProvider} from "supertokens-auth-react/recipe/thirdpartyemailpassword";
 
-ThirdPartyEmailPassword.init({
-    override: {
-        components: {
-            EmailPasswordSignInHeader_Override: ({ DefaultComponent, ...props }) => {
-                /**
-                * In this case, the <EmailPasswordSignInHeader_Override> will render the original component
-                * wrapped in a div with an octocat picture above it.
-                */
-                return (
-                    <div>
-                        <img src="octocat.jpg" />
-                        <DefaultComponent {...props} />
-                    </div>
-                );
-            },
-        }
-    }
-});
+// @ts-ignore
+import octocat from "./octocat.png";
+
+function App() {
+    return (
+        <SuperTokensWrapper>
+            <ThirdPartyEmailPasswordComponentsOverrideProvider
+                components={{
+                    // In this case, the <EmailPasswordSignInHeader_Override> will render the original component
+                    // wrapped in a div with an octocat picture above it.
+                    EmailPasswordSignInHeader_Override: ({ DefaultComponent, ...props }) => {
+                        return (
+                            <div>
+                                <img src="octocat.jpg" />
+                                <DefaultComponent {...props} />
+                            </div>
+                        );
+                    },
+                }}>
+                {/* Rest of the JSX */}
+            </ThirdPartyEmailPasswordComponentsOverrideProvider>
+        </SuperTokensWrapper>
+    );
+}
+export default App;
 ```
 
 <img alt="Prebuilt sign in UI with custom image" src="/img/thirdpartyemailpassword/react-override-octocat.png" />

--- a/v2/thirdpartyemailpassword/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/thirdpartyemailpassword/advanced-customizations/react-component-override/usage.mdx
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
 ```tsx
 import React from "react";
 import { SuperTokensWrapper } from "supertokens-auth-react";
-import {ThirdPartyEmailPasswordComponentsOverrideProvider} from "supertokens-auth-react/recipe/thirdpartyemailpassword";
+import { ThirdpartyEmailPasswordComponentsOverrideProvider } from "supertokens-auth-react/recipe/thirdpartyemailpassword";
 
 // @ts-ignore
 import octocat from "./octocat.png";
@@ -29,7 +29,7 @@ import octocat from "./octocat.png";
 function App() {
     return (
         <SuperTokensWrapper>
-            <ThirdPartyEmailPasswordComponentsOverrideProvider
+            <ThirdpartyEmailPasswordComponentsOverrideProvider
                 components={{
                     // In this case, the <EmailPasswordSignInHeader_Override> will render the original component
                     // wrapped in a div with an octocat picture above it.
@@ -43,7 +43,7 @@ function App() {
                     },
                 }}>
                 {/* Rest of the JSX */}
-            </ThirdPartyEmailPasswordComponentsOverrideProvider>
+            </ThirdpartyEmailPasswordComponentsOverrideProvider>
         </SuperTokensWrapper>
     );
 }

--- a/v2/thirdpartypasswordless/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/react-component-override/usage.mdx
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
 ```tsx
 import React from "react";
 import { SuperTokensWrapper } from "supertokens-auth-react";
-import ThirdPartyPasswordless, {ThirdpartyPasswordlessComponentsOverrideProvider} from "supertokens-auth-react/recipe/thirdpartypasswordless";
+import { ThirdpartyPasswordlessComponentsOverrideProvider } from "supertokens-auth-react/recipe/thirdpartypasswordless";
 
 // @ts-ignore
 import octocat from "./octocat.png";
@@ -80,7 +80,7 @@ by spreading them.
 ```tsx
 import React from "react";
 import { SuperTokensWrapper } from "supertokens-auth-react";
-import ThirdPartyPasswordless, {ThirdpartyPasswordlessComponentsOverrideProvider} from "supertokens-auth-react/recipe/thirdpartypasswordless";
+import { ThirdpartyPasswordlessComponentsOverrideProvider } from "supertokens-auth-react/recipe/thirdpartypasswordless";
 
 function App() {
     return (

--- a/v2/thirdpartypasswordless/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/react-component-override/usage.mdx
@@ -20,30 +20,39 @@ import TabItem from '@theme/TabItem';
 
 ```tsx
 import React from "react";
-import ThirdPartyPasswordless from "supertokens-auth-react/recipe/thirdpartypasswordless";
+import { SuperTokensWrapper } from "supertokens-auth-react";
+import ThirdPartyPasswordless, {ThirdpartyPasswordlessComponentsOverrideProvider} from "supertokens-auth-react/recipe/thirdpartypasswordless";
 
 // @ts-ignore
 import octocat from "./octocat.png";
 
- ThirdPartyPasswordless.init({
+ThirdPartyPasswordless.init({
     contactMethod: "EMAIL", // This example will work with any contactMethod.
-    override: {
-        components: {
-            ThirdPartyPasswordlessHeader_Override: ({ DefaultComponent, ...props }) => {
-                /**
-                * In this case, the <ThirdPartyPasswordlessHeader_Override> will render the original component
-                * wrapped in a div with an octocat picture above it.
-                */
-                return (
-                    <div>
-                        <img src={octocat} />
-                        <DefaultComponent {...props} />
-                    </div>
-                );
-            }
-        }
-    }
 });
+
+function App() {
+    return (
+        <SuperTokensWrapper>
+            <ThirdpartyPasswordlessComponentsOverrideProvider
+                components={{
+                    // In this case, the <ThirdPartyPasswordlessHeader_Override> 
+                    // will render the original component
+                    // wrapped in a div with an octocat picture above it.
+                    ThirdPartyPasswordlessHeader_Override: ({ DefaultComponent, ...props }) => {
+                        return (
+                            <div>
+                                <img src={octocat} />
+                                <DefaultComponent {...props} />
+                            </div>
+                        );
+                    }
+                }}>
+                {/* Rest of the JSX */}
+            </ThirdpartyPasswordlessComponentsOverrideProvider>
+        </SuperTokensWrapper>
+    );
+}
+export default App;
 ```
 
 <img alt="Prebuilt sign up or log in UI with custom image" src="/img/passwordless/react-override-octocat.png" style={{
@@ -74,24 +83,31 @@ by spreading them.
 
 ```tsx
 import React from "react";
-import ThirdPartyPasswordless from "supertokens-auth-react/recipe/thirdpartypasswordless";
+import { SuperTokensWrapper } from "supertokens-auth-react";
+import ThirdPartyPasswordless, {ThirdpartyPasswordlessComponentsOverrideProvider} from "supertokens-auth-react/recipe/thirdpartypasswordless";
 
-// @ts-ignore
-import octocat from "./octocat.png";
-
- ThirdPartyPasswordless.init({
+ThirdPartyPasswordless.init({
     contactMethod: "EMAIL", // This example will work with any contactMethod.
-    override: {
-        components: {
-            ThirdPartyPasswordlessHeader_Override: ({ DefaultComponent, ...props }) => {
-                return (
-                    <>
-                        <h1>I'm a header that you added above original component</h1>
-                        <DefaultComponent {...props} />
-                    </>
-                )
-            }
-        }
-    }
 });
+
+function App() {
+    return (
+        <SuperTokensWrapper>
+            <ThirdpartyPasswordlessComponentsOverrideProvider
+                components={{
+                    ThirdPartyPasswordlessHeader_Override: ({ DefaultComponent, ...props }) => {
+                        return (
+                            <>
+                                <h1>I'm a header that you added above original component</h1>
+                                <DefaultComponent {...props} />
+                            </>
+                        )
+                    }
+                }}>
+                {/* Rest of the JSX */}
+            </ThirdpartyPasswordlessComponentsOverrideProvider>
+        </SuperTokensWrapper>
+    );
+}
+export default App;
 ```

--- a/v2/thirdpartypasswordless/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/react-component-override/usage.mdx
@@ -26,10 +26,6 @@ import ThirdPartyPasswordless, {ThirdpartyPasswordlessComponentsOverrideProvider
 // @ts-ignore
 import octocat from "./octocat.png";
 
-ThirdPartyPasswordless.init({
-    contactMethod: "EMAIL", // This example will work with any contactMethod.
-});
-
 function App() {
     return (
         <SuperTokensWrapper>
@@ -85,10 +81,6 @@ by spreading them.
 import React from "react";
 import { SuperTokensWrapper } from "supertokens-auth-react";
 import ThirdPartyPasswordless, {ThirdpartyPasswordlessComponentsOverrideProvider} from "supertokens-auth-react/recipe/thirdpartypasswordless";
-
-ThirdPartyPasswordless.init({
-    contactMethod: "EMAIL", // This example will work with any contactMethod.
-});
 
 function App() {
     return (

--- a/v2/thirdpartypasswordless/supabase-intergration/backend-signup-override.mdx
+++ b/v2/thirdpartypasswordless/supabase-intergration/backend-signup-override.mdx
@@ -81,7 +81,7 @@ let backendConfig = (): TypeInput => {
 
 ```
 
-We will be changing the the Passwordless flow by overriding the `consumeCodePOST` api. When a user signs up we will retrieve the `supabase_token` from the user's `accessTokenPayload`(this was added in the previous step where we changed the `createNewSession` function) and use it to query Supabase to insert the new user's information.
+We will be changing the Passwordless flow by overriding the `consumeCodePOST` api. When a user signs up we will retrieve the `supabase_token` from the user's `accessTokenPayload`(this was added in the previous step where we changed the `createNewSession` function) and use it to query Supabase to insert the new user's information.
 
 
 ## Step 2: Overriding the Social Provider login function:


### PR DESCRIPTION
## Summary of change
Moving components override config to a separate component

## Related issues
- https://github.com/supertokens/supertokens-auth-react/issues/616

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [x] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
-