### PR TITLE
Adding ADR about handling front-token after flattening the access token

### DIFF
--- a/v2/contribute/decisions/session/0015-jwt-compatibility.mdx
+++ b/v2/contribute/decisions/session/0015-jwt-compatibility.mdx
@@ -30,5 +30,6 @@ Once we make the entire access token into a JWT:
 - Since the access token can now be used instead of the a separate JWT embedded in the access token, it is more useful to send to third-party APIs where we are not intercepting request.
     - These will check the access token based on the JWKs endpoint exposed by the BE, but we do not need to worry about key rotation here, since the signing keys stay in the output of the jwks endpoint long after the access token expires.
     - Calling `getAccessToken` will cause a refresh to happen if the locally stored access token is expired, so refreshing should happen automatically in most cases (if the access token doesn't expire during the request) even if we are not intercepting requests to the domain.
+    - Claim checking needs to be done manually in this case (e.g.: an API Gateway will not check if the email is verified or not). This should be documented/communicated somewhere.
 
 Until then: the auth mode and jwt options are entirely independent, the jwt can be accessed through the access token payload in both auth modes.

--- a/v2/contribute/decisions/session/0015-jwt-compatibility.mdx
+++ b/v2/contribute/decisions/session/0015-jwt-compatibility.mdx
@@ -27,5 +27,8 @@ We want to make our access token into a valid JWT. So, in the future the jwt set
 Once we make the entire access token into a JWT:
 - Add deprecation warning with a migration link and set `exposeAccessTokenToFrontendInCookieBasedAuth` to true. See [here](./0022)
 - Add a function to the FE to access the entire access token as a string.
+- Since the access token can now be used instead of the a separate JWT embedded in the access token, it is more useful to send to third-party APIs where we are not intercepting request.
+    - These will check the access token based on the JWKs endpoint exposed by the BE, but we do not need to worry about key rotation here, since the signing keys stay in the output of the jwks endpoint long after the access token expires.
+    - Calling `getAccessToken` will cause a refresh to happen if the locally stored access token is expired, so refreshing should happen automatically in most cases (if the access token doesn't expire during the request) even if we are not intercepting requests to the domain.
 
 Until then: the auth mode and jwt options are entirely independent, the jwt can be accessed through the access token payload in both auth modes.

--- a/v2/contribute/decisions/session/0024-access-tokenstandard-jwt-claims.mdx
+++ b/v2/contribute/decisions/session/0024-access-tokenstandard-jwt-claims.mdx
@@ -57,3 +57,5 @@ We do not need to add:
 - `jti`: since this has to be globally unique (even among JWTs), we do not have any id to store here.
 
 While optional, we should add the `kid` (Key ID) Header Parameter
+
+We also need to throw if the user tries to add these claims into a custom payload (checked on the core level), since overwriting these could be a security risk. (e.g.: changing the userId of the session and extending the validity)

--- a/v2/contribute/decisions/session/0031-internal-prop-handling-in-flat-access-tokens.mdx
+++ b/v2/contribute/decisions/session/0031-internal-prop-handling-in-flat-access-tokens.mdx
@@ -1,0 +1,62 @@
+---
+id: "0031"
+title: Do not add internal only claims to the front-token
+hide_title: true
+---
+
+import DecisionHeader from "/src/components/decisionLogs/DecisionHeader";
+import ArgumentPro from "/src/components/decisionLogs/ArgumentPro";
+import ArgumentCon from "/src/components/decisionLogs/ArgumentCon";
+import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut";
+
+# Do not add internal only claims to the front-token
+
+<DecisionHeader
+  status="proposed"
+  lastUpdate="2023-01-02"
+  created="2022-12-06"
+  deciders={["rishabhpoddar", "porcellus"]}
+  proposedBy={["porcellus"]}
+/>
+
+## Context and Problem Statement
+
+When flattening the access token structure and making it into a standard JWT, we have to decide if it's safe to add all claims (including internally used ones) into the front-token, or not.
+
+## Considered Options
+
+- Hide internal-only claims
+- Hide all claims not added by the user
+- Expose all claims
+
+## Decision Outcome
+
+We should hide internal-only claims
+
+- We don't want to confuse our users
+- They are never used in applications
+
+We decided to hide: `refreshTokenHash1`, `parentRefreshTokenHash1`, because they do not make sense for the application and are never used as a part of CDI or FDI. 
+We can expose `sub`, `exp` and `iat`, because they have standard names and carry potentially useful information that we expose anyway.
+Exposing the `sessionHandle` should not cause any issues and could be useful in very rare cases on the frontend to detect session changes. This is only used on the CDI, while getting session information and updating sessionData in the database (not in access token). As a side-note, using the session handle to call `updateSessionData` doesn't seem to be documented.
+
+### Hide internal-only claims
+
+<ArgumentPro> Hides claims that would be useless to the application </ArgumentPro>
+<ArgumentPro> Exposes the standard claims (people have tried to get them through `getAccessTokenPayload` before) </ArgumentPro>
+<ArgumentCon> Changes the current behaviour/interface </ArgumentCon>
+
+### Hide all claims not added by the user
+
+<ArgumentPro> Matches the current behaviour </ArgumentPro>
+<ArgumentPro> Hides all claims that could be confusing </ArgumentPro>
+<ArgumentCon> People have been looking for the userId claim </ArgumentCon>
+<ArgumentCon> We are hiding otherwise standard claims </ArgumentCon>
+
+### Expose all claims 
+
+<ArgumentPro> Front-token is very straght-forward </ArgumentPro>
+<ArgumentCon> Changes the current behaviour/interface </ArgumentCon>
+<ArgumentPro> Exposes the standard claims (people have tried to use them through getAccessTokenPayload before) </ArgumentPro>
+<ArgumentCon> Could be confusing, we'd need to document each internal claim (and/or move them into a separate `st_internal` claim) </ArgumentCon>
+<ArgumentCon> `parentRefreshTokenHash1` and `refreshTokenHash1` are never used outside of the access token </ArgumentCon>

--- a/v2/contribute/decisions/session/0031-internal-prop-handling-in-flat-access-tokens.mdx
+++ b/v2/contribute/decisions/session/0031-internal-prop-handling-in-flat-access-tokens.mdx
@@ -1,6 +1,6 @@
 ---
 id: "0031"
-title: Do not add internal only claims to the front-token
+title: Expose all access token claims to the FE
 hide_title: true
 ---
 
@@ -9,7 +9,7 @@ import ArgumentPro from "/src/components/decisionLogs/ArgumentPro";
 import ArgumentCon from "/src/components/decisionLogs/ArgumentCon";
 import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut";
 
-# Do not add internal only claims to the front-token
+# Expose all access token claims to the FE
 
 <DecisionHeader
   status="proposed"
@@ -31,20 +31,22 @@ When flattening the access token structure and making it into a standard JWT, we
 
 ## Decision Outcome
 
-We should hide internal-only claims
+We decided to expose all claims to the FE
 
-- We don't want to confuse our users
-- They are never used in applications
+- Making them accessible to the FE is not a security risk
+- Straightforward interface
 
-We decided to hide: `refreshTokenHash1`, `parentRefreshTokenHash1`, because they do not make sense for the application and are never used as a part of CDI or FDI. 
 We can expose `sub`, `exp` and `iat`, because they have standard names and carry potentially useful information that we expose anyway.
 Exposing the `sessionHandle` should not cause any issues and could be useful in very rare cases on the frontend to detect session changes. This is only used on the CDI, while getting session information and updating sessionData in the database (not in access token). As a side-note, using the session handle to call `updateSessionData` doesn't seem to be documented.
+Exposing `refreshTokenHash1`, `parentRefreshTokenHash1` to the frontend should not cause any issues, since they are never used as a part of the CDI or FDI. Only used in context of the (signed) access token.
 
 ### Hide internal-only claims
 
 <ArgumentPro> Hides claims that would be useless to the application </ArgumentPro>
-<ArgumentPro> Exposes the standard claims (people have tried to get them through `getAccessTokenPayload` before) </ArgumentPro>
-<ArgumentCon> Changes the current behaviour/interface </ArgumentCon>
+<ArgumentPro>
+  Exposes the standard claims (people have tried to get them through `getAccessTokenPayload` before)
+</ArgumentPro>
+<ArgumentCon> Changes the current behaviour/interface (new props appearing in `getAccessTokenPayload`) </ArgumentCon>
 
 ### Hide all claims not added by the user
 
@@ -53,10 +55,17 @@ Exposing the `sessionHandle` should not cause any issues and could be useful in 
 <ArgumentCon> People have been looking for the userId claim </ArgumentCon>
 <ArgumentCon> We are hiding otherwise standard claims </ArgumentCon>
 
-### Expose all claims 
+### Expose all claims
 
 <ArgumentPro> Front-token is very straght-forward </ArgumentPro>
-<ArgumentCon> Changes the current behaviour/interface </ArgumentCon>
-<ArgumentPro> Exposes the standard claims (people have tried to use them through getAccessTokenPayload before) </ArgumentPro>
-<ArgumentCon> Could be confusing, we'd need to document each internal claim (and/or move them into a separate `st_internal` claim) </ArgumentCon>
-<ArgumentCon> `parentRefreshTokenHash1` and `refreshTokenHash1` are never used outside of the access token </ArgumentCon>
+<ArgumentCon> Changes the current behaviour/interface (new props appearing in `getAccessTokenPayload`) </ArgumentCon>
+<ArgumentPro>
+  Exposes the standard claims (people have tried to use them through getAccessTokenPayload before)
+</ArgumentPro>
+<ArgumentCon>
+  Could be confusing, but we can answer questions as they arise. We can decide to document this in the future if these
+  questions get repeated too much.
+</ArgumentCon>
+<ArgumentCon>
+  `parentRefreshTokenHash1` and `refreshTokenHash1` are never used outside of the access token
+</ArgumentCon>

--- a/v2/contribute/decisions/session/0031-internal-prop-handling-in-flat-access-tokens.mdx
+++ b/v2/contribute/decisions/session/0031-internal-prop-handling-in-flat-access-tokens.mdx
@@ -13,8 +13,8 @@ import ArgumentNeut from "/src/components/decisionLogs/ArgumentNeut";
 
 <DecisionHeader
   status="proposed"
-  lastUpdate="2023-01-02"
-  created="2022-12-06"
+  lastUpdate="2023-01-22"
+  created="2023-01-22"
   deciders={["rishabhpoddar", "porcellus"]}
   proposedBy={["porcellus"]}
 />

--- a/v2/contribute/sidebars.js
+++ b/v2/contribute/sidebars.js
@@ -180,7 +180,8 @@ module.exports = {
             "decisions/session/0027",
             "decisions/session/0028",
             "decisions/session/0029",
-            "decisions/session/0030"
+            "decisions/session/0030",
+            "decisions/session/0031"
           ],
         },
         {


### PR DESCRIPTION
## Summary of change
Adding ADR about handling front-token after flattening the access token

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
