### PR TITLE
fix: Added service up check command in docker compose files

### DIFF
--- a/v2/community/supertokens-core/self-hosted/with-docker.mdx
+++ b/v2/community/supertokens-core/self-hosted/with-docker.mdx
@@ -176,7 +176,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:
@@ -224,7 +225,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:

--- a/v2/emailpassword/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/emailpassword/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -176,7 +176,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:
@@ -224,7 +225,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:

--- a/v2/emailpassword/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/emailpassword/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -176,7 +176,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:
@@ -224,7 +225,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:

--- a/v2/passwordless/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/passwordless/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -176,7 +176,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:
@@ -224,7 +225,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:

--- a/v2/passwordless/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/passwordless/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -176,7 +176,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:
@@ -224,7 +225,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:

--- a/v2/session/quick-setup/core/self-hosted-with-docker.mdx
+++ b/v2/session/quick-setup/core/self-hosted-with-docker.mdx
@@ -176,7 +176,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:
@@ -224,7 +225,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:

--- a/v2/thirdparty/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/thirdparty/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -176,7 +176,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:
@@ -224,7 +225,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:

--- a/v2/thirdparty/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/thirdparty/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -176,7 +176,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:
@@ -224,7 +225,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:

--- a/v2/thirdpartyemailpassword/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/thirdpartyemailpassword/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -176,7 +176,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:
@@ -224,7 +225,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:

--- a/v2/thirdpartyemailpassword/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/thirdpartyemailpassword/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -176,7 +176,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:
@@ -224,7 +225,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:

--- a/v2/thirdpartypasswordless/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/thirdpartypasswordless/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -176,7 +176,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:
@@ -224,7 +225,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:

--- a/v2/thirdpartypasswordless/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/thirdpartypasswordless/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -176,7 +176,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-mysql^{docker_version_mysql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:
@@ -224,7 +225,8 @@ services:
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql^{docker_version_postgresql}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - 3567:3567
     environment:


### PR DESCRIPTION
## Summary of change
Instead of:

```docker
  supertokens:
    image: registry.supertokens.io/supertokens/supertokens-postgresql:4.3
    depends_on:
      - db
```

It should be:

```docker
  supertokens:
    image: registry.supertokens.io/supertokens/supertokens-postgresql:4.3
    depends_on:
      db:
        condition: service_healthy
```

## Related issues
- [Docker compose file should use health check. #557 
](https://github.com/supertokens/supertokens-core/issues/557)


## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2