### PR TITLE
fix: Fix guides page github link in the header

### DIFF
--- a/v2/src/theme/NavbarItem/index.js
+++ b/v2/src/theme/NavbarItem/index.js
@@ -87,7 +87,8 @@ export default function NavbarItem({ type, ...props }) {
     if (DO_NOT_SHOW_GITHUB_BUTTON.filter(i => i === currDocs).length > 0) {
       return null;
     }
-    let toReplace = currDocs === "community" ? "core" : currDocs;
+    const shouldUseCore = currDocs === "core" || currDocs === "guides";
+    let toReplace = shouldUseCore ? "core" : currDocs;
 
     if (toReplace === "nodejs") {
       toReplace = "node";


### PR DESCRIPTION
## Summary of change
- Fixes the url for the github navbar link on the guides page

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] ...