### PR TITLE
fix: Add axios interceptors step to react native quick setup in session docs

### DIFF
--- a/v2/session/quick-setup/frontend.mdx
+++ b/v2/session/quick-setup/frontend.mdx
@@ -187,6 +187,12 @@ SuperTokens.init({
 });
 ```
 
+<h3>Add API interceptors for automatic session refreshing</h3>
+
+import NetworkInterceptors from "/session/reusableMD/networkInterceptors.mdx"
+
+<NetworkInterceptors />
+
 </AppInfoForm>
 
 </TabItem>


### PR DESCRIPTION
## Summary of change

In an older change, the section covering adding axios interceptors for react native in the Session recipe docs was removed. This PR adds it again.

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] ...