### PR TITLE
Small updates to jwt rework related ADRs

### DIFF
--- a/v2/contribute/decisions/session/0022-ssr-jwt-use-case.mdx
+++ b/v2/contribute/decisions/session/0022-ssr-jwt-use-case.mdx
@@ -32,6 +32,7 @@ Introduce a new setting that will send the access token to the frontend even if 
 - We need to add a new function to make it accessible. (this will work for both header based auth and explicitly exposed access tokens)
 - Mention this in web-socket docs
 - This should also be set to true by the legacy `jwt: {enable: true }` setting.
+- We should mention this in the handling session tokens sections of each recipe (search for getAccessToken in docs)
 
 ## Pros and Cons of the Options
 

--- a/v2/contribute/decisions/session/0024-access-tokenstandard-jwt-claims.mdx
+++ b/v2/contribute/decisions/session/0024-access-tokenstandard-jwt-claims.mdx
@@ -55,3 +55,5 @@ We do not need to add:
 - `iss`: although this is widely used, it's optional (as per the rfc) and we don't have meaningful information to put here.
 - `nbf`: this could contain timeCreated but since we do not issue tokens with `nbf` in the future this is not useful.
 - `jti`: since this has to be globally unique (even among JWTs), we do not have any id to store here.
+
+While optional, we should add the `kid` (Key ID) Header Parameter

--- a/v2/contribute/decisions/session/0030-get-session-from-string.mdx
+++ b/v2/contribute/decisions/session/0030-get-session-from-string.mdx
@@ -11,7 +11,7 @@ import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
 
 # Add a new versions of createNew/refresh/getSession without response
 
-<DecisionHeader status="proposed" lastUpdate="2023-01-02" created="2022-12-13" deciders={["rishabhpoddar", "porcellus"]} proposedBy={["porcellus"]} />
+<DecisionHeader status="proposed" lastUpdate="2023-01-13" created="2022-12-13" deciders={["rishabhpoddar", "porcellus"]} proposedBy={["porcellus"]} />
 
 ## Context and Problem Statement
 
@@ -27,12 +27,8 @@ In some cases, the BE may need to create, refresh or validate access tokens base
 
 We've decided to add new functions: `getSessionWithoutModifyingResponse`, `refreshSessionWithoutModifyingResponse`, `createNewSessionWithoutModifyingResponse` functions that take/return the tokens as a string:
 - This will be very similar to the existing functions
-- It will need to add a new session container type that makes it explicit that you can't update the session on the FE through it.
-- It should not throw, match the pattern of `{ status: "OK", session: ImmutableSessionContainer }`
-
-`ImmutableSessionContainer` should:
-- Provide no modifying functions. (a deprecated&throwing version would mean we move this error to the runtime)
-- Have the same "read" functions: `getUserId`, `getSessionHandle`, etc.
+- It should not throw, match the pattern of `{ status: "OK"; session: SessionContainer }`
+- We should add a `getTokensDangerously` to the `SessionContainer` class, which should return all available tokens: `{ accessToken: string; refreshToken: string | undefined; antiCsrf: string | undefined; frontToken: string }`
 
 ### Recommend using a jwt verification lib
 

--- a/v2/contribute/decisions/session/0030-get-session-from-string.mdx
+++ b/v2/contribute/decisions/session/0030-get-session-from-string.mdx
@@ -28,7 +28,7 @@ In some cases, the BE may need to create, refresh or validate access tokens base
 We've decided to add new functions: `getSessionWithoutModifyingResponse`, `refreshSessionWithoutModifyingResponse`, `createNewSessionWithoutModifyingResponse` functions that take/return the tokens as a string:
 - This will be very similar to the existing functions
 - It should not throw, match the pattern of `{ status: "OK"; session: SessionContainer }`
-- We should add a `getTokensDangerously` to the `SessionContainer` class, which should return all available tokens: `{ accessToken: string; refreshToken: string | undefined; antiCsrf: string | undefined; frontToken: string }`
+- We should add a `getTokensDangerously` to the `SessionContainer` class, which should return all available tokens: `{ accessToken: string; refreshToken: string | undefined; antiCsrf: string | undefined; frontToken: string, accessAndFrontTokenUpdated: boolean }`
 
 ### Recommend using a jwt verification lib
 


### PR DESCRIPTION
## Summary of change
- Added `kid` header param into ADR about new jwt structure
- Added note to mention `exposeAccessTokenToFrontendInCookieBasedAuth` in `getAccessToken` docs

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
