### PR TITLE
ADR tabindex issue in main-website auth route

### DIFF
--- a/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
+++ b/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
@@ -19,20 +19,20 @@ When a custom field is added to the sign-up form, and the order of these fields 
 
 ## Considered Options
 
-* Change tabindex value in main-website repo itself
+* Change tabindex in the app that uses SDK
 * Make Recipe.init custom field(formFields) accept additional order property
 
 
 ## Decision Outcome
 
-Chosen option: Change tabindex value in main-website repo itself, because
+Chosen option: Change tabindex in the app that uses SDK, because
 
 * Option requires a lot less time
 * Changing order of the fields is a rare case
 
 ## Pros and Cons of the Options
 
-### Change tabindex value in main-website repo itself
+### Change tabindex in the app that uses SDK
 
 <ArgumentPro> Implementation is easy and faster </ArgumentPro>
 <ArgumentPro> supertokens-auth-react SDK does not need to be changed </ArgumentPro>
@@ -43,3 +43,4 @@ Chosen option: Change tabindex value in main-website repo itself, because
 <ArgumentPro> Would provide a nice developer experience </ArgumentPro>
 <ArgumentPro> Would work with as many fields as we want </ArgumentPro>
 <ArgumentCon> Requires more time and user facing interface changes </ArgumentCon>
+<ArgumentCon> Expands the interface for a very rare use-case </ArgumentCon>

--- a/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
+++ b/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
@@ -15,7 +15,7 @@ import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
 
 ## Context and Problem Statement
 
-When custom field is added to sign up form and the order of these fields are changed using CSS keyboard navigation between inputs is broken. See related [issue](https://github.com/supertokens/supertokens-auth-react/issues/634)
+When a custom field is added to the sign-up form, and the order of these fields is changed using CSS, keyboard navigation between inputs breaks. See related [issue](https://github.com/supertokens/supertokens-auth-react/issues/634)
 
 ## Considered Options
 

--- a/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
+++ b/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
@@ -9,7 +9,7 @@ import ArgumentPro from "/src/components/decisionLogs/ArgumentPro"
 import ArgumentCon from "/src/components/decisionLogs/ArgumentCon"
 import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
 
-# Fix input tabbing issue in main-website auth route
+# Input tabbing issue when re-ordering default fields
 
 <DecisionHeader status="proposed" lastUpdate="2023-01-17" created="2023-01-17" deciders={["rishabhpoddar", "porcellus"]} proposedBy={["alisher-aituarov"]} />
 

--- a/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
+++ b/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
@@ -1,0 +1,45 @@
+---
+id: "0002"
+title: Fix input tabbing issue in main-website auth route
+hide_title: true
+---
+
+import DecisionHeader from "/src/components/decisionLogs/DecisionHeader"
+import ArgumentPro from "/src/components/decisionLogs/ArgumentPro"
+import ArgumentCon from "/src/components/decisionLogs/ArgumentCon"
+import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut"
+
+# Fix input tabbing issue in main-website auth route
+
+<DecisionHeader status="proposed" lastUpdate="2023-01-17" created="2023-01-17" deciders={["rishabhpoddar", "porcellus"]} proposedBy={["alisher-aituarov"]} />
+
+## Context and Problem Statement
+
+When custom field is added to sign up form and the order of these fields are changed using CSS keyboard navigation between inputs is broken. See related [issue](https://github.com/supertokens/supertokens-auth-react/issues/634)
+
+## Considered Options
+
+* Change tabindex value in main-website repo itself
+* Make Recipe.init custom field(formFields) accept additional order property
+
+
+## Decision Outcome
+
+Chosen option: Change tabindex value in main-website repo itself, because
+
+* Option requires a lot less time
+* Changing order of the fields is a rare case
+
+## Pros and Cons of the Options
+
+### Change tabindex value in main-website repo itself
+
+<ArgumentPro> Implementation is easy and faster </ArgumentPro>
+<ArgumentPro> supertokens-auth-react SDK does not need to be changed </ArgumentPro>
+<ArgumentCon> Option works only with the way it is now, adding any more fields would break tab navigation again </ArgumentCon>
+
+### Make Recipe.init custom field(formFields) accept additional order property
+
+<ArgumentPro> Would provide a nice developer experience </ArgumentPro>
+<ArgumentPro> Would work with as many fields as we want </ArgumentPro>
+<ArgumentCon> Requires more time and user facing interface changes </ArgumentCon>

--- a/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
+++ b/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
@@ -1,6 +1,6 @@
 ---
 id: "0002"
-title: Fix input tabbing issue in main-website auth route
+title: Input tabbing issue when re-ordering default fields
 hide_title: true
 ---
 

--- a/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
+++ b/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
@@ -28,7 +28,7 @@ When a custom field is added to the sign-up form, and the order of these fields 
 Chosen option: Change tabindex in the app that uses SDK, because
 
 * Option requires a lot less time
-* Changing order of the fields is a rare case
+* Tab works fine with fields added afters defaults. They can be ordered in the input, making the use of CSS to order rare
 
 ## Pros and Cons of the Options
 

--- a/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
+++ b/v2/contribute/decisions/reactsdk/0002-custom-field-tabindex-issue.mdx
@@ -36,7 +36,7 @@ Chosen option: Change tabindex value in main-website repo itself, because
 
 <ArgumentPro> Implementation is easy and faster </ArgumentPro>
 <ArgumentPro> supertokens-auth-react SDK does not need to be changed </ArgumentPro>
-<ArgumentCon> Option works only with the way it is now, adding any more fields would break tab navigation again </ArgumentCon>
+<ArgumentCon> Adding more fields would break tab navigation again </ArgumentCon>
 
 ### Make Recipe.init custom field(formFields) accept additional order property
 

--- a/v2/contribute/sidebars.js
+++ b/v2/contribute/sidebars.js
@@ -247,6 +247,7 @@ module.exports = {
           label: "React-SDK",
           items: [
             "decisions/reactsdk/0001",
+            "decisions/reactsdk/0002",
           ],
         },
       ],


### PR DESCRIPTION
## Summary of change
Adds ADR about tabindex issue with reordered custom fields

## Related issues
- https://github.com/supertokens/supertokens-auth-react/issues/634

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
