### PR TITLE
add caution about setting access token expiry over 400 days

### DIFF
--- a/v2/emailpassword/common-customizations/sessions/change-session-timeout.mdx
+++ b/v2/emailpassword/common-customizations/sessions/change-session-timeout.mdx
@@ -79,3 +79,9 @@ We recommend keeping the `access_token_validity` as small as possible because:
 - If they are stolen, then token theft detection can only occur after the access token expires.
 - If the session is revoked, and the user somehow still has their access token, they will be able to query the APIs until it expires (unless you switch on [access token blacklisting](./revoke-session#access-token-blacklisting)).
 :::
+
+:::caution
+Setting `access_token_validity` to over 400 days may disable session-refreshing in Chrome (and Chromium-based browsers), meaning that it will make sessions expire after 400 days with or without activity.
+
+This is a limitation added by Chrome. For more information, check [here](https://developer.chrome.com/blog/cookie-max-age-expires/#:~:text=As%20of%20Chrome%20release%20M104,400%20days%20in%20the%20future.).
+:::

--- a/v2/passwordless/common-customizations/sessions/change-session-timeout.mdx
+++ b/v2/passwordless/common-customizations/sessions/change-session-timeout.mdx
@@ -79,3 +79,9 @@ We recommend keeping the `access_token_validity` as small as possible because:
 - If they are stolen, then token theft detection can only occur after the access token expires.
 - If the session is revoked, and the user somehow still has their access token, they will be able to query the APIs until it expires (unless you switch on [access token blacklisting](./revoke-session#access-token-blacklisting)).
 :::
+
+:::caution
+Setting `access_token_validity` to over 400 days may disable session-refreshing in Chrome (and Chromium-based browsers), meaning that it will make sessions expire after 400 days with or without activity.
+
+This is a limitation added by Chrome. For more information, check [here](https://developer.chrome.com/blog/cookie-max-age-expires/#:~:text=As%20of%20Chrome%20release%20M104,400%20days%20in%20the%20future.).
+:::

--- a/v2/session/common-customizations/sessions/change-session-timeout.mdx
+++ b/v2/session/common-customizations/sessions/change-session-timeout.mdx
@@ -79,3 +79,9 @@ We recommend keeping the `access_token_validity` as small as possible because:
 - If they are stolen, then token theft detection can only occur after the access token expires.
 - If the session is revoked, and the user somehow still has their access token, they will be able to query the APIs until it expires (unless you switch on [access token blacklisting](./revoke-session#access-token-blacklisting)).
 :::
+
+:::caution
+Setting `access_token_validity` to over 400 days may disable session-refreshing in Chrome (and Chromium-based browsers), meaning that it will make sessions expire after 400 days with or without activity in those browsers.
+
+This is a limitation added by Chrome. For more information, check [here](https://developer.chrome.com/blog/cookie-max-age-expires/#:~:text=As%20of%20Chrome%20release%20M104,400%20days%20in%20the%20future.).
+:::

--- a/v2/thirdparty/common-customizations/sessions/change-session-timeout.mdx
+++ b/v2/thirdparty/common-customizations/sessions/change-session-timeout.mdx
@@ -79,3 +79,9 @@ We recommend keeping the `access_token_validity` as small as possible because:
 - If they are stolen, then token theft detection can only occur after the access token expires.
 - If the session is revoked, and the user somehow still has their access token, they will be able to query the APIs until it expires (unless you switch on [access token blacklisting](./revoke-session#access-token-blacklisting)).
 :::
+
+:::caution
+Setting `access_token_validity` to over 400 days may disable session-refreshing in Chrome (and Chromium-based browsers), meaning that it will make sessions expire after 400 days with or without activity.
+
+This is a limitation added by Chrome. For more information, check [here](https://developer.chrome.com/blog/cookie-max-age-expires/#:~:text=As%20of%20Chrome%20release%20M104,400%20days%20in%20the%20future.).
+:::

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/change-session-timeout.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/change-session-timeout.mdx
@@ -79,3 +79,9 @@ We recommend keeping the `access_token_validity` as small as possible because:
 - If they are stolen, then token theft detection can only occur after the access token expires.
 - If the session is revoked, and the user somehow still has their access token, they will be able to query the APIs until it expires (unless you switch on [access token blacklisting](./revoke-session#access-token-blacklisting)).
 :::
+
+:::caution
+Setting `access_token_validity` to over 400 days may disable session-refreshing in Chrome (and Chromium-based browsers), meaning that it will make sessions expire after 400 days with or without activity.
+
+This is a limitation added by Chrome. For more information, check [here](https://developer.chrome.com/blog/cookie-max-age-expires/#:~:text=As%20of%20Chrome%20release%20M104,400%20days%20in%20the%20future.).
+:::

--- a/v2/thirdpartypasswordless/common-customizations/sessions/change-session-timeout.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/change-session-timeout.mdx
@@ -79,3 +79,9 @@ We recommend keeping the `access_token_validity` as small as possible because:
 - If they are stolen, then token theft detection can only occur after the access token expires.
 - If the session is revoked, and the user somehow still has their access token, they will be able to query the APIs until it expires (unless you switch on [access token blacklisting](./revoke-session#access-token-blacklisting)).
 :::
+
+:::caution
+Setting `access_token_validity` to over 400 days may disable session-refreshing in Chrome (and Chromium-based browsers), meaning that it will make sessions expire after 400 days with or without activity.
+
+This is a limitation added by Chrome. For more information, check [here](https://developer.chrome.com/blog/cookie-max-age-expires/#:~:text=As%20of%20Chrome%20release%20M104,400%20days%20in%20the%20future.).
+:::


### PR DESCRIPTION
## Summary of change
add caution about setting access token expiry over 400 days to 

## Related issues
- https://github.com/supertokens/supertokens-node/issues/492

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
