### PR TITLE
fix: components override guide

### DIFF
--- a/v2/emailpassword/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/emailpassword/advanced-customizations/react-component-override/usage.mdx
@@ -6,6 +6,8 @@ hide_title: true
 
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
+import {Answer} from "/src/components/question"
+import {Question}from "/src/components/question"
 
 # How to use
 
@@ -17,6 +19,10 @@ import TabItem from '@theme/TabItem';
 ## Example
 <FrontendSDKTabs>
 <TabItem value="reactjs">
+
+<Question
+    question="Do you use react-router-dom?">
+<Answer title="Yes">
 
 ```tsx
 import React from "react";
@@ -48,12 +54,59 @@ function App() {
 export default App;
 
 ```
+</Answer>
+
+<Answer title="No">
+
+```tsx
+import React from "react";
+import { SuperTokensWrapper } from "supertokens-auth-react";
+import { getRoutingComponent, canHandleRoute } from "supertokens-auth-react/ui"
+import { EmailPasswordPreBuiltUI } from "supertokens-auth-react/recipe/emailpassword/prebuiltui"
+import { EmailPasswordComponentsOverrideProvider } from "supertokens-auth-react/recipe/emailpassword";
+
+function App() {
+    if(canHandleRoute([EmailPasswordPreBuiltUI])){
+        return (
+            <EmailPasswordComponentsOverrideProvider
+                components={{
+                    // In this case, the <EmailPasswordSignIn_Override> 
+                    // will render the original component
+                    // wrapped in a div with an octocat picture above it.
+                    EmailPasswordSignIn_Override: ({ DefaultComponent, ...props }) => {
+                        return (
+                            <div>
+                                <img src="octocat.jpg" />
+                                <DefaultComponent {...props} />
+                            </div>
+                        );
+                    },
+                }}>
+                {getRoutingComponent([EmailPasswordPreBuiltUI])}
+            </EmailPasswordComponentsOverrideProvider>
+        )
+    }
+    return (
+        <SuperTokensWrapper>
+            {/* Rest of the JSX */}
+        </SuperTokensWrapper>
+    );
+}
+export default App;
+
+```
+
+
+</Answer>
+
+</Question>
 
 <img alt="Prebuilt sign in UI with custom image" src="/img/emailpassword/react-override-octocat.png" />
 
 :::important
 Please make sure that the file in which this config is specified is a `.tsx` or ` .jsx` file type.
 :::
+
 
 </TabItem>
 </FrontendSDKTabs>

--- a/v2/passwordless/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/passwordless/advanced-customizations/react-component-override/usage.mdx
@@ -6,6 +6,8 @@ hide_title: true
 
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
+import {Answer} from "/src/components/question"
+import {Question}from "/src/components/question"
 
 # How to use
 
@@ -17,6 +19,10 @@ import TabItem from '@theme/TabItem';
 ## Example
 <FrontendSDKTabs>
 <TabItem value="reactjs">
+
+<Question
+    question="Do you use react-router-dom?">
+<Answer title="Yes">
 
 ```tsx
 import React from "react";
@@ -51,6 +57,53 @@ function App() {
 export default App;
 
 ```
+</Answer>
+
+<Answer title="No">
+
+```tsx
+import React from "react";
+import { SuperTokensWrapper } from "supertokens-auth-react";
+import { getRoutingComponent, canHandleRoute } from "supertokens-auth-react/ui";
+import { PasswordlessComponentsOverrideProvider } from "supertokens-auth-react/recipe/passwordless";
+import { PasswordlessPreBuiltUI } from "supertokens-auth-react/recipe/passwordless/prebuiltui";
+
+// @ts-ignore
+import octocat from "./octocat.png";
+
+function App() {
+    if(canHandleRoute([PasswordlessPreBuiltUI])){
+        return (
+            <PasswordlessComponentsOverrideProvider
+                components={{
+                    PasswordlessSignInUpHeader_Override: ({ DefaultComponent, ...props }) => {
+                        // In this case, the <PasswordlessSignInUpHeader_Override> 
+                        // will render the original component
+                        // wrapped in a div with an octocat picture above it.
+                        return (
+                            <div>
+                                <img src={octocat} />
+                                <DefaultComponent {...props} />
+                            </div>
+                        );
+                    }
+                }}>
+                {getRoutingComponent([PasswordlessPreBuiltUI])}
+            </PasswordlessComponentsOverrideProvider>
+        )
+    }
+    return (
+        <SuperTokensWrapper>
+            {/* Rest of the JSX */}
+        </SuperTokensWrapper>
+    );
+}
+export default App;
+
+```
+</Answer>
+
+</Question>
 
 <img alt="Prebuilt sign in UI with custom image" src="/img/passwordless/react-override-octocat.png" style={{
     height: "500px"

--- a/v2/src/plugins/codeTypeChecking/jsEnv/package.json
+++ b/v2/src/plugins/codeTypeChecking/jsEnv/package.json
@@ -51,7 +51,7 @@
     "react-router-dom5": "npm:react-router-dom@^5.3.0",
     "socket.io": "^4.6.1",
     "socketio": "^1.0.0",
-    "supertokens-auth-react": "^0.32.0",
+    "supertokens-auth-react": "^0.32.3",
     "supertokens-node": "^14.0.0",
     "supertokens-node7": "npm:supertokens-node@7.3",
     "supertokens-react-native": "^4.0.0",

--- a/v2/thirdparty/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/thirdparty/advanced-customizations/react-component-override/usage.mdx
@@ -7,6 +7,8 @@ hide_title: true
 
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
+import {Answer} from "/src/components/question"
+import {Question}from "/src/components/question"
 
 # How to use
 
@@ -18,6 +20,10 @@ import TabItem from '@theme/TabItem';
 ### Example
 <FrontendSDKTabs>
 <TabItem value="reactjs">
+
+<Question
+    question="Do you use react-router-dom?">
+<Answer title="Yes">
 
 ```tsx
 import React from 'react';
@@ -51,6 +57,53 @@ function App() {
 }
 export default App;
 ```
+</Answer>
+
+<Answer title="No">
+
+```tsx
+import React from 'react';
+import { SuperTokensWrapper } from "supertokens-auth-react";
+import { getRoutingComponent, canHandleRoute } from "supertokens-auth-react/ui";
+import { ThirdPartyPreBuiltUI } from "supertokens-auth-react/recipe/thirdparty/prebuiltui";
+import { ThirdpartyComponentsOverrideProvider } from "supertokens-auth-react/recipe/thirdparty";
+
+// @ts-ignore
+import octocat from "./octocat.png";
+
+function App() {
+    if(canHandleRoute([ThirdPartyPreBuiltUI])){
+        return (
+            <ThirdpartyComponentsOverrideProvider
+                components={{
+                    // In this case, the <ThirdPartySignUpFooter_Override> 
+                    // will render the original component
+                    // wrapped in a div with an octocat picture above it.
+                    ThirdPartySignUpFooter_Override: ({ DefaultComponent, ...props }) => {
+                        return (
+                            <div>
+                                <img src="octocat.jpg" />
+                                <DefaultComponent {...props} />
+                            </div>
+                        );
+                    },
+                }}>
+                {getRoutingComponent([ThirdPartyPreBuiltUI])}
+            </ThirdpartyComponentsOverrideProvider>
+        )
+    }
+
+    return (
+        <SuperTokensWrapper>
+            {/* Rest of the JSX */}
+        </SuperTokensWrapper>
+    );
+}
+export default App;
+```
+</Answer>
+
+</Question>
 
 <img alt="Prebuilt sign in UI with custom image" src="/img/thirdparty/react-override-octocat.png" />
 

--- a/v2/thirdpartyemailpassword/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/thirdpartyemailpassword/advanced-customizations/react-component-override/usage.mdx
@@ -6,6 +6,8 @@ hide_title: true
 
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
+import {Answer} from "/src/components/question"
+import {Question}from "/src/components/question"
 
 # How to use
 
@@ -17,6 +19,10 @@ import TabItem from '@theme/TabItem';
 ## Example
 <FrontendSDKTabs>
 <TabItem value="reactjs">
+
+<Question
+    question="Do you use react-router-dom?">
+<Answer title="Yes">
 
 ```tsx
 import React from "react";
@@ -49,6 +55,53 @@ function App() {
 }
 export default App;
 ```
+</Answer>
+
+<Answer title="No">
+
+```tsx
+import React from "react";
+import { SuperTokensWrapper } from "supertokens-auth-react";
+import { getRoutingComponent, canHandleRoute } from "supertokens-auth-react/ui";
+import { ThirdpartyEmailPasswordComponentsOverrideProvider } from "supertokens-auth-react/recipe/thirdpartyemailpassword";
+import { ThirdpartyEmailPasswordPreBuiltUI } from "supertokens-auth-react/recipe/thirdpartyemailpassword/prebuiltui";
+
+// @ts-ignore
+import octocat from "./octocat.png";
+
+function App() {
+    if(canHandleRoute([ThirdpartyEmailPasswordPreBuiltUI])){
+        return (
+            <ThirdpartyEmailPasswordComponentsOverrideProvider
+                components={{
+                    // In this case, the <EmailPasswordSignInHeader_Override> will render the original component
+                    // wrapped in a div with an octocat picture above it.
+                    EmailPasswordSignInHeader_Override: ({ DefaultComponent, ...props }) => {
+                        return (
+                            <div>
+                                <img src="octocat.jpg" />
+                                <DefaultComponent {...props} />
+                            </div>
+                        );
+                    },
+                }}>
+                {getRoutingComponent([ThirdpartyEmailPasswordPreBuiltUI])}
+            </ThirdpartyEmailPasswordComponentsOverrideProvider>
+        )
+    }
+    return (
+        <SuperTokensWrapper>
+            {/* Rest of the JSX */}
+        </SuperTokensWrapper>
+    );
+}
+export default App;
+```
+
+</Answer>
+
+</Question>
+
 
 <img alt="Prebuilt sign in UI with custom image" src="/img/thirdpartyemailpassword/react-override-octocat.png" />
 

--- a/v2/thirdpartyemailpassword/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/thirdpartyemailpassword/advanced-customizations/react-component-override/usage.mdx
@@ -64,13 +64,13 @@ import React from "react";
 import { SuperTokensWrapper } from "supertokens-auth-react";
 import { getRoutingComponent, canHandleRoute } from "supertokens-auth-react/ui";
 import { ThirdpartyEmailPasswordComponentsOverrideProvider } from "supertokens-auth-react/recipe/thirdpartyemailpassword";
-import { ThirdpartyEmailPasswordPreBuiltUI } from "supertokens-auth-react/recipe/thirdpartyemailpassword/prebuiltui";
+import { ThirdPartyEmailPasswordPreBuiltUI } from "supertokens-auth-react/recipe/thirdpartyemailpassword/prebuiltui";
 
 // @ts-ignore
 import octocat from "./octocat.png";
 
 function App() {
-    if(canHandleRoute([ThirdpartyEmailPasswordPreBuiltUI])){
+    if(canHandleRoute([ThirdPartyEmailPasswordPreBuiltUI])){
         return (
             <ThirdpartyEmailPasswordComponentsOverrideProvider
                 components={{
@@ -85,7 +85,7 @@ function App() {
                         );
                     },
                 }}>
-                {getRoutingComponent([ThirdpartyEmailPasswordPreBuiltUI])}
+                {getRoutingComponent([ThirdPartyEmailPasswordPreBuiltUI])}
             </ThirdpartyEmailPasswordComponentsOverrideProvider>
         )
     }

--- a/v2/thirdpartypasswordless/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/react-component-override/usage.mdx
@@ -65,13 +65,13 @@ import React from "react";
 import { SuperTokensWrapper } from "supertokens-auth-react";
 import { getRoutingComponent, canHandleRoute } from "supertokens-auth-react/ui";
 import { ThirdpartyPasswordlessComponentsOverrideProvider } from "supertokens-auth-react/recipe/thirdpartypasswordless";
-import { ThirdpartyPasswordlessPreBuiltUI } from "supertokens-auth-react/recipe/thirdpartypasswordless/prebuiltui";
+import { ThirdPartyPasswordlessPreBuiltUI } from "supertokens-auth-react/recipe/thirdpartypasswordless/prebuiltui";
 
 // @ts-ignore
 import octocat from "./octocat.png";
 
 function App() {
-    if(canHandleRoute([ThirdpartyPasswordlessPreBuiltUI])){
+    if(canHandleRoute([ThirdPartyPasswordlessPreBuiltUI])){
         return (
              <ThirdpartyPasswordlessComponentsOverrideProvider
                 components={{
@@ -87,7 +87,7 @@ function App() {
                         );
                     }
                 }}>
-                {getRoutingComponent([ThirdpartyPasswordlessPreBuiltUI])}
+                {getRoutingComponent([ThirdPartyPasswordlessPreBuiltUI])}
             </ThirdpartyPasswordlessComponentsOverrideProvider>
         )
     }

--- a/v2/thirdpartypasswordless/advanced-customizations/react-component-override/usage.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/react-component-override/usage.mdx
@@ -6,6 +6,8 @@ hide_title: true
 
 import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import TabItem from '@theme/TabItem';
+import {Answer} from "/src/components/question"
+import {Question}from "/src/components/question"
 
 # How to use
 
@@ -17,6 +19,10 @@ import TabItem from '@theme/TabItem';
 ## Example
 <FrontendSDKTabs>
 <TabItem value="reactjs">
+
+<Question
+    question="Do you use react-router-dom?">
+<Answer title="Yes">
 
 ```tsx
 import React from "react";
@@ -50,6 +56,53 @@ function App() {
 }
 export default App;
 ```
+</Answer>
+
+<Answer title="No">
+
+```tsx
+import React from "react";
+import { SuperTokensWrapper } from "supertokens-auth-react";
+import { getRoutingComponent, canHandleRoute } from "supertokens-auth-react/ui";
+import { ThirdpartyPasswordlessComponentsOverrideProvider } from "supertokens-auth-react/recipe/thirdpartypasswordless";
+import { ThirdpartyPasswordlessPreBuiltUI } from "supertokens-auth-react/recipe/thirdpartypasswordless/prebuiltui";
+
+// @ts-ignore
+import octocat from "./octocat.png";
+
+function App() {
+    if(canHandleRoute([ThirdpartyPasswordlessPreBuiltUI])){
+        return (
+             <ThirdpartyPasswordlessComponentsOverrideProvider
+                components={{
+                    // In this case, the <ThirdPartyPasswordlessHeader_Override> 
+                    // will render the original component
+                    // wrapped in a div with an octocat picture above it.
+                    ThirdPartyPasswordlessHeader_Override: ({ DefaultComponent, ...props }) => {
+                        return (
+                            <div>
+                                <img src={octocat} />
+                                <DefaultComponent {...props} />
+                            </div>
+                        );
+                    }
+                }}>
+                {getRoutingComponent([ThirdpartyPasswordlessPreBuiltUI])}
+            </ThirdpartyPasswordlessComponentsOverrideProvider>
+        )
+    }
+    
+    return (
+        <SuperTokensWrapper>
+            {/* Rest of the JSX */}
+        </SuperTokensWrapper>
+    );
+}
+export default App;
+```
+</Answer>
+
+</Question>
 
 <img alt="Prebuilt sign up or log in UI with custom image" src="/img/passwordless/react-override-octocat.png" style={{
     height: "500px"


### PR DESCRIPTION
## Summary of change
Adds component override snippets for without react-router-dom usage

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2