### PR TITLE
chore: Add snippets for mobile SDKs for header based auth

### DIFF
--- a/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -155,6 +155,10 @@ SuperTokens.init({
 
 </FrontendPreBuiltUITabs>
 
+:::caution
+Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+:::
+
 </PreBuiltUIContent>
 
 <CustomUIContent>
@@ -209,6 +213,10 @@ supertokens.init({
 </TabItem>
 </NpmOrScriptTabs>
 
+:::caution
+Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+:::
+
 </TabItem>
 
 <TabItem value="mobile">
@@ -224,7 +232,3 @@ Not applicable
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
-
-:::caution
-Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
-:::

--- a/v2/emailpassword/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/emailpassword/common-customizations/sessions/token-transfer-method.mdx
@@ -218,9 +218,69 @@ supertokens.init({
 
 <TabItem value="mobile">
 
-:::caution
-TODO for mobile SDKs
-:::
+<FrontendMobileSubTabs>
+
+<TabItem value="reactnative">
+
+```tsx
+import SuperTokens from 'supertokens-react-native';
+
+SuperTokens.init({
+    apiDomain: "...",
+    tokenTransferMethod: "header", // or "cookie". "header" by default
+});
+```
+
+</TabItem>
+
+<TabItem value="android">
+
+```kotlin
+import android.app.Application
+import com.supertokens.session.SuperTokens
+
+class MainApplication: Application() {
+    override fun onCreate() {
+        super.onCreate()
+        
+        SuperTokens.Builder(this, "...")
+            .tokenTransferMethod("header") // or "cookie". "header" by default
+            .build()
+    }
+}
+```
+
+</TabItem>
+
+<TabItem value="ios">
+
+```swift
+import UIKit
+import SuperTokensIOS
+
+fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        do {
+            try SuperTokens.initialize(
+                apiDomain: "...",
+                tokenTransferMethod: .header // or .cookie . header by default
+            )
+        } catch SuperTokensError.initError(let message) {
+            // TODO: Handle initialization error
+        } catch {
+            // Some other error
+        }
+
+        return true
+    }
+    
+}
+```
+
+</TabItem>
+
+</FrontendMobileSubTabs>
 
 </TabItem>
 

--- a/v2/emailpassword/custom-ui/handling-session-tokens.mdx
+++ b/v2/emailpassword/custom-ui/handling-session-tokens.mdx
@@ -271,6 +271,31 @@ async function getToken(): Promise<boolean> {
 ```
 
 </TabItem>
+
+<TabItem value="android">
+
+```kotlin
+import com.supertokens.session.SuperTokens
+
+public String getToken() {
+    return SuperTokens.getAccessToken();
+}
+```
+
+</TabItem>
+
+<TabItem value="ios">
+
+```swift
+import Foundation
+import SuperTokensIOS
+
+func getToken() -> String? {
+    return SuperTokens.getAccessToken()
+}
+```
+
+</TabItem>
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -155,6 +155,10 @@ SuperTokens.init({
 
 </FrontendPreBuiltUITabs>
 
+:::caution
+Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+:::
+
 </PreBuiltUIContent>
 
 <CustomUIContent>
@@ -209,6 +213,10 @@ supertokens.init({
 </TabItem>
 </NpmOrScriptTabs>
 
+:::caution
+Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+:::
+
 </TabItem>
 
 <TabItem value="mobile">
@@ -224,7 +232,3 @@ Not applicable
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
-
-:::caution
-Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
-:::

--- a/v2/passwordless/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/passwordless/common-customizations/sessions/token-transfer-method.mdx
@@ -218,9 +218,69 @@ supertokens.init({
 
 <TabItem value="mobile">
 
-:::caution
-TODO for mobile SDKs
-:::
+<FrontendMobileSubTabs>
+
+<TabItem value="reactnative">
+
+```tsx
+import SuperTokens from 'supertokens-react-native';
+
+SuperTokens.init({
+    apiDomain: "...",
+    tokenTransferMethod: "header", // or "cookie". "header" by default
+});
+```
+
+</TabItem>
+
+<TabItem value="android">
+
+```kotlin
+import android.app.Application
+import com.supertokens.session.SuperTokens
+
+class MainApplication: Application() {
+    override fun onCreate() {
+        super.onCreate()
+        
+        SuperTokens.Builder(this, "...")
+            .tokenTransferMethod("header") // or "cookie". "header" by default
+            .build()
+    }
+}
+```
+
+</TabItem>
+
+<TabItem value="ios">
+
+```swift
+import UIKit
+import SuperTokensIOS
+
+fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        do {
+            try SuperTokens.initialize(
+                apiDomain: "...",
+                tokenTransferMethod: .header // or .cookie . header by default
+            )
+        } catch SuperTokensError.initError(let message) {
+            // TODO: Handle initialization error
+        } catch {
+            // Some other error
+        }
+
+        return true
+    }
+    
+}
+```
+
+</TabItem>
+
+</FrontendMobileSubTabs>
 
 </TabItem>
 

--- a/v2/passwordless/custom-ui/handling-session-tokens.mdx
+++ b/v2/passwordless/custom-ui/handling-session-tokens.mdx
@@ -271,6 +271,31 @@ async function getToken(): Promise<boolean> {
 ```
 
 </TabItem>
+
+<TabItem value="android">
+
+```kotlin
+import com.supertokens.session.SuperTokens
+
+public String getToken() {
+    return SuperTokens.getAccessToken();
+}
+```
+
+</TabItem>
+
+<TabItem value="ios">
+
+```swift
+import Foundation
+import SuperTokensIOS
+
+func getToken() -> String? {
+    return SuperTokens.getAccessToken()
+}
+```
+
+</TabItem>
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -155,6 +155,10 @@ SuperTokens.init({
 
 </FrontendPreBuiltUITabs>
 
+:::caution
+Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+:::
+
 </PreBuiltUIContent>
 
 <CustomUIContent>
@@ -209,6 +213,10 @@ supertokens.init({
 </TabItem>
 </NpmOrScriptTabs>
 
+:::caution
+Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+:::
+
 </TabItem>
 
 <TabItem value="mobile">
@@ -224,7 +232,3 @@ Not applicable
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
-
-:::caution
-Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
-:::

--- a/v2/session/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/session/common-customizations/sessions/token-transfer-method.mdx
@@ -218,9 +218,69 @@ supertokens.init({
 
 <TabItem value="mobile">
 
-:::caution
-TODO for mobile SDKs
-:::
+<FrontendMobileSubTabs>
+
+<TabItem value="reactnative">
+
+```tsx
+import SuperTokens from 'supertokens-react-native';
+
+SuperTokens.init({
+    apiDomain: "...",
+    tokenTransferMethod: "header", // or "cookie". "header" by default
+});
+```
+
+</TabItem>
+
+<TabItem value="android">
+
+```kotlin
+import android.app.Application
+import com.supertokens.session.SuperTokens
+
+class MainApplication: Application() {
+    override fun onCreate() {
+        super.onCreate()
+        
+        SuperTokens.Builder(this, "...")
+            .tokenTransferMethod("header") // or "cookie". "header" by default
+            .build()
+    }
+}
+```
+
+</TabItem>
+
+<TabItem value="ios">
+
+```swift
+import UIKit
+import SuperTokensIOS
+
+fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        do {
+            try SuperTokens.initialize(
+                apiDomain: "...",
+                tokenTransferMethod: .header // or .cookie . header by default
+            )
+        } catch SuperTokensError.initError(let message) {
+            // TODO: Handle initialization error
+        } catch {
+            // Some other error
+        }
+
+        return true
+    }
+    
+}
+```
+
+</TabItem>
+
+</FrontendMobileSubTabs>
 
 </TabItem>
 

--- a/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -155,6 +155,10 @@ SuperTokens.init({
 
 </FrontendPreBuiltUITabs>
 
+:::caution
+Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+:::
+
 </PreBuiltUIContent>
 
 <CustomUIContent>
@@ -209,6 +213,10 @@ supertokens.init({
 </TabItem>
 </NpmOrScriptTabs>
 
+:::caution
+Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+:::
+
 </TabItem>
 
 <TabItem value="mobile">
@@ -224,7 +232,3 @@ Not applicable
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
-
-:::caution
-Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
-:::

--- a/v2/thirdparty/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/thirdparty/common-customizations/sessions/token-transfer-method.mdx
@@ -218,9 +218,69 @@ supertokens.init({
 
 <TabItem value="mobile">
 
-:::caution
-TODO for mobile SDKs
-:::
+<FrontendMobileSubTabs>
+
+<TabItem value="reactnative">
+
+```tsx
+import SuperTokens from 'supertokens-react-native';
+
+SuperTokens.init({
+    apiDomain: "...",
+    tokenTransferMethod: "header", // or "cookie". "header" by default
+});
+```
+
+</TabItem>
+
+<TabItem value="android">
+
+```kotlin
+import android.app.Application
+import com.supertokens.session.SuperTokens
+
+class MainApplication: Application() {
+    override fun onCreate() {
+        super.onCreate()
+        
+        SuperTokens.Builder(this, "...")
+            .tokenTransferMethod("header") // or "cookie". "header" by default
+            .build()
+    }
+}
+```
+
+</TabItem>
+
+<TabItem value="ios">
+
+```swift
+import UIKit
+import SuperTokensIOS
+
+fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        do {
+            try SuperTokens.initialize(
+                apiDomain: "...",
+                tokenTransferMethod: .header // or .cookie . header by default
+            )
+        } catch SuperTokensError.initError(let message) {
+            // TODO: Handle initialization error
+        } catch {
+            // Some other error
+        }
+
+        return true
+    }
+    
+}
+```
+
+</TabItem>
+
+</FrontendMobileSubTabs>
 
 </TabItem>
 

--- a/v2/thirdparty/custom-ui/handling-session-tokens.mdx
+++ b/v2/thirdparty/custom-ui/handling-session-tokens.mdx
@@ -271,6 +271,31 @@ async function getToken(): Promise<boolean> {
 ```
 
 </TabItem>
+
+<TabItem value="android">
+
+```kotlin
+import com.supertokens.session.SuperTokens
+
+public String getToken() {
+    return SuperTokens.getAccessToken();
+}
+```
+
+</TabItem>
+
+<TabItem value="ios">
+
+```swift
+import Foundation
+import SuperTokensIOS
+
+func getToken() -> String? {
+    return SuperTokens.getAccessToken()
+}
+```
+
+</TabItem>
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -155,6 +155,10 @@ SuperTokens.init({
 
 </FrontendPreBuiltUITabs>
 
+:::caution
+Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+:::
+
 </PreBuiltUIContent>
 
 <CustomUIContent>
@@ -209,6 +213,10 @@ supertokens.init({
 </TabItem>
 </NpmOrScriptTabs>
 
+:::caution
+Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+:::
+
 </TabItem>
 
 <TabItem value="mobile">
@@ -224,7 +232,3 @@ Not applicable
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
-
-:::caution
-Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
-:::

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/token-transfer-method.mdx
@@ -218,9 +218,69 @@ supertokens.init({
 
 <TabItem value="mobile">
 
-:::caution
-TODO for mobile SDKs
-:::
+<FrontendMobileSubTabs>
+
+<TabItem value="reactnative">
+
+```tsx
+import SuperTokens from 'supertokens-react-native';
+
+SuperTokens.init({
+    apiDomain: "...",
+    tokenTransferMethod: "header", // or "cookie". "header" by default
+});
+```
+
+</TabItem>
+
+<TabItem value="android">
+
+```kotlin
+import android.app.Application
+import com.supertokens.session.SuperTokens
+
+class MainApplication: Application() {
+    override fun onCreate() {
+        super.onCreate()
+        
+        SuperTokens.Builder(this, "...")
+            .tokenTransferMethod("header") // or "cookie". "header" by default
+            .build()
+    }
+}
+```
+
+</TabItem>
+
+<TabItem value="ios">
+
+```swift
+import UIKit
+import SuperTokensIOS
+
+fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        do {
+            try SuperTokens.initialize(
+                apiDomain: "...",
+                tokenTransferMethod: .header // or .cookie . header by default
+            )
+        } catch SuperTokensError.initError(let message) {
+            // TODO: Handle initialization error
+        } catch {
+            // Some other error
+        }
+
+        return true
+    }
+    
+}
+```
+
+</TabItem>
+
+</FrontendMobileSubTabs>
 
 </TabItem>
 

--- a/v2/thirdpartyemailpassword/custom-ui/handling-session-tokens.mdx
+++ b/v2/thirdpartyemailpassword/custom-ui/handling-session-tokens.mdx
@@ -271,6 +271,31 @@ async function getToken(): Promise<boolean> {
 ```
 
 </TabItem>
+
+<TabItem value="android">
+
+```kotlin
+import com.supertokens.session.SuperTokens
+
+public String getToken() {
+    return SuperTokens.getAccessToken();
+}
+```
+
+</TabItem>
+
+<TabItem value="ios">
+
+```swift
+import Foundation
+import SuperTokensIOS
+
+func getToken() -> String? {
+    return SuperTokens.getAccessToken()
+}
+```
+
+</TabItem>
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -155,6 +155,10 @@ SuperTokens.init({
 
 </FrontendPreBuiltUITabs>
 
+:::caution
+Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+:::
+
 </PreBuiltUIContent>
 
 <CustomUIContent>
@@ -209,6 +213,10 @@ supertokens.init({
 </TabItem>
 </NpmOrScriptTabs>
 
+:::caution
+Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
+:::
+
 </TabItem>
 
 <TabItem value="mobile">
@@ -224,7 +232,3 @@ Not applicable
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
-
-:::caution
-Do not set `sessionTokenFrontendDomain` to a value that's in the [public suffix list](https://publicsuffix.org/list/public_suffix_list.dat) (Search for your value without the leading dot). Otherwise session management will not work.
-:::

--- a/v2/thirdpartypasswordless/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/token-transfer-method.mdx
@@ -218,9 +218,69 @@ supertokens.init({
 
 <TabItem value="mobile">
 
-:::caution
-TODO for mobile SDKs
-:::
+<FrontendMobileSubTabs>
+
+<TabItem value="reactnative">
+
+```tsx
+import SuperTokens from 'supertokens-react-native';
+
+SuperTokens.init({
+    apiDomain: "...",
+    tokenTransferMethod: "header", // or "cookie". "header" by default
+});
+```
+
+</TabItem>
+
+<TabItem value="android">
+
+```kotlin
+import android.app.Application
+import com.supertokens.session.SuperTokens
+
+class MainApplication: Application() {
+    override fun onCreate() {
+        super.onCreate()
+        
+        SuperTokens.Builder(this, "...")
+            .tokenTransferMethod("header") // or "cookie". "header" by default
+            .build()
+    }
+}
+```
+
+</TabItem>
+
+<TabItem value="ios">
+
+```swift
+import UIKit
+import SuperTokensIOS
+
+fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        do {
+            try SuperTokens.initialize(
+                apiDomain: "...",
+                tokenTransferMethod: .header // or .cookie . header by default
+            )
+        } catch SuperTokensError.initError(let message) {
+            // TODO: Handle initialization error
+        } catch {
+            // Some other error
+        }
+
+        return true
+    }
+    
+}
+```
+
+</TabItem>
+
+</FrontendMobileSubTabs>
 
 </TabItem>
 

--- a/v2/thirdpartypasswordless/custom-ui/handling-session-tokens.mdx
+++ b/v2/thirdpartypasswordless/custom-ui/handling-session-tokens.mdx
@@ -271,6 +271,31 @@ async function getToken(): Promise<boolean> {
 ```
 
 </TabItem>
+
+<TabItem value="android">
+
+```kotlin
+import com.supertokens.session.SuperTokens
+
+public String getToken() {
+    return SuperTokens.getAccessToken();
+}
+```
+
+</TabItem>
+
+<TabItem value="ios">
+
+```swift
+import Foundation
+import SuperTokensIOS
+
+func getToken() -> String? {
+    return SuperTokens.getAccessToken()
+}
+```
+
+</TabItem>
 </FrontendMobileSubTabs>
 
 </TabItem>


### PR DESCRIPTION
## Summary of change
Adds snippets for header based auth for React Native, Android and iOS

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] ...