### PR TITLE
chore: Add handling session tokens docs to session recipe

### DIFF
--- a/v2/session/quick-setup/handling-session-tokens.mdx
+++ b/v2/session/quick-setup/handling-session-tokens.mdx
@@ -1,0 +1,447 @@
+---
+id: handling-session-tokens
+title: Handling session tokens
+hide_title: true
+---
+
+<!-- COPY DOCS -->
+<!-- ./thirdpartyemailpassword/custom-ui/handling-session-tokens.mdx -->
+
+import NpmOrScriptTabs from "/src/components/tabs/NpmOrScriptTabs"
+import FrontendPreBuiltUITabs from "/src/components/tabs/FrontendPreBuiltUITabs"
+import FrontendCustomUITabs from "/src/components/tabs/FrontendCustomUITabs"
+import FrontendMobileSubTabs from "/src/components/tabs/FrontendMobileSubTabs"
+import AppInfoForm from "/src/components/appInfoForm"
+import {Question, Answer}from "/src/components/question"
+
+# Handling session tokens
+
+## If using our frontend SDK
+
+### For Web
+
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/pre-built-ui/handling-session-tokens.mdx -->
+<!-- 1 -->
+
+:::success
+No action required.
+:::
+
+Our frontend SDK handles everything for you. You only need to make sure that you have called `supertokens.init` before making any network requests.
+
+Our SDK adds interceptors to `fetch` and `XHR` (used by `axios`) to save and add session tokens from and to the request.
+
+:::note
+By default, our web SDKs use cookies to provide credentials.
+:::
+
+<!-- END COPY SECTION -->
+
+import NetworkInterceptors from "/session/reusableMD/networkInterceptors.mdx"
+
+### For React-Native
+Our frontend SDK handles everything for you. You only need to make sure that you have added our network interceptors as shown below
+
+<NetworkInterceptors />
+
+:::note
+By default our mobile SDKs use a bearer token in the Authorization header to provide credentials.
+:::
+
+### For Android
+
+<Question
+    question="Which library are you using for networking?">
+<Answer title="HttpURLConnection">
+
+```kotlin
+import android.app.Application
+import com.supertokens.session.SuperTokens
+import com.supertokens.session.SuperTokensHttpURLConnection
+import com.supertokens.session.SuperTokensPersistentCookieStore
+import java.net.URL
+import java.net.HttpURLConnection
+
+class MainApplication: Application() {
+    override fun onCreate() {
+        super.onCreate()
+        // TODO: Make sure to call SuperTokens.init
+    }
+    
+    fun makeRequest() {
+        val url = URL("<API_URL>")
+        val connection = SuperTokensHttpURLConnection.newRequest(url, object: SuperTokensHttpURLConnection.PreConnectCallback {
+            override fun doAction(con: HttpURLConnection?) {
+                // TODO: Use `con` to set request method, headers etc
+            }
+        })
+        
+        // Handle response using connection object, for example:
+        if (connection.responseCode == 200) {
+            // TODO: implement 
+        }
+    }
+}
+```
+
+:::note
+When making network requests you do not need to call `HttpURLConnection.connect` because SuperTokens does this for you.
+:::
+
+</Answer>
+<Answer title="Okhttp / Retrofit">
+
+```kotlin
+import android.content.Context
+import com.supertokens.session.SuperTokens
+import com.supertokens.session.SuperTokensInterceptor
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+
+class NetworkManager {
+    fun getClient(context: Context): OkHttpClient {
+        val clientBuilder = OkHttpClient.Builder()
+        clientBuilder.addInterceptor(SuperTokensInterceptor())
+        // TODO: Make sure to call SuperTokens.init
+
+        val client = clientBuilder.build()
+
+        // REQUIRED FOR RETROFIT ONLY
+        val instance = Retrofit.Builder()
+            .baseUrl("<YOUR_BASE_URL>")
+            .client(client)
+            .build()
+
+        return client
+    }
+
+    fun makeRequest(context: Context) {
+        val client = getClient(context)
+        // Use client to make requests normally
+    }
+}
+```
+
+</Answer>
+</Question>
+
+:::note
+By default our mobile SDKs use a bearer token in the Authorization header to provide credentials.
+:::
+
+### For iOS
+
+<Question question="Which library are you using for networking?">
+
+<Answer title="URLSession">
+
+<h4>Using <code>URLSession.shared</code></h4>
+
+```swift
+import Foundation
+import SuperTokensIOS
+
+fileprivate class NetworkManager {
+    func setupSuperTokensInterceptor() {
+        URLProtocol.registerClass(SuperTokensURLProtocol.self)
+    }
+}
+```
+
+<h4>Using a custom <code>URLSession</code> instance</h4>
+
+```swift
+import Foundation
+import SuperTokensIOS
+
+fileprivate class NetworkManager {
+    func setupSuperTokensInterceptor() {
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [SuperTokensURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+
+        // Use session when making network requests
+    }
+}
+```
+
+</Answer>
+
+<Answer title="Alamofire">
+
+```swift
+import Foundation
+import SuperTokensIOS
+import Alamofire
+
+fileprivate class NetworkManager {
+    func setupSuperTokensInterceptor() {
+        let configuration = URLSessionConfiguration.af.default
+        configuration.protocolClasses = [SuperTokensURLProtocol.self] + (configuration.protocolClasses ?? [])
+        let session = Session(configuration: configuration)
+
+        // Use session when making network requests
+    }
+}
+```
+
+</Answer>
+
+</Question>
+
+:::note
+By default our mobile SDKs use a bearer token in the Authorization header to provide credentials.
+:::
+
+### Getting the access token
+
+:::caution
+Our SDK automatically handles adding the access token to request headers. You only need to add the access token to the request if you want to send the access token to a different API domain than what is configured on the frontend SDK init function call.
+:::
+
+If you are using a header-based session, you can read the access token on the frontend using the `getAccessToken` method:
+
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/custom-ui/handling-session-tokens.mdx -->
+<!-- 2 -->
+
+<FrontendCustomUITabs>
+<TabItem value="web">
+
+<NpmOrScriptTabs>
+<TabItem value="npm">
+
+```tsx
+import Session from "supertokens-web-js/recipe/session";
+
+async function getToken(): Promise<void> {
+    // highlight-next-line
+    const accessToken = await Session.getAccessToken();
+    console.log(accessToken);
+}
+```
+
+</TabItem>
+<TabItem value="script">
+
+```tsx
+import supertokensSession from "supertokens-web-js-script/recipe/session";
+import supertokensEmailVerification from "supertokens-web-js-script/recipe/emailverification";
+async function getToken(): Promise<void> {
+    // highlight-next-line
+    const accessToken = await supertokensSession.getAccessToken();
+    console.log(accessToken);
+}
+```
+
+</TabItem>
+</NpmOrScriptTabs>
+</TabItem>
+
+<TabItem value="mobile">
+
+<FrontendMobileSubTabs>
+<TabItem value="reactnative">
+
+```tsx
+import SuperTokens from 'supertokens-react-native';
+
+async function getToken(): Promise<void> {
+    // highlight-next-line
+    const accessToken = await SuperTokens.getAccessToken();
+    console.log(accessToken);
+}
+```
+
+</TabItem>
+
+<TabItem value="android">
+
+```kotlin
+import android.app.Application
+import com.supertokens.session.SuperTokens
+
+class MainApplication: Application() {
+    fun getToken(): String {
+        return SuperTokens.getAccessToken(applicationContext)
+    }
+}
+```
+
+</TabItem>
+
+<TabItem value="ios">
+
+```swift
+import UIKit
+import SuperTokensIOS
+
+fileprivate class ViewController: UIViewController {
+    func getToken() -> String? {
+        return SuperTokens.getAccessToken()
+    }
+}
+```
+
+</TabItem>
+</FrontendMobileSubTabs>
+
+</TabItem>
+</FrontendCustomUITabs>
+
+<!-- END COPY SECTION -->
+
+## If not using our frontend SDK 
+
+:::caution
+We highly recommend using our frontend SDK to handle session token management. It will save you a lot of time.
+:::
+
+In this case, you will need to manually handle the tokens and session refreshing, and decide if you are going to use header or cookie-based sessions.
+
+For browsers, we recommend cookies, while for mobile apps (or if you don't want to use the built-in cookie manager) you should use header-based sessions.
+
+<Question question="Which request authentication mode are you using?">
+    
+<Answer title="Cookie">
+
+### On login
+
+You should attach the `st-auth-mode` header to calls to the login API, but this header is safe to attach to all requests. In this case it should be set to "cookie".
+
+The login API will return the following headers:
+- `Set-Cookie`: This will contain the `sAccessToken`, `sRefreshToken` cookies which will be `httpOnly` and will be automatically mananaged by the browser. For mobile apps, you will need to setup cookie handling yourself, use our SDK or use a header based authentication mode.
+- `front-token` header: This contains information about the access token:
+    - The userID
+    - The expiry time of the access token
+    - The payload added by you in the access token.
+    
+    Here is the structure of the token:
+    ```tsx
+    let frontTokenFromRequestHeader = "...";
+    let frontTokenDecoded = JSON.parse(decodeURIComponent(escape(atob(frontTokenFromRequestHeader))));
+    console.log(frontTokenDecoded);
+    /*
+    {
+        ate: 1665226412455, // time in milliseconds for when the access token will expire, and then a refresh is required
+        uid: "....", // user ID
+        up: {
+            ...
+        } // custom payload added to the access token by you on the backend
+    }
+    
+    */
+    ```
+
+    This is required because you don't have access to the actual access token on the frontend (for security reasons), but may want to read its payload (for example to know the user's role). This token itself is not signed and hence can't be used in place of the access token itself.
+
+
+    You may want to save this token in localstorage or in frontend cookies (using `document.cookies`).
+- `anti-csrf` header (optional): By default it's not required, so it's not sent. But if this is sent, you should save this token as well for use when making requests.
+
+### Making network requests to protected APIs
+
+The `sAccessToken` will get attached to the request automatically by the browser. Other than that, you need to add the following headers to the request:
+- `rid: "anti-csrf"` - this prevents against anti-CSRF requests. If your `apiDomain` and `websiteDomain` values are exactly the same, then this is not necessary.
+- `anti-csrf` header (optional): If this was provided to you during login, then you need to add that token as the value of this header.
+- You need to set the `credentials` header to `true` or `include`. This is achieved different based on the library you are using to make requests.
+
+An API call can potentially update the `sAccessToken` and `front-token` tokens, for example if you call the `mergeIntoAccessTokenPayload` function on the `session` object on the backend. This kind of update is reflected in the response headers for your API calls. The headers will contain new values for:
+- `sAccessToken`: This will be as a new `Set-Cookie` header and will be managed by the browser automatically.
+- `front-token`: This should be read and saved by you in the same way as it's being done during login.
+
+### Handling session refreshing
+If any of your API calls return with a status code of `401`, it means that the access token has expired. This will require you to refresh the session before retrying the same API call.
+
+You can call the refresh API as follows:
+
+<AppInfoForm askForAPIDomain>
+
+```bash
+curl --location --request POST '^{form_apiDomain}^{form_apiBasePath}/session/refresh' \
+--header 'rid: session' \
+--header 'Cookie: sRefreshToken=...'
+```
+
+:::note
+You may also need to add the `anti-csrf` header to the request if that was provided to you during sign in.
+:::
+
+</AppInfoForm>
+
+The result of a session refresh will be either:
+- Status code `200`: This implies a succesful refresh. The set of tokens returned here will be the same as when the user logs in, so you can handle them in the same way.
+- Status code `401`: This means that the refresh token is invalid, or has been revoked. You must ask the user to relogin. Remember to clear the `front-token` that you saved on the frontend earlier.
+
+</Answer>
+
+<Answer title="Header (Authorization Bearer)">
+
+### On login
+
+You should attach the `st-auth-mode` header to calls to the login API, but this header is safe to attach to all requests. In this case it should be set to "header".
+
+The login API will return the following headers:
+- `st-access-token`: This contains the current access token associated with the session. You should save this in your application (e.g., in frontend localstorage).
+- `st-refresh-token`: This contains the current refresh token associated with the session. You should save this in your application (e.g., in frontend localstorage).
+- `front-token` header: This contains information about the access token:
+    - The userID
+    - The expiry time of the access token
+    - The payload added by you in the access token.
+    
+    Here is the structure of the token:
+    ```tsx
+    let frontTokenFromRequestHeader = "...";
+    let frontTokenDecoded = JSON.parse(decodeURIComponent(escape(atob(frontTokenFromRequestHeader))));
+    console.log(frontTokenDecoded);
+    /*
+    {
+        ate: 1665226412455, // time in milliseconds for when the access token will expire, and then a refresh is required
+        uid: "....", // user ID
+        up: {
+            ...
+        } // custom payload added to the access token by you on the backend
+    }
+    
+    */
+    ```
+
+    This is added because while you have access to the access token, you may want to read its payload without decoding it (for example to know the user's role). This token itself is not signed and hence can't be used in place of the access token itself.
+
+    You may want to save this token in localstorage or in frontend cookies (using `document.cookies`).
+
+### Making network requests to protected APIs
+
+You need to add the following headers to request:
+- `authorization: Bearer {access-token}`
+- You need to set the `credentials` to `true` or `include`. This is achieved different based on the library you are using to make requests.
+
+An API call can potentially update the `access-token` and `front-token` tokens, for example if you call the `mergeIntoAccessTokenPayload` function on the `session` object on the backend. This kind of update is reflected in the response headers for your API calls. The headers will contain new values for:
+- `st-access-token`
+- `front-token`
+
+These should be read and saved by you in the same way as it's being done during login.
+
+### Handling session refreshing
+If any of your API calls return with a status code of `401`, it means that the access token has expired. This will require you to refresh the session before retrying the same API call.
+
+You can call the refresh API as follows:
+
+<AppInfoForm askForAPIDomain>
+
+```bash
+curl --location --request POST '^{form_apiDomain}^{form_apiBasePath}/session/refresh' \
+--header 'rid: session' \
+--header 'authorization: Bearer {refresh-token}'
+```
+
+</AppInfoForm>
+
+The result of a session refresh will be either:
+- Status code `200`: This implies a succesful refresh. The set of tokens returned here will be the same as when the user logs in, so you can handle them in the same way.
+- Status code `401`: This means that the refresh token is invalid, or has been revoked. You must ask the user to relogin. Remember to clear the `front-token`, `st-refresh-token`, `st-access-token` that you saved on the frontend earlier.
+
+</Answer>
+
+</Question>

--- a/v2/session/sidebars.js
+++ b/v2/session/sidebars.js
@@ -39,6 +39,7 @@ module.exports = {
                 "quick-setup/core/saas-setup"
               ],
             },
+            "quick-setup/handling-session-tokens",
           ],
         },
       ],


### PR DESCRIPTION
## Summary of change
- Adds handling session tokens to session recipe to match the structure of other recipes and to explain the need for interceptors in react native

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2