### PR TITLE
chore: Flutter header based auth docs

### DIFF
--- a/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -366,7 +366,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        cookieDomain: ".example.com",
+        sessionTokenBackendDomain: ".example.com",
     );
 }
 ```

--- a/v2/emailpassword/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/emailpassword/common-customizations/sessions/token-transfer-method.mdx
@@ -342,6 +342,21 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 </TabItem>
 
+<TabItem value="flutter">
+
+```dart
+import 'package:supertokens_flutter/supertokens.dart';
+
+void main() {
+    SuperTokens.init(
+        apiDomain: "...",
+        tokenTransferMethod: SuperTokensTokenTransferMethod.COOKIE,
+    );
+}
+```
+
+</TabItem>
+
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/emailpassword/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/emailpassword/common-customizations/sessions/token-transfer-method.mdx
@@ -346,7 +346,6 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 ```dart
 import 'package:supertokens_flutter/supertokens.dart';
-import 'package:supertokens_flutter/src/utilities.dart' show SuperTokensTokenTransferMethod;
 
 void main() {
     SuperTokens.init(

--- a/v2/emailpassword/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/emailpassword/common-customizations/sessions/token-transfer-method.mdx
@@ -346,6 +346,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 ```dart
 import 'package:supertokens_flutter/supertokens.dart';
+import 'package:supertokens_flutter/src/utilities.dart' show SuperTokensTokenTransferMethod;
 
 void main() {
     SuperTokens.init(

--- a/v2/emailpassword/custom-ui/handling-session-tokens.mdx
+++ b/v2/emailpassword/custom-ui/handling-session-tokens.mdx
@@ -285,6 +285,18 @@ fileprivate class ViewController: UIViewController {
 ```
 
 </TabItem>
+
+<TabItem value="flutter">
+
+```dart
+import 'package:supertokens_flutter/supertokens.dart';
+
+Future<String?> getToken() async {
+    return await SuperTokens.getAccessToken();
+}
+```
+
+</TabItem>
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -366,7 +366,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        cookieDomain: ".example.com",
+        sessionTokenBackendDomain: ".example.com",
     );
 }
 ```

--- a/v2/passwordless/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/passwordless/common-customizations/sessions/token-transfer-method.mdx
@@ -342,6 +342,21 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 </TabItem>
 
+<TabItem value="flutter">
+
+```dart
+import 'package:supertokens_flutter/supertokens.dart';
+
+void main() {
+    SuperTokens.init(
+        apiDomain: "...",
+        tokenTransferMethod: SuperTokensTokenTransferMethod.COOKIE,
+    );
+}
+```
+
+</TabItem>
+
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/passwordless/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/passwordless/common-customizations/sessions/token-transfer-method.mdx
@@ -346,7 +346,6 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 ```dart
 import 'package:supertokens_flutter/supertokens.dart';
-import 'package:supertokens_flutter/src/utilities.dart' show SuperTokensTokenTransferMethod;
 
 void main() {
     SuperTokens.init(

--- a/v2/passwordless/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/passwordless/common-customizations/sessions/token-transfer-method.mdx
@@ -346,6 +346,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 ```dart
 import 'package:supertokens_flutter/supertokens.dart';
+import 'package:supertokens_flutter/src/utilities.dart' show SuperTokensTokenTransferMethod;
 
 void main() {
     SuperTokens.init(

--- a/v2/passwordless/custom-ui/handling-session-tokens.mdx
+++ b/v2/passwordless/custom-ui/handling-session-tokens.mdx
@@ -285,6 +285,18 @@ fileprivate class ViewController: UIViewController {
 ```
 
 </TabItem>
+
+<TabItem value="flutter">
+
+```dart
+import 'package:supertokens_flutter/supertokens.dart';
+
+Future<String?> getToken() async {
+    return await SuperTokens.getAccessToken();
+}
+```
+
+</TabItem>
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -366,7 +366,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        cookieDomain: ".example.com",
+        sessionTokenBackendDomain: ".example.com",
     );
 }
 ```

--- a/v2/session/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/session/common-customizations/sessions/token-transfer-method.mdx
@@ -342,6 +342,21 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 </TabItem>
 
+<TabItem value="flutter">
+
+```dart
+import 'package:supertokens_flutter/supertokens.dart';
+
+void main() {
+    SuperTokens.init(
+        apiDomain: "...",
+        tokenTransferMethod: SuperTokensTokenTransferMethod.COOKIE,
+    );
+}
+```
+
+</TabItem>
+
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/session/quick-setup/handling-session-tokens.mdx
+++ b/v2/session/quick-setup/handling-session-tokens.mdx
@@ -285,6 +285,18 @@ fileprivate class ViewController: UIViewController {
 ```
 
 </TabItem>
+
+<TabItem value="flutter">
+
+```dart
+import 'package:supertokens_flutter/supertokens.dart';
+
+Future<String?> getToken() async {
+    return await SuperTokens.getAccessToken();
+}
+```
+
+</TabItem>
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/src/plugins/codeTypeChecking/dart_env/pubspec.lock
+++ b/v2/src/plugins/codeTypeChecking/dart_env/pubspec.lock
@@ -321,10 +321,10 @@ packages:
     dependency: "direct main"
     description:
       name: supertokens_flutter
-      sha256: ac19b2d99d711063874987a7079774471d4b129e0f80936783ac69dd093ee24c
+      sha256: "527599059e983f2c8bfef1907bb6716f3a9d646acc3221ae3f1008c46ce8e7da"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   term_glyph:
     dependency: transitive
     description:

--- a/v2/src/plugins/codeTypeChecking/dart_env/pubspec.lock
+++ b/v2/src/plugins/codeTypeChecking/dart_env/pubspec.lock
@@ -321,10 +321,10 @@ packages:
     dependency: "direct main"
     description:
       name: supertokens_flutter
-      sha256: cfaa8ae186f672ec3c4d61fed507a73cbd1d5c47e01ec3f798885d369fc98908
+      sha256: ac19b2d99d711063874987a7079774471d4b129e0f80936783ac69dd093ee24c
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.2.1"
   term_glyph:
     dependency: transitive
     description:

--- a/v2/src/plugins/codeTypeChecking/dart_env/pubspec.yaml
+++ b/v2/src/plugins/codeTypeChecking/dart_env/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  supertokens_flutter: ^0.2.1
+  supertokens_flutter: ^0.2.2
 
 dev_dependencies:
   flutter_test:

--- a/v2/src/plugins/codeTypeChecking/dart_env/pubspec.yaml
+++ b/v2/src/plugins/codeTypeChecking/dart_env/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  supertokens_flutter: ^0.1.1
+  supertokens_flutter: ^0.2.1
 
 dev_dependencies:
   flutter_test:

--- a/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -366,7 +366,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        cookieDomain: ".example.com",
+        sessionTokenBackendDomain: ".example.com",
     );
 }
 ```

--- a/v2/thirdparty/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/thirdparty/common-customizations/sessions/token-transfer-method.mdx
@@ -342,6 +342,21 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 </TabItem>
 
+<TabItem value="flutter">
+
+```dart
+import 'package:supertokens_flutter/supertokens.dart';
+
+void main() {
+    SuperTokens.init(
+        apiDomain: "...",
+        tokenTransferMethod: SuperTokensTokenTransferMethod.COOKIE,
+    );
+}
+```
+
+</TabItem>
+
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/thirdparty/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/thirdparty/common-customizations/sessions/token-transfer-method.mdx
@@ -346,7 +346,6 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 ```dart
 import 'package:supertokens_flutter/supertokens.dart';
-import 'package:supertokens_flutter/src/utilities.dart' show SuperTokensTokenTransferMethod;
 
 void main() {
     SuperTokens.init(

--- a/v2/thirdparty/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/thirdparty/common-customizations/sessions/token-transfer-method.mdx
@@ -346,6 +346,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 ```dart
 import 'package:supertokens_flutter/supertokens.dart';
+import 'package:supertokens_flutter/src/utilities.dart' show SuperTokensTokenTransferMethod;
 
 void main() {
     SuperTokens.init(

--- a/v2/thirdparty/custom-ui/handling-session-tokens.mdx
+++ b/v2/thirdparty/custom-ui/handling-session-tokens.mdx
@@ -285,6 +285,18 @@ fileprivate class ViewController: UIViewController {
 ```
 
 </TabItem>
+
+<TabItem value="flutter">
+
+```dart
+import 'package:supertokens_flutter/supertokens.dart';
+
+Future<String?> getToken() async {
+    return await SuperTokens.getAccessToken();
+}
+```
+
+</TabItem>
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -366,7 +366,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        cookieDomain: ".example.com",
+        sessionTokenBackendDomain: ".example.com",
     );
 }
 ```

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/token-transfer-method.mdx
@@ -342,6 +342,21 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 </TabItem>
 
+<TabItem value="flutter">
+
+```dart
+import 'package:supertokens_flutter/supertokens.dart';
+
+void main() {
+    SuperTokens.init(
+        apiDomain: "...",
+        tokenTransferMethod: SuperTokensTokenTransferMethod.COOKIE,
+    );
+}
+```
+
+</TabItem>
+
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/token-transfer-method.mdx
@@ -346,7 +346,6 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 ```dart
 import 'package:supertokens_flutter/supertokens.dart';
-import 'package:supertokens_flutter/src/utilities.dart' show SuperTokensTokenTransferMethod;
 
 void main() {
     SuperTokens.init(

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/token-transfer-method.mdx
@@ -346,6 +346,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 ```dart
 import 'package:supertokens_flutter/supertokens.dart';
+import 'package:supertokens_flutter/src/utilities.dart' show SuperTokensTokenTransferMethod;
 
 void main() {
     SuperTokens.init(

--- a/v2/thirdpartyemailpassword/custom-ui/handling-session-tokens.mdx
+++ b/v2/thirdpartyemailpassword/custom-ui/handling-session-tokens.mdx
@@ -285,6 +285,18 @@ fileprivate class ViewController: UIViewController {
 ```
 
 </TabItem>
+
+<TabItem value="flutter">
+
+```dart
+import 'package:supertokens_flutter/supertokens.dart';
+
+Future<String?> getToken() async {
+    return await SuperTokens.getAccessToken();
+}
+```
+
+</TabItem>
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -366,7 +366,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        cookieDomain: ".example.com",
+        sessionTokenBackendDomain: ".example.com",
     );
 }
 ```

--- a/v2/thirdpartypasswordless/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/token-transfer-method.mdx
@@ -342,6 +342,21 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 </TabItem>
 
+<TabItem value="flutter">
+
+```dart
+import 'package:supertokens_flutter/supertokens.dart';
+
+void main() {
+    SuperTokens.init(
+        apiDomain: "...",
+        tokenTransferMethod: SuperTokensTokenTransferMethod.COOKIE,
+    );
+}
+```
+
+</TabItem>
+
 </FrontendMobileSubTabs>
 
 </TabItem>

--- a/v2/thirdpartypasswordless/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/token-transfer-method.mdx
@@ -346,7 +346,6 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 ```dart
 import 'package:supertokens_flutter/supertokens.dart';
-import 'package:supertokens_flutter/src/utilities.dart' show SuperTokensTokenTransferMethod;
 
 void main() {
     SuperTokens.init(

--- a/v2/thirdpartypasswordless/common-customizations/sessions/token-transfer-method.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/token-transfer-method.mdx
@@ -346,6 +346,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
 
 ```dart
 import 'package:supertokens_flutter/supertokens.dart';
+import 'package:supertokens_flutter/src/utilities.dart' show SuperTokensTokenTransferMethod;
 
 void main() {
     SuperTokens.init(

--- a/v2/thirdpartypasswordless/custom-ui/handling-session-tokens.mdx
+++ b/v2/thirdpartypasswordless/custom-ui/handling-session-tokens.mdx
@@ -285,6 +285,18 @@ fileprivate class ViewController: UIViewController {
 ```
 
 </TabItem>
+
+<TabItem value="flutter">
+
+```dart
+import 'package:supertokens_flutter/supertokens.dart';
+
+Future<String?> getToken() async {
+    return await SuperTokens.getAccessToken();
+}
+```
+
+</TabItem>
 </FrontendMobileSubTabs>
 
 </TabItem>


### PR DESCRIPTION
## Summary of change

- Adds docs for token transfer method for flutter
- Updated flutter docs to rename `cookieDomain` to `sessionTokenBackendDomain`
- Updates supertokens_flutter dependency in dart_env to 0.2.2

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] ...