### PR TITLE
chore: Add mobile tab for frontend pre built ui quick setup

### DIFF
--- a/v2/emailpassword/pre-built-ui/setup/frontend.mdx
+++ b/v2/emailpassword/pre-built-ui/setup/frontend.mdx
@@ -38,7 +38,7 @@ Or, you can manually integrate SuperTokens by following the steps below.
 
 ## 1) Install
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 
 <TabItem value="reactjs">
 
@@ -177,13 +177,21 @@ yarn add supertokens-auth-react supertokens-web-js
 
 </TabItem>
 
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
+
+</TabItem>
+
 </FrontendPreBuiltUITabs>
 
 <!-- END COPY SECTION -->
 
 ## 2) Call the `init` function
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 <TabItem value="reactjs">
 
 <AppInfoForm
@@ -469,6 +477,14 @@ Before we initialize the `supertokens-auth-react` SDK let's see how we will use 
 
 </TabItem>
 
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
+
+</TabItem>
+
 </FrontendPreBuiltUITabs>
 
 <!-- COPY SECTION -->
@@ -477,7 +493,7 @@ Before we initialize the `supertokens-auth-react` SDK let's see how we will use 
 
 ## 3) Setup Routing to show the login UI
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 <TabItem value="reactjs">
 <AppInfoForm askForWebsiteBasePath>
 <Question
@@ -663,6 +679,14 @@ export default router;
 ```
 
 </AppInfoForm>
+
+</TabItem>
+
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
 
 </TabItem>
 

--- a/v2/passwordless/pre-built-ui/setup/frontend.mdx
+++ b/v2/passwordless/pre-built-ui/setup/frontend.mdx
@@ -39,7 +39,7 @@ Or, you can manually integrate SuperTokens by following the steps below.
 
 ## 1) Install
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 
 <TabItem value="reactjs">
 
@@ -178,13 +178,21 @@ yarn add supertokens-auth-react supertokens-web-js
 
 </TabItem>
 
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
+
+</TabItem>
+
 </FrontendPreBuiltUITabs>
 
 <!-- END COPY SECTION -->
 
 ## 2) Call the `init` function
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 <TabItem value="reactjs">
 
 <AppInfoForm
@@ -482,6 +490,14 @@ Before we initialize the `supertokens-auth-react` SDK let's see how we will use 
 
 </TabItem>
 
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
+
+</TabItem>
+
 </FrontendPreBuiltUITabs>
 
 <!-- COPY SECTION -->
@@ -490,7 +506,7 @@ Before we initialize the `supertokens-auth-react` SDK let's see how we will use 
 
 ## 3) Setup Routing to show the login UI
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 <TabItem value="reactjs">
 <AppInfoForm askForWebsiteBasePath>
 <Question
@@ -676,6 +692,14 @@ export default router;
 ```
 
 </AppInfoForm>
+
+</TabItem>
+
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
 
 </TabItem>
 

--- a/v2/src/components/tabs/FrontendPreBuiltUITabs.tsx
+++ b/v2/src/components/tabs/FrontendPreBuiltUITabs.tsx
@@ -10,15 +10,24 @@ import { Answer } from "../question"
 const copyTabIdentifier = "~COPY-TABS=";
 
 export default function FrontendPreBuiltUITabs(props: any) {
+  let values = [
+    { label: "ReactJS", value: "reactjs" },
+    { label: "Angular", value: "angular" },
+    { label: "Vue", value: "vue" }
+  ];
+
+  if (props.showMobileTab !== undefined) {
+    values.push({ 
+      label: "Mobile", 
+      value: "mobile", 
+    });
+  }
+
   // this is done twice since vue has a copy tabs pointing at angular and angular also has copy tabs
   return applyCopyTabs(applyCopyTabs(<Tabs
     groupId="frontendsdk"
     defaultValue="reactjs"
-    values={[
-      { label: "ReactJS", value: "reactjs" },
-      { label: "Angular", value: "angular" },
-      { label: "Vue", value: "vue" }
-    ]}
+    values={values}
   >
     {childContainsTabItemWithValue("reactjs", props.children)
       ? null

--- a/v2/thirdparty/pre-built-ui/setup/frontend.mdx
+++ b/v2/thirdparty/pre-built-ui/setup/frontend.mdx
@@ -37,7 +37,7 @@ Or, you can manually integrate SuperTokens by following the steps below.
 
 ## 1) Install
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 
 <TabItem value="reactjs">
 
@@ -176,13 +176,21 @@ yarn add supertokens-auth-react supertokens-web-js
 
 </TabItem>
 
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
+
+</TabItem>
+
 </FrontendPreBuiltUITabs>
 
 <!-- END COPY SECTION -->
 
 ## 2) Call the `init` function
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 <TabItem value="reactjs">
 
 <AppInfoForm
@@ -560,6 +568,14 @@ Before we initialize the `supertokens-auth-react` SDK let's see how we will use 
 
 </TabItem>
 
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
+
+</TabItem>
+
 </FrontendPreBuiltUITabs>
 
 
@@ -569,7 +585,7 @@ Before we initialize the `supertokens-auth-react` SDK let's see how we will use 
 
 ## 3) Setup Routing to show the login UI
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 <TabItem value="reactjs">
 <AppInfoForm askForWebsiteBasePath>
 <Question
@@ -755,6 +771,14 @@ export default router;
 ```
 
 </AppInfoForm>
+
+</TabItem>
+
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
 
 </TabItem>
 

--- a/v2/thirdpartyemailpassword/pre-built-ui/setup/frontend.mdx
+++ b/v2/thirdpartyemailpassword/pre-built-ui/setup/frontend.mdx
@@ -37,7 +37,7 @@ Or, you can manually integrate SuperTokens by following the steps below.
 
 ## 1) Install
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 
 <TabItem value="reactjs">
 
@@ -176,13 +176,21 @@ yarn add supertokens-auth-react supertokens-web-js
 
 </TabItem>
 
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
+
+</TabItem>
+
 </FrontendPreBuiltUITabs>
 
 <!-- END COPY SECTION -->
 
 ## 2) Call the `init` function
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 <TabItem value="reactjs">
 
 <AppInfoForm
@@ -496,6 +504,14 @@ Before we initialize the `supertokens-auth-react` SDK let's see how we will use 
 
 </TabItem>
 
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
+
+</TabItem>
+
 </FrontendPreBuiltUITabs>
 
 
@@ -505,7 +521,7 @@ Before we initialize the `supertokens-auth-react` SDK let's see how we will use 
 
 ## 3) Setup Routing to show the login UI
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 <TabItem value="reactjs">
 <AppInfoForm askForWebsiteBasePath>
 <Question
@@ -691,6 +707,14 @@ export default router;
 ```
 
 </AppInfoForm>
+
+</TabItem>
+
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
 
 </TabItem>
 

--- a/v2/thirdpartypasswordless/pre-built-ui/setup/frontend.mdx
+++ b/v2/thirdpartypasswordless/pre-built-ui/setup/frontend.mdx
@@ -40,7 +40,7 @@ Or, you can manually integrate SuperTokens by following the steps below.
 
 ## 1) Install
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 
 <TabItem value="reactjs">
 
@@ -179,13 +179,21 @@ yarn add supertokens-auth-react supertokens-web-js
 
 </TabItem>
 
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
+
+</TabItem>
+
 </FrontendPreBuiltUITabs>
 
 <!-- END COPY SECTION -->
 
 ## 2) Call the `init` function
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 <TabItem value="reactjs">
 
 <AppInfoForm
@@ -576,6 +584,14 @@ Before we initialize the `supertokens-auth-react` SDK let's see how we will use 
 
 </TabItem>
 
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
+
+</TabItem>
+
 </FrontendPreBuiltUITabs>
 
 <!-- COPY SECTION -->
@@ -584,7 +600,7 @@ Before we initialize the `supertokens-auth-react` SDK let's see how we will use 
 
 ## 3) Setup Routing to show the login UI
 
-<FrontendPreBuiltUITabs>
+<FrontendPreBuiltUITabs showMobileTab>
 <TabItem value="reactjs">
 <AppInfoForm askForWebsiteBasePath>
 <Question
@@ -770,6 +786,14 @@ export default router;
 ```
 
 </AppInfoForm>
+
+</TabItem>
+
+<TabItem value="mobile">
+
+:::important
+SuperTokens does not support pre-built UI for mobile frameworks. Please refer to the [setup guide for custom UI](../../custom-ui/init/frontend) to integrate SuperTokens in your app.
+:::
 
 </TabItem>
 


### PR DESCRIPTION
## Summary of change

- The new tab explains that we dont provide pre built UI for mobile and links to custom UI quick setup

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] ...