### PR TITLE
Adds note on avoiding underscores in service name

### DIFF
--- a/v2/community/supertokens-core/self-hosted/with-docker.mdx
+++ b/v2/community/supertokens-core/self-hosted/with-docker.mdx
@@ -205,6 +205,7 @@ networks:
 version: '3'
 
 services:
+  # Note: If you are assigning a custom name to your db service on the line below, make sure it does not contain underscores
   db:
     image: 'postgres:latest'
     environment:

--- a/v2/emailpassword/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/emailpassword/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -205,6 +205,7 @@ networks:
 version: '3'
 
 services:
+  # Note: If you are assigning a custom name to your db service on the line below, make sure it does not contain underscores
   db:
     image: 'postgres:latest'
     environment:

--- a/v2/emailpassword/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/emailpassword/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -205,6 +205,7 @@ networks:
 version: '3'
 
 services:
+  # Note: If you are assigning a custom name to your db service on the line below, make sure it does not contain underscores
   db:
     image: 'postgres:latest'
     environment:

--- a/v2/passwordless/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/passwordless/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -205,6 +205,7 @@ networks:
 version: '3'
 
 services:
+  # Note: If you are assigning a custom name to your db service on the line below, make sure it does not contain underscores
   db:
     image: 'postgres:latest'
     environment:

--- a/v2/passwordless/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/passwordless/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -205,6 +205,7 @@ networks:
 version: '3'
 
 services:
+  # Note: If you are assigning a custom name to your db service on the line below, make sure it does not contain underscores
   db:
     image: 'postgres:latest'
     environment:

--- a/v2/session/quick-setup/core/self-hosted-with-docker.mdx
+++ b/v2/session/quick-setup/core/self-hosted-with-docker.mdx
@@ -205,6 +205,7 @@ networks:
 version: '3'
 
 services:
+  # Note: If you are assigning a custom name to your db service on the line below, make sure it does not contain underscores
   db:
     image: 'postgres:latest'
     environment:

--- a/v2/thirdparty/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/thirdparty/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -205,6 +205,7 @@ networks:
 version: '3'
 
 services:
+  # Note: If you are assigning a custom name to your db service on the line below, make sure it does not contain underscores
   db:
     image: 'postgres:latest'
     environment:

--- a/v2/thirdparty/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/thirdparty/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -205,6 +205,7 @@ networks:
 version: '3'
 
 services:
+  # Note: If you are assigning a custom name to your db service on the line below, make sure it does not contain underscores
   db:
     image: 'postgres:latest'
     environment:

--- a/v2/thirdpartyemailpassword/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/thirdpartyemailpassword/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -205,6 +205,7 @@ networks:
 version: '3'
 
 services:
+  # Note: If you are assigning a custom name to your db service on the line below, make sure it does not contain underscores
   db:
     image: 'postgres:latest'
     environment:

--- a/v2/thirdpartyemailpassword/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/thirdpartyemailpassword/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -205,6 +205,7 @@ networks:
 version: '3'
 
 services:
+  # Note: If you are assigning a custom name to your db service on the line below, make sure it does not contain underscores
   db:
     image: 'postgres:latest'
     environment:

--- a/v2/thirdpartypasswordless/custom-ui/init/core/self-hosted-with-docker.mdx
+++ b/v2/thirdpartypasswordless/custom-ui/init/core/self-hosted-with-docker.mdx
@@ -205,6 +205,7 @@ networks:
 version: '3'
 
 services:
+  # Note: If you are assigning a custom name to your db service on the line below, make sure it does not contain underscores
   db:
     image: 'postgres:latest'
     environment:

--- a/v2/thirdpartypasswordless/pre-built-ui/setup/core/self-hosted-with-docker.mdx
+++ b/v2/thirdpartypasswordless/pre-built-ui/setup/core/self-hosted-with-docker.mdx
@@ -205,6 +205,7 @@ networks:
 version: '3'
 
 services:
+  # Note: If you are assigning a custom name to your db service on the line below, make sure it does not contain underscores
   db:
     image: 'postgres:latest'
     environment:


### PR DESCRIPTION
## Summary of change
This change adds a note to avoid using underscores as part of the db service name in the `docker-compose` config for Postgres.  If the db service name includes an underscore e.g. `supertokens_db`, Supertokens will fail to connect to the db server using what appears to be a correct `POSTGRESQL_CONNECTION_URI` (e.g. `"postgresql://supertokens_user:somePassword@supertokens_db:5432/supertokens"`) - full discussion with @rishabhpoddar on Discord [here](https://discord.com/channels/603466164219281420/1069771923938091048).  It's not clear from the error log that the underscores are the problem (it just says it couldn't connect), but I believe it can be traced back to the usage of `java.net.URI.create()` [here](https://github.com/supertokens/supertokens-postgresql-plugin/blob/535a5ba046d4f6b5d0cbe1d48f1c10676a3fa72b/src/main/java/io/supertokens/storage/postgresql/config/PostgreSQLConfig.java#L90).  That function apparently is based on an old RFC spec for URIs which classes underscores as invalid in URIs.

## Related issues
N/A

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
None