### PR TITLE
Update user context and request related docs

### DIFF
--- a/v2/emailpassword/advanced-customizations/frontend-hooks/pre-api.mdx
+++ b/v2/emailpassword/advanced-customizations/frontend-hooks/pre-api.mdx
@@ -328,3 +328,13 @@ void main() {
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+
+<!-- COPY SECTION -->
+<!-- ./emailpassword/advanced-customizations/frontend-hooks/pre-api.mdx -->
+<!-- 1 -->
+
+## Reading custom request information in the backend
+
+Visit [this page](../user-context/custom-request-properties) to learn how to read custom headers etc from the request on the backend.
+
+<!-- END COPY SECTION -->

--- a/v2/emailpassword/advanced-customizations/user-context.mdx
+++ b/v2/emailpassword/advanced-customizations/user-context.mdx
@@ -6,7 +6,6 @@ hide_title: true
 
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import TabItem from '@theme/TabItem';
-import DefaultContext from "../reusableMD/user-context-default.mdx"
 
 # User Context
 
@@ -422,6 +421,14 @@ When that is called, that function checks if `isSignUp === true`, and if it is, 
 
 Note that there are other ways of achiving this, but the above showcases how we can use user context to communicate across recipes and across API & Recipe functions.
 
+<!-- COPY SECTION -->
+<!-- ./emailpassword/advanced-customizations/user-context.mdx -->
+<!-- 1 -->
+
 ## Default information in the user context object
 
-<DefaultContext />
+By default the user context passed to APIs and functions contains the request object that can be used to read custom headers, body/query params etc.
+
+To learn more on how you can use the default user context to consume custom request information [visit this page](./user-context/custom-request-properties).
+
+<!-- END COPY SECTION -->

--- a/v2/emailpassword/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/emailpassword/advanced-customizations/user-context/custom-request-properties.mdx
@@ -145,9 +145,11 @@ Session.init({
 We use the `GetRequestFromUserContext` function provided by the SDK to get the request object from the user context.
 
 ```go
-"github.com/supertokens/supertokens-golang/recipe/session"
-"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
-"github.com/supertokens/supertokens-golang/supertokens"
+import (
+    "github.com/supertokens/supertokens-golang/recipe/session"
+    "github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+    "github.com/supertokens/supertokens-golang/supertokens"
+)
 
 func main() {
     session.Init(&sessmodels.TypeInput{

--- a/v2/emailpassword/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/emailpassword/advanced-customizations/user-context/custom-request-properties.mdx
@@ -1,0 +1,298 @@
+---
+id: custom-request-properties
+title: Adding and reading custom request properties
+hide_title: true
+---
+
+<!-- COPY DOCS -->
+<!-- ./emailpassword/advanced-customizations/user-context/custom-request-properties.mdx -->
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
+import TabItem from '@theme/TabItem';
+
+# Adding and reading custom request properties
+
+When using the APIs exposed by the SuperTokens SDKs, you may want to pass custom information to your backend. You can leverage our pre api hook, overrides and user context features to achieve this by:
+1. Using the pre api hook to add custom information to network requests made by our frontend SDKs
+2. Using the overrides feature to provide custom handling for APIs and functions in the backend SDK
+3. Using the user context feature in the backend to access to original request and consuming any custom information
+
+## Adding custom information to requests on the frontend
+
+You can use our [pre api hook feature](../frontend-hooks/pre-api) to add custom information to network requests made by the frontend SDKs.
+
+For example let us consider a React app using `supertokens-auth-react` where we add some custom header whenever the user signs out:
+
+```tsx
+import Session from "supertokens-auth-react/recipe/session";
+
+Session.init({
+    preAPIHook: async (context) => {
+        let requestInit = context.requestInit;
+
+        if (context.action === "SIGN_OUT") {
+            let headers = {
+                ...requestInit.headers,
+                customHeader: "customvalue,"
+            };
+            requestInit = {
+                ...requestInit,
+                headers,
+            }
+        }
+
+        return {
+            url: context.url,
+            requestInit,
+        };
+    }
+})
+```
+
+:::info
+Refer to the [pre api hook documentation](../frontend-hooks/pre-api) to learn how to do this for our other frontend SDKs
+:::
+
+## Reading custom request information in the backend
+
+To read information on the backend we need to use either the [API overrides feature](../apis-override/about.mdx) or the [backend function override feature](../backend-functions-override/about.mdx). We override the API/function we want to read the information in, get the original request object and then read the query/body to consume the custom property.
+
+Let us continue the example we used above, we need to read the headers from the request and read the value of `customHeader`. This will involve:
+- Overriding either the `revokeSession` function or the `signOutPOST` API of the session recipe
+- Getting the request object from the user context
+- Reading the custom header value
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+We use the `getRequestFromUserContext` function provided by the SDK to get the request object from the user context.
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+Session.init({
+    override: {
+        functions: (oI) => {
+            return {
+                ...oI,
+                revokeSession: async (input) => {
+                    // highlight-start
+                    let customHeaderValue = "";
+                    const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                    if (request !== undefined) {
+                        //@ts-ignore
+                        customHeaderValue = request.getHeaderValue("customHeader");
+                    } else {
+                        /**
+                         * This is possible if the function is triggerred from the user management dashboard
+                         * OR if the function was called internally from the SDK
+                         * 
+                         * In this case set a reasonable default value to use
+                         */
+                        customHeaderValue = "default";
+                    }
+
+                    // highlight-end
+
+                    // Perform custom logic based on the value of customHeaderValue
+
+                    return oI.revokeSession(input);
+                },
+            };
+        },
+        apis: (oI) => {
+            return {
+                ...oI,
+                signOutPOST: async (input) => {
+                    if (oI.signOutPOST === undefined) {
+                        throw Error("Signout API is disabled");
+                    }
+
+                    // highlight-start
+                    let customHeaderValue = "";
+                    const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                    if (request !== undefined) {
+                        //@ts-ignore
+                        customHeaderValue = request.getHeaderValue("customHeader");
+                    } else {
+                        /**
+                         * This is possible if the function is triggerred from the user management dashboard
+                         * OR if the function was called internally from the SDK
+                         * 
+                         * In this case set a reasonable default value to use
+                         */
+                        customHeaderValue = "default";
+                    }
+
+                    // highlight-end
+
+                    // Perform custom logic based on the value of customHeaderValue
+
+                    return oI.signOutPOST(input);
+                },
+            };
+        }
+    },
+})
+```
+
+</TabItem>
+<TabItem value="go">
+
+We use the `GetRequestFromUserContext` function provided by the SDK to get the request object from the user context.
+
+```go
+"github.com/supertokens/supertokens-golang/recipe/session"
+"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+"github.com/supertokens/supertokens-golang/supertokens"
+
+func main() {
+    session.Init(&sessmodels.TypeInput{
+        Override: &sessmodels.OverrideStruct{
+            Functions: func(originalImplementation sessmodels.RecipeInterface) sessmodels.RecipeInterface {
+                originalRevokeSession := *originalImplementation.RevokeSession
+
+                *originalImplementation.RevokeSession = func(sessionHandle string, userContext supertokens.UserContext) (bool, error) {
+                    // highlight-start
+                    customHeadervalue := ""
+                    request := supertokens.GetRequestFromUserContext(userContext)
+
+                    if request != nil {
+                        customHeadervalue = request.Header.Get("customHeader")
+                    } else {
+                        /**
+                        * This is possible if the function is triggerred from the user management dashboard
+                        * OR if the function was called internally from the SDK
+                        * 
+                        * In this case set a reasonable default value to use
+                        */
+                        customHeadervalue = "default";
+                    }
+                    // highlight-end
+
+                    print(customHeadervalue)
+
+                    // Perform custom logic based on the value of customHeadervalue
+
+                    return originalRevokeSession(sessionHandle, userContext)
+                }
+
+                return originalImplementation
+            },
+            APIs: func(originalImplementation sessmodels.APIInterface) sessmodels.APIInterface {
+                originalSignOutPost := *originalImplementation.SignOutPOST
+
+                *originalImplementation.SignOutPOST = func(sessionContainer sessmodels.SessionContainer, options sessmodels.APIOptions, userContext supertokens.UserContext) (sessmodels.SignOutPOSTResponse, error) {
+                    // highlight-start
+                    customHeadervalue := ""
+                    request := supertokens.GetRequestFromUserContext(userContext)
+
+                    if request != nil {
+                        customHeadervalue = request.Header.Get("customHeader")
+                    } else {
+                        /**
+                        * This is possible if the function is triggerred from the user management dashboard
+                        * OR if the function was called internally from the SDK
+                        * 
+                        * In this case set a reasonable default value to use
+                        */
+                        customHeadervalue = "default";
+                    }
+                    // highlight-end
+
+                    print(customHeadervalue)
+
+                    // Perform custom logic based on the value of customHeadervalue
+
+                    return originalSignOutPost(sessionContainer, options, userContext)
+                }
+
+                return originalImplementation
+            },
+        },
+    })
+}
+```
+
+</TabItem>
+<TabItem value="python">
+
+We use the `get_request_from_user_context` function provided by the SDK to get the request object from the user context.
+
+```python
+from supertokens_python import get_request_from_user_context
+from supertokens_python.recipe import session
+from supertokens_python.recipe.session.interfaces import RecipeInterface, APIInterface, APIOptions
+from typing import Any, Dict, Optional
+
+def override_session_functions(original_implementation: RecipeInterface):
+    original_revoke_session = original_implementation.revoke_session
+
+    async def revoke_session(session_handle: str, user_context: Dict[str, Any]):
+        # highlight-start
+        request=get_request_from_user_context(user_context)
+        customHeaderValue=""
+
+        if request is not None:
+            customHeaderValue=request.get_header("customHeader")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
+            customHeaderValue="default"
+        # highlight-end
+        
+        print(customHeaderValue)
+        # Perform custom logic based on the value of customHeadervalue
+
+        return await original_revoke_session(session_handle, user_context)
+
+    original_implementation.revoke_session = revoke_session
+    return original_implementation
+
+def override_session_apis(original_implementation: APIInterface):
+    original_signout_post = original_implementation.signout_post
+
+    async def signout_post(session: Optional[session.SessionContainer], api_options: APIOptions, user_context: Dict[str, Any]):
+        # highlight-start
+        request=get_request_from_user_context(user_context)
+        customHeaderValue=""
+
+        if request is not None:
+            customHeaderValue=request.get_header("customHeader")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
+            customHeaderValue="default"
+        # highlight-end
+        
+        print(customHeaderValue)
+        # Perform custom logic based on the value of customHeadervalue
+
+        return await original_signout_post(session, api_options, user_context)
+
+    original_implementation.signout_post = signout_post
+    return original_implementation
+
+session.init(
+    override=session.InputOverrideConfig(
+        functions=override_session_functions,
+        apis=override_session_apis
+    ),
+)
+```
+
+</TabItem>
+</BackendSDKTabs>
+
+

--- a/v2/emailpassword/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/emailpassword/advanced-customizations/user-context/custom-request-properties.mdx
@@ -87,7 +87,6 @@ Session.init({
                     } else {
                         /**
                          * This is possible if the function is triggerred from the user management dashboard
-                         * OR if the function was called internally from the SDK
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -120,7 +119,6 @@ Session.init({
                     } else {
                         /**
                          * This is possible if the function is triggerred from the user management dashboard
-                         * OR if the function was called internally from the SDK
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -167,7 +165,6 @@ func main() {
                     } else {
                         /**
                         * This is possible if the function is triggerred from the user management dashboard
-                        * OR if the function was called internally from the SDK
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -197,7 +194,6 @@ func main() {
                     } else {
                         /**
                         * This is possible if the function is triggerred from the user management dashboard
-                        * OR if the function was called internally from the SDK
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -243,7 +239,6 @@ def override_session_functions(original_implementation: RecipeInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
             # In this case set a reasonable default value to use
             #
@@ -271,7 +266,6 @@ def override_session_apis(original_implementation: APIInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
             # In this case set a reasonable default value to use
             #

--- a/v2/emailpassword/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/emailpassword/common-customizations/sessions/anonymous-session.mdx
@@ -270,7 +270,7 @@ func main() {
 <TabItem value="python">
 
 ```python
-from supertokens_python import init, InputAppInfo
+from supertokens_python import init, InputAppInfo, get_request_from_user_context
 from supertokens_python.recipe import session
 from supertokens_python.recipe.session.interfaces import RecipeInterface
 from typing import Any, Dict, Optional
@@ -286,7 +286,7 @@ def override_functions(original_implementation: RecipeInterface):
                                  user_context: Dict[str, Any]):
 
         request=get_request_from_user_context(user_context)
-        jwt: Optional[str]
+        jwt: Optional[str] = None
 
         if request is not None:
             jwt=request.get_cookie("jwt")
@@ -297,6 +297,7 @@ def override_functions(original_implementation: RecipeInterface):
             # 
             # In this case set a reasonable default value to use
             #
+            jwt=None
 
         if jwt is not None:
             # verify JWT using a JWT verification library..

--- a/v2/emailpassword/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/emailpassword/common-customizations/sessions/anonymous-session.mdx
@@ -207,8 +207,6 @@ SuperTokens.init({
 
 ```go
 import (
-	"net/http"
-
 	"github.com/supertokens/supertokens-golang/recipe/session"
 	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"

--- a/v2/emailpassword/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/emailpassword/common-customizations/sessions/anonymous-session.mdx
@@ -174,9 +174,9 @@ SuperTokens.init({
                             } else {
                                 /**
                                  * This is possible if the function is triggerred from the user management dashboard
-                                 * OR if the function was called internally from the SDK
                                  * 
-                                 * In this case set a reasonable default value to use
+                                 * In this case because we cannot read the JWT, we create a session without the custom
+                                 * payload properties
                                  */
                             }
 
@@ -248,9 +248,9 @@ func main() {
                             } else {
                                 /**
                                 * This is possible if the function is triggerred from the user management dashboard
-                                * OR if the function was called internally from the SDK
                                 * 
-                                * In this case set a reasonable default value to use
+                                * In this case because we cannot read the JWT, we create a session without the custom
+                                * payload properties
                                 */
                             }
 
@@ -293,9 +293,9 @@ def override_functions(original_implementation: RecipeInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
-            # In this case set a reasonable default value to use
+            # In this case because we cannot read the JWT, we create a session without the custom
+            # payload properties
             #
             jwt=None
 

--- a/v2/emailpassword/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/emailpassword/common-customizations/sessions/anonymous-session.mdx
@@ -164,19 +164,33 @@ SuperTokens.init({
                         createNewSession: async function (input) {
                             let userId = input.userId;
 
-                            let jwt = input.userContext._default.request.getCookieValue("jwt");
+                            const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                            let jwt: string | undefined
+                            let jwtPayload = {}
+
+                            if (request !== undefined) {
+                                jwt = request.getCookieValue("jwt");
+                            } else {
+                                /**
+                                 * This is possible if the function is triggerred from the user management dashboard
+                                 * OR if the function was called internally from the SDK
+                                 * 
+                                 * In this case set a reasonable default value to use
+                                 */
+                            }
 
                             if (jwt !== undefined) {
                                 // verify JWT using a JWT verification library..
 
-                                let jwtPayload = { /* ... get from decoded jwt ... */};
-
-                                // This goes in the access token, and is availble to read on the frontend.
-                                input.accessTokenPayload = {
-                                    ...input.accessTokenPayload,
-                                    ...jwtPayload
-                                };
+                                jwtPayload = { /* ... get from decoded jwt ... */};
                             }
+
+                            // This goes in the access token, and is availble to read on the frontend.
+                            input.accessTokenPayload = {
+                                ...input.accessTokenPayload,
+                                ...jwtPayload
+                            };
 
                             return originalImplementation.createNewSession(input);
                         },
@@ -212,24 +226,35 @@ func main() {
 
 						// Now we override the CreateNewSession function
 						(*originalImplementation.CreateNewSession) = func(userID string, accessTokenPayload, sessionDataInDatabase map[string]interface{}, disableAntiCsrf *bool, userContext supertokens.UserContext) (sessmodels.SessionContainer, error) {
+                            request := supertokens.GetRequestFromUserContext(userContext)
 
-							jwt, err := (*userContext)["_default"].(map[string]interface{})["request"].(*http.Request).Cookie("jwt")
-							if err != nil {
-								return nil, err
-							}
+                            if (request != nil) {
+                                jwt, err := request.Cookie("jwt")
 
-							if jwt != nil {
-								// verify JWT using a jwt verification library..
-								decodedJWT := map[string]interface{}{
-									// from JWT verification lib
-								}
+                                if err != nil {
+                                    return nil, err
+                                }
 
-								// This goes in the access token, and is availble to read on the frontend.
-								if accessTokenPayload == nil {
-									accessTokenPayload = map[string]interface{}{}
-								}
-								accessTokenPayload["someKey"] = decodedJWT["someKey"]
-							}
+                                if jwt != nil {
+                                    // verify JWT using a jwt verification library..
+                                    decodedJWT := map[string]interface{}{
+                                        // from JWT verification lib
+                                    }
+
+                                    // This goes in the access token, and is availble to read on the frontend.
+                                    if accessTokenPayload == nil {
+                                        accessTokenPayload = map[string]interface{}{}
+                                    }
+                                    accessTokenPayload["someKey"] = decodedJWT["someKey"]
+                                }
+                            } else {
+                                /**
+                                * This is possible if the function is triggerred from the user management dashboard
+                                * OR if the function was called internally from the SDK
+                                * 
+                                * In this case set a reasonable default value to use
+                                */
+                            }
 
 							return originalCreateNewSession(userID, accessTokenPayload, sessionDataInDatabase, disableAntiCsrf, userContext)
 						}
@@ -262,7 +287,18 @@ def override_functions(original_implementation: RecipeInterface):
                                  disable_anti_csrf: Optional[bool],
                                  user_context: Dict[str, Any]):
 
-        jwt = user_context["_default"]["request"].get_cookie("jwt")
+        request=get_request_from_user_context(user_context)
+        jwt: Optional[str]
+
+        if request is not None:
+            jwt=request.get_cookie("jwt")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
 
         if jwt is not None:
             # verify JWT using a JWT verification library..

--- a/v2/emailpassword/sidebars.js
+++ b/v2/emailpassword/sidebars.js
@@ -475,6 +475,7 @@ module.exports = {
           label: 'Actions, Hooks and Custom API responses',
           items: [
             "advanced-customizations/overview",
+            "advanced-customizations/user-context/custom-request-properties",
             {
               type: 'category',
               label: 'React component override',

--- a/v2/passwordless/advanced-customizations/frontend-hooks/pre-api.mdx
+++ b/v2/passwordless/advanced-customizations/frontend-hooks/pre-api.mdx
@@ -322,4 +322,14 @@ void main() {
 
 </PreBuiltOrCustomUISwitcher>
 
+<!-- COPY SECTION -->
+<!-- ./emailpassword/advanced-customizations/frontend-hooks/pre-api.mdx -->
+<!-- 1 -->
+
+## Reading custom request information in the backend
+
+Visit [this page](../user-context/custom-request-properties) to learn how to read custom headers etc from the request on the backend.
+
+<!-- END COPY SECTION -->
+
 

--- a/v2/passwordless/advanced-customizations/user-context.mdx
+++ b/v2/passwordless/advanced-customizations/user-context.mdx
@@ -6,7 +6,6 @@ hide_title: true
 
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import TabItem from '@theme/TabItem';
-import DefaultContext from "../../emailpassword/reusableMD/user-context-default.mdx"
 
 # User Context
 
@@ -467,6 +466,14 @@ As a summary, when the sign up API is called, the initial value of `userContext`
 
 When that is called, that function checks if `isSignUp === true`, and if it is, it doesn't call the original implementation, and instead, just returns an empty session. This way, we don't create a session if the user is signing up, but we do create one if the user is signing in.
 
+<!-- COPY SECTION -->
+<!-- ./emailpassword/advanced-customizations/user-context.mdx -->
+<!-- 1 -->
+
 ## Default information in the user context object
 
-<DefaultContext />
+By default the user context passed to APIs and functions contains the request object that can be used to read custom headers, body/query params etc.
+
+To learn more on how you can use the default user context to consume custom request information [visit this page](./user-context/custom-request-properties).
+
+<!-- END COPY SECTION -->

--- a/v2/passwordless/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/passwordless/advanced-customizations/user-context/custom-request-properties.mdx
@@ -145,9 +145,11 @@ Session.init({
 We use the `GetRequestFromUserContext` function provided by the SDK to get the request object from the user context.
 
 ```go
-"github.com/supertokens/supertokens-golang/recipe/session"
-"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
-"github.com/supertokens/supertokens-golang/supertokens"
+import (
+    "github.com/supertokens/supertokens-golang/recipe/session"
+    "github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+    "github.com/supertokens/supertokens-golang/supertokens"
+)
 
 func main() {
     session.Init(&sessmodels.TypeInput{

--- a/v2/passwordless/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/passwordless/advanced-customizations/user-context/custom-request-properties.mdx
@@ -87,7 +87,6 @@ Session.init({
                     } else {
                         /**
                          * This is possible if the function is triggerred from the user management dashboard
-                         * OR if the function was called internally from the SDK
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -120,7 +119,6 @@ Session.init({
                     } else {
                         /**
                          * This is possible if the function is triggerred from the user management dashboard
-                         * OR if the function was called internally from the SDK
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -167,7 +165,6 @@ func main() {
                     } else {
                         /**
                         * This is possible if the function is triggerred from the user management dashboard
-                        * OR if the function was called internally from the SDK
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -197,7 +194,6 @@ func main() {
                     } else {
                         /**
                         * This is possible if the function is triggerred from the user management dashboard
-                        * OR if the function was called internally from the SDK
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -243,7 +239,6 @@ def override_session_functions(original_implementation: RecipeInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
             # In this case set a reasonable default value to use
             #
@@ -271,7 +266,6 @@ def override_session_apis(original_implementation: APIInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
             # In this case set a reasonable default value to use
             #

--- a/v2/passwordless/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/passwordless/advanced-customizations/user-context/custom-request-properties.mdx
@@ -1,0 +1,296 @@
+---
+id: custom-request-properties
+title: Adding and reading custom request properties
+hide_title: true
+---
+
+<!-- COPY DOCS -->
+<!-- ./emailpassword/advanced-customizations/user-context/custom-request-properties.mdx -->
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
+import TabItem from '@theme/TabItem';
+
+# Adding and reading custom request properties
+
+When using the APIs exposed by the SuperTokens SDKs, you may want to pass custom information to your backend. You can leverage our pre api hook, overrides and user context features to achieve this by:
+1. Using the pre api hook to add custom information to network requests made by our frontend SDKs
+2. Using the overrides feature to provide custom handling for APIs and functions in the backend SDK
+3. Using the user context feature in the backend to access to original request and consuming any custom information
+
+## Adding custom information to requests on the frontend
+
+You can use our [pre api hook feature](../frontend-hooks/pre-api) to add custom information to network requests made by the frontend SDKs.
+
+For example let us consider a React app using `supertokens-auth-react` where we add some custom header whenever the user signs out:
+
+```tsx
+import Session from "supertokens-auth-react/recipe/session";
+
+Session.init({
+    preAPIHook: async (context) => {
+        let requestInit = context.requestInit;
+
+        if (context.action === "SIGN_OUT") {
+            let headers = {
+                ...requestInit.headers,
+                customHeader: "customvalue,"
+            };
+            requestInit = {
+                ...requestInit,
+                headers,
+            }
+        }
+
+        return {
+            url: context.url,
+            requestInit,
+        };
+    }
+})
+```
+
+:::info
+Refer to the [pre api hook documentation](../frontend-hooks/pre-api) to learn how to do this for our other frontend SDKs
+:::
+
+## Reading custom request information in the backend
+
+To read information on the backend we need to use either the [API overrides feature](../apis-override/about.mdx) or the [backend function override feature](../backend-functions-override/about.mdx). We override the API/function we want to read the information in, get the original request object and then read the query/body to consume the custom property.
+
+Let us continue the example we used above, we need to read the headers from the request and read the value of `customHeader`. This will involve:
+- Overriding either the `revokeSession` function or the `signOutPOST` API of the session recipe
+- Getting the request object from the user context
+- Reading the custom header value
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+We use the `getRequestFromUserContext` function provided by the SDK to get the request object from the user context.
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+Session.init({
+    override: {
+        functions: (oI) => {
+            return {
+                ...oI,
+                revokeSession: async (input) => {
+                    // highlight-start
+                    let customHeaderValue = "";
+                    const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                    if (request !== undefined) {
+                        //@ts-ignore
+                        customHeaderValue = request.getHeaderValue("customHeader");
+                    } else {
+                        /**
+                         * This is possible if the function is triggerred from the user management dashboard
+                         * OR if the function was called internally from the SDK
+                         * 
+                         * In this case set a reasonable default value to use
+                         */
+                        customHeaderValue = "default";
+                    }
+
+                    // highlight-end
+
+                    // Perform custom logic based on the value of customHeaderValue
+
+                    return oI.revokeSession(input);
+                },
+            };
+        },
+        apis: (oI) => {
+            return {
+                ...oI,
+                signOutPOST: async (input) => {
+                    if (oI.signOutPOST === undefined) {
+                        throw Error("Signout API is disabled");
+                    }
+
+                    // highlight-start
+                    let customHeaderValue = "";
+                    const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                    if (request !== undefined) {
+                        //@ts-ignore
+                        customHeaderValue = request.getHeaderValue("customHeader");
+                    } else {
+                        /**
+                         * This is possible if the function is triggerred from the user management dashboard
+                         * OR if the function was called internally from the SDK
+                         * 
+                         * In this case set a reasonable default value to use
+                         */
+                        customHeaderValue = "default";
+                    }
+
+                    // highlight-end
+
+                    // Perform custom logic based on the value of customHeaderValue
+
+                    return oI.signOutPOST(input);
+                },
+            };
+        }
+    },
+})
+```
+
+</TabItem>
+<TabItem value="go">
+
+We use the `GetRequestFromUserContext` function provided by the SDK to get the request object from the user context.
+
+```go
+"github.com/supertokens/supertokens-golang/recipe/session"
+"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+"github.com/supertokens/supertokens-golang/supertokens"
+
+func main() {
+    session.Init(&sessmodels.TypeInput{
+        Override: &sessmodels.OverrideStruct{
+            Functions: func(originalImplementation sessmodels.RecipeInterface) sessmodels.RecipeInterface {
+                originalRevokeSession := *originalImplementation.RevokeSession
+
+                *originalImplementation.RevokeSession = func(sessionHandle string, userContext supertokens.UserContext) (bool, error) {
+                    // highlight-start
+                    customHeadervalue := ""
+                    request := supertokens.GetRequestFromUserContext(userContext)
+
+                    if request != nil {
+                        customHeadervalue = request.Header.Get("customHeader")
+                    } else {
+                        /**
+                        * This is possible if the function is triggerred from the user management dashboard
+                        * OR if the function was called internally from the SDK
+                        * 
+                        * In this case set a reasonable default value to use
+                        */
+                        customHeadervalue = "default";
+                    }
+                    // highlight-end
+
+                    print(customHeadervalue)
+
+                    // Perform custom logic based on the value of customHeadervalue
+
+                    return originalRevokeSession(sessionHandle, userContext)
+                }
+
+                return originalImplementation
+            },
+            APIs: func(originalImplementation sessmodels.APIInterface) sessmodels.APIInterface {
+                originalSignOutPost := *originalImplementation.SignOutPOST
+
+                *originalImplementation.SignOutPOST = func(sessionContainer sessmodels.SessionContainer, options sessmodels.APIOptions, userContext supertokens.UserContext) (sessmodels.SignOutPOSTResponse, error) {
+                    // highlight-start
+                    customHeadervalue := ""
+                    request := supertokens.GetRequestFromUserContext(userContext)
+
+                    if request != nil {
+                        customHeadervalue = request.Header.Get("customHeader")
+                    } else {
+                        /**
+                        * This is possible if the function is triggerred from the user management dashboard
+                        * OR if the function was called internally from the SDK
+                        * 
+                        * In this case set a reasonable default value to use
+                        */
+                        customHeadervalue = "default";
+                    }
+                    // highlight-end
+
+                    print(customHeadervalue)
+
+                    // Perform custom logic based on the value of customHeadervalue
+
+                    return originalSignOutPost(sessionContainer, options, userContext)
+                }
+
+                return originalImplementation
+            },
+        },
+    })
+}
+```
+
+</TabItem>
+<TabItem value="python">
+
+We use the `get_request_from_user_context` function provided by the SDK to get the request object from the user context.
+
+```python
+from supertokens_python import get_request_from_user_context
+from supertokens_python.recipe import session
+from supertokens_python.recipe.session.interfaces import RecipeInterface, APIInterface, APIOptions
+from typing import Any, Dict, Optional
+
+def override_session_functions(original_implementation: RecipeInterface):
+    original_revoke_session = original_implementation.revoke_session
+
+    async def revoke_session(session_handle: str, user_context: Dict[str, Any]):
+        # highlight-start
+        request=get_request_from_user_context(user_context)
+        customHeaderValue=""
+
+        if request is not None:
+            customHeaderValue=request.get_header("customHeader")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
+            customHeaderValue="default"
+        # highlight-end
+        
+        print(customHeaderValue)
+        # Perform custom logic based on the value of customHeadervalue
+
+        return await original_revoke_session(session_handle, user_context)
+
+    original_implementation.revoke_session = revoke_session
+    return original_implementation
+
+def override_session_apis(original_implementation: APIInterface):
+    original_signout_post = original_implementation.signout_post
+
+    async def signout_post(session: Optional[session.SessionContainer], api_options: APIOptions, user_context: Dict[str, Any]):
+        # highlight-start
+        request=get_request_from_user_context(user_context)
+        customHeaderValue=""
+
+        if request is not None:
+            customHeaderValue=request.get_header("customHeader")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
+            customHeaderValue="default"
+        # highlight-end
+        
+        print(customHeaderValue)
+        # Perform custom logic based on the value of customHeadervalue
+
+        return await original_signout_post(session, api_options, user_context)
+
+    original_implementation.signout_post = signout_post
+    return original_implementation
+
+session.init(
+    override=session.InputOverrideConfig(
+        functions=override_session_functions,
+        apis=override_session_apis
+    ),
+)
+```
+
+</TabItem>
+</BackendSDKTabs>

--- a/v2/passwordless/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/passwordless/common-customizations/sessions/anonymous-session.mdx
@@ -270,7 +270,7 @@ func main() {
 <TabItem value="python">
 
 ```python
-from supertokens_python import init, InputAppInfo
+from supertokens_python import init, InputAppInfo, get_request_from_user_context
 from supertokens_python.recipe import session
 from supertokens_python.recipe.session.interfaces import RecipeInterface
 from typing import Any, Dict, Optional
@@ -286,7 +286,7 @@ def override_functions(original_implementation: RecipeInterface):
                                  user_context: Dict[str, Any]):
 
         request=get_request_from_user_context(user_context)
-        jwt: Optional[str]
+        jwt: Optional[str] = None
 
         if request is not None:
             jwt=request.get_cookie("jwt")
@@ -297,6 +297,7 @@ def override_functions(original_implementation: RecipeInterface):
             # 
             # In this case set a reasonable default value to use
             #
+            jwt=None
 
         if jwt is not None:
             # verify JWT using a JWT verification library..

--- a/v2/passwordless/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/passwordless/common-customizations/sessions/anonymous-session.mdx
@@ -207,8 +207,6 @@ SuperTokens.init({
 
 ```go
 import (
-	"net/http"
-
 	"github.com/supertokens/supertokens-golang/recipe/session"
 	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"

--- a/v2/passwordless/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/passwordless/common-customizations/sessions/anonymous-session.mdx
@@ -174,9 +174,9 @@ SuperTokens.init({
                             } else {
                                 /**
                                  * This is possible if the function is triggerred from the user management dashboard
-                                 * OR if the function was called internally from the SDK
                                  * 
-                                 * In this case set a reasonable default value to use
+                                 * In this case because we cannot read the JWT, we create a session without the custom
+                                 * payload properties
                                  */
                             }
 
@@ -248,9 +248,9 @@ func main() {
                             } else {
                                 /**
                                 * This is possible if the function is triggerred from the user management dashboard
-                                * OR if the function was called internally from the SDK
                                 * 
-                                * In this case set a reasonable default value to use
+                                * In this case because we cannot read the JWT, we create a session without the custom
+                                * payload properties
                                 */
                             }
 
@@ -293,9 +293,9 @@ def override_functions(original_implementation: RecipeInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
-            # In this case set a reasonable default value to use
+            # In this case because we cannot read the JWT, we create a session without the custom
+            # payload properties
             #
             jwt=None
 

--- a/v2/passwordless/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/passwordless/common-customizations/sessions/anonymous-session.mdx
@@ -164,19 +164,33 @@ SuperTokens.init({
                         createNewSession: async function (input) {
                             let userId = input.userId;
 
-                            let jwt = input.userContext._default.request.getCookieValue("jwt");
+                            const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                            let jwt: string | undefined
+                            let jwtPayload = {}
+
+                            if (request !== undefined) {
+                                jwt = request.getCookieValue("jwt");
+                            } else {
+                                /**
+                                 * This is possible if the function is triggerred from the user management dashboard
+                                 * OR if the function was called internally from the SDK
+                                 * 
+                                 * In this case set a reasonable default value to use
+                                 */
+                            }
 
                             if (jwt !== undefined) {
                                 // verify JWT using a JWT verification library..
 
-                                let jwtPayload = { /* ... get from decoded jwt ... */};
-
-                                // This goes in the access token, and is availble to read on the frontend.
-                                input.accessTokenPayload = {
-                                    ...input.accessTokenPayload,
-                                    ...jwtPayload
-                                };
+                                jwtPayload = { /* ... get from decoded jwt ... */};
                             }
+
+                            // This goes in the access token, and is availble to read on the frontend.
+                            input.accessTokenPayload = {
+                                ...input.accessTokenPayload,
+                                ...jwtPayload
+                            };
 
                             return originalImplementation.createNewSession(input);
                         },
@@ -212,24 +226,35 @@ func main() {
 
 						// Now we override the CreateNewSession function
 						(*originalImplementation.CreateNewSession) = func(userID string, accessTokenPayload, sessionDataInDatabase map[string]interface{}, disableAntiCsrf *bool, userContext supertokens.UserContext) (sessmodels.SessionContainer, error) {
+                            request := supertokens.GetRequestFromUserContext(userContext)
 
-							jwt, err := (*userContext)["_default"].(map[string]interface{})["request"].(*http.Request).Cookie("jwt")
-							if err != nil {
-								return nil, err
-							}
+                            if (request != nil) {
+                                jwt, err := request.Cookie("jwt")
 
-							if jwt != nil {
-								// verify JWT using a jwt verification library..
-								decodedJWT := map[string]interface{}{
-									// from JWT verification lib
-								}
+                                if err != nil {
+                                    return nil, err
+                                }
 
-								// This goes in the access token, and is availble to read on the frontend.
-								if accessTokenPayload == nil {
-									accessTokenPayload = map[string]interface{}{}
-								}
-								accessTokenPayload["someKey"] = decodedJWT["someKey"]
-							}
+                                if jwt != nil {
+                                    // verify JWT using a jwt verification library..
+                                    decodedJWT := map[string]interface{}{
+                                        // from JWT verification lib
+                                    }
+
+                                    // This goes in the access token, and is availble to read on the frontend.
+                                    if accessTokenPayload == nil {
+                                        accessTokenPayload = map[string]interface{}{}
+                                    }
+                                    accessTokenPayload["someKey"] = decodedJWT["someKey"]
+                                }
+                            } else {
+                                /**
+                                * This is possible if the function is triggerred from the user management dashboard
+                                * OR if the function was called internally from the SDK
+                                * 
+                                * In this case set a reasonable default value to use
+                                */
+                            }
 
 							return originalCreateNewSession(userID, accessTokenPayload, sessionDataInDatabase, disableAntiCsrf, userContext)
 						}
@@ -262,7 +287,18 @@ def override_functions(original_implementation: RecipeInterface):
                                  disable_anti_csrf: Optional[bool],
                                  user_context: Dict[str, Any]):
 
-        jwt = user_context["_default"]["request"].get_cookie("jwt")
+        request=get_request_from_user_context(user_context)
+        jwt: Optional[str]
+
+        if request is not None:
+            jwt=request.get_cookie("jwt")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
 
         if jwt is not None:
             # verify JWT using a JWT verification library..

--- a/v2/passwordless/sidebars.js
+++ b/v2/passwordless/sidebars.js
@@ -455,6 +455,7 @@ module.exports = {
           label: 'Actions, Hooks and Custom API responses',
           items: [
             "advanced-customizations/overview",
+            "advanced-customizations/user-context/custom-request-properties",
             {
               type: 'category',
               label: 'React component override',

--- a/v2/session/advanced-customizations/frontend-hooks/pre-api.mdx
+++ b/v2/session/advanced-customizations/frontend-hooks/pre-api.mdx
@@ -266,3 +266,13 @@ void main() {
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+
+<!-- COPY SECTION -->
+<!-- ./emailpassword/advanced-customizations/frontend-hooks/pre-api.mdx -->
+<!-- 1 -->
+
+## Reading custom request information in the backend
+
+Visit [this page](../user-context/custom-request-properties) to learn how to read custom headers etc from the request on the backend.
+
+<!-- END COPY SECTION -->

--- a/v2/session/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/session/advanced-customizations/user-context/custom-request-properties.mdx
@@ -145,9 +145,11 @@ Session.init({
 We use the `GetRequestFromUserContext` function provided by the SDK to get the request object from the user context.
 
 ```go
-"github.com/supertokens/supertokens-golang/recipe/session"
-"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
-"github.com/supertokens/supertokens-golang/supertokens"
+import (
+    "github.com/supertokens/supertokens-golang/recipe/session"
+    "github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+    "github.com/supertokens/supertokens-golang/supertokens"
+)
 
 func main() {
     session.Init(&sessmodels.TypeInput{

--- a/v2/session/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/session/advanced-customizations/user-context/custom-request-properties.mdx
@@ -87,7 +87,6 @@ Session.init({
                     } else {
                         /**
                          * This is possible if the function is triggerred from the user management dashboard
-                         * OR if the function was called internally from the SDK
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -120,7 +119,6 @@ Session.init({
                     } else {
                         /**
                          * This is possible if the function is triggerred from the user management dashboard
-                         * OR if the function was called internally from the SDK
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -167,7 +165,6 @@ func main() {
                     } else {
                         /**
                         * This is possible if the function is triggerred from the user management dashboard
-                        * OR if the function was called internally from the SDK
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -197,7 +194,6 @@ func main() {
                     } else {
                         /**
                         * This is possible if the function is triggerred from the user management dashboard
-                        * OR if the function was called internally from the SDK
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -243,7 +239,6 @@ def override_session_functions(original_implementation: RecipeInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
             # In this case set a reasonable default value to use
             #
@@ -271,7 +266,6 @@ def override_session_apis(original_implementation: APIInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
             # In this case set a reasonable default value to use
             #

--- a/v2/session/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/session/advanced-customizations/user-context/custom-request-properties.mdx
@@ -1,0 +1,296 @@
+---
+id: custom-request-properties
+title: Adding and reading custom request properties
+hide_title: true
+---
+
+<!-- COPY DOCS -->
+<!-- ./emailpassword/advanced-customizations/user-context/custom-request-properties.mdx -->
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
+import TabItem from '@theme/TabItem';
+
+# Adding and reading custom request properties
+
+When using the APIs exposed by the SuperTokens SDKs, you may want to pass custom information to your backend. You can leverage our pre api hook, overrides and user context features to achieve this by:
+1. Using the pre api hook to add custom information to network requests made by our frontend SDKs
+2. Using the overrides feature to provide custom handling for APIs and functions in the backend SDK
+3. Using the user context feature in the backend to access to original request and consuming any custom information
+
+## Adding custom information to requests on the frontend
+
+You can use our [pre api hook feature](../frontend-hooks/pre-api) to add custom information to network requests made by the frontend SDKs.
+
+For example let us consider a React app using `supertokens-auth-react` where we add some custom header whenever the user signs out:
+
+```tsx
+import Session from "supertokens-auth-react/recipe/session";
+
+Session.init({
+    preAPIHook: async (context) => {
+        let requestInit = context.requestInit;
+
+        if (context.action === "SIGN_OUT") {
+            let headers = {
+                ...requestInit.headers,
+                customHeader: "customvalue,"
+            };
+            requestInit = {
+                ...requestInit,
+                headers,
+            }
+        }
+
+        return {
+            url: context.url,
+            requestInit,
+        };
+    }
+})
+```
+
+:::info
+Refer to the [pre api hook documentation](../frontend-hooks/pre-api) to learn how to do this for our other frontend SDKs
+:::
+
+## Reading custom request information in the backend
+
+To read information on the backend we need to use either the [API overrides feature](../apis-override/about.mdx) or the [backend function override feature](../backend-functions-override/about.mdx). We override the API/function we want to read the information in, get the original request object and then read the query/body to consume the custom property.
+
+Let us continue the example we used above, we need to read the headers from the request and read the value of `customHeader`. This will involve:
+- Overriding either the `revokeSession` function or the `signOutPOST` API of the session recipe
+- Getting the request object from the user context
+- Reading the custom header value
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+We use the `getRequestFromUserContext` function provided by the SDK to get the request object from the user context.
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+Session.init({
+    override: {
+        functions: (oI) => {
+            return {
+                ...oI,
+                revokeSession: async (input) => {
+                    // highlight-start
+                    let customHeaderValue = "";
+                    const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                    if (request !== undefined) {
+                        //@ts-ignore
+                        customHeaderValue = request.getHeaderValue("customHeader");
+                    } else {
+                        /**
+                         * This is possible if the function is triggerred from the user management dashboard
+                         * OR if the function was called internally from the SDK
+                         * 
+                         * In this case set a reasonable default value to use
+                         */
+                        customHeaderValue = "default";
+                    }
+
+                    // highlight-end
+
+                    // Perform custom logic based on the value of customHeaderValue
+
+                    return oI.revokeSession(input);
+                },
+            };
+        },
+        apis: (oI) => {
+            return {
+                ...oI,
+                signOutPOST: async (input) => {
+                    if (oI.signOutPOST === undefined) {
+                        throw Error("Signout API is disabled");
+                    }
+
+                    // highlight-start
+                    let customHeaderValue = "";
+                    const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                    if (request !== undefined) {
+                        //@ts-ignore
+                        customHeaderValue = request.getHeaderValue("customHeader");
+                    } else {
+                        /**
+                         * This is possible if the function is triggerred from the user management dashboard
+                         * OR if the function was called internally from the SDK
+                         * 
+                         * In this case set a reasonable default value to use
+                         */
+                        customHeaderValue = "default";
+                    }
+
+                    // highlight-end
+
+                    // Perform custom logic based on the value of customHeaderValue
+
+                    return oI.signOutPOST(input);
+                },
+            };
+        }
+    },
+})
+```
+
+</TabItem>
+<TabItem value="go">
+
+We use the `GetRequestFromUserContext` function provided by the SDK to get the request object from the user context.
+
+```go
+"github.com/supertokens/supertokens-golang/recipe/session"
+"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+"github.com/supertokens/supertokens-golang/supertokens"
+
+func main() {
+    session.Init(&sessmodels.TypeInput{
+        Override: &sessmodels.OverrideStruct{
+            Functions: func(originalImplementation sessmodels.RecipeInterface) sessmodels.RecipeInterface {
+                originalRevokeSession := *originalImplementation.RevokeSession
+
+                *originalImplementation.RevokeSession = func(sessionHandle string, userContext supertokens.UserContext) (bool, error) {
+                    // highlight-start
+                    customHeadervalue := ""
+                    request := supertokens.GetRequestFromUserContext(userContext)
+
+                    if request != nil {
+                        customHeadervalue = request.Header.Get("customHeader")
+                    } else {
+                        /**
+                        * This is possible if the function is triggerred from the user management dashboard
+                        * OR if the function was called internally from the SDK
+                        * 
+                        * In this case set a reasonable default value to use
+                        */
+                        customHeadervalue = "default";
+                    }
+                    // highlight-end
+
+                    print(customHeadervalue)
+
+                    // Perform custom logic based on the value of customHeadervalue
+
+                    return originalRevokeSession(sessionHandle, userContext)
+                }
+
+                return originalImplementation
+            },
+            APIs: func(originalImplementation sessmodels.APIInterface) sessmodels.APIInterface {
+                originalSignOutPost := *originalImplementation.SignOutPOST
+
+                *originalImplementation.SignOutPOST = func(sessionContainer sessmodels.SessionContainer, options sessmodels.APIOptions, userContext supertokens.UserContext) (sessmodels.SignOutPOSTResponse, error) {
+                    // highlight-start
+                    customHeadervalue := ""
+                    request := supertokens.GetRequestFromUserContext(userContext)
+
+                    if request != nil {
+                        customHeadervalue = request.Header.Get("customHeader")
+                    } else {
+                        /**
+                        * This is possible if the function is triggerred from the user management dashboard
+                        * OR if the function was called internally from the SDK
+                        * 
+                        * In this case set a reasonable default value to use
+                        */
+                        customHeadervalue = "default";
+                    }
+                    // highlight-end
+
+                    print(customHeadervalue)
+
+                    // Perform custom logic based on the value of customHeadervalue
+
+                    return originalSignOutPost(sessionContainer, options, userContext)
+                }
+
+                return originalImplementation
+            },
+        },
+    })
+}
+```
+
+</TabItem>
+<TabItem value="python">
+
+We use the `get_request_from_user_context` function provided by the SDK to get the request object from the user context.
+
+```python
+from supertokens_python import get_request_from_user_context
+from supertokens_python.recipe import session
+from supertokens_python.recipe.session.interfaces import RecipeInterface, APIInterface, APIOptions
+from typing import Any, Dict, Optional
+
+def override_session_functions(original_implementation: RecipeInterface):
+    original_revoke_session = original_implementation.revoke_session
+
+    async def revoke_session(session_handle: str, user_context: Dict[str, Any]):
+        # highlight-start
+        request=get_request_from_user_context(user_context)
+        customHeaderValue=""
+
+        if request is not None:
+            customHeaderValue=request.get_header("customHeader")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
+            customHeaderValue="default"
+        # highlight-end
+        
+        print(customHeaderValue)
+        # Perform custom logic based on the value of customHeadervalue
+
+        return await original_revoke_session(session_handle, user_context)
+
+    original_implementation.revoke_session = revoke_session
+    return original_implementation
+
+def override_session_apis(original_implementation: APIInterface):
+    original_signout_post = original_implementation.signout_post
+
+    async def signout_post(session: Optional[session.SessionContainer], api_options: APIOptions, user_context: Dict[str, Any]):
+        # highlight-start
+        request=get_request_from_user_context(user_context)
+        customHeaderValue=""
+
+        if request is not None:
+            customHeaderValue=request.get_header("customHeader")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
+            customHeaderValue="default"
+        # highlight-end
+        
+        print(customHeaderValue)
+        # Perform custom logic based on the value of customHeadervalue
+
+        return await original_signout_post(session, api_options, user_context)
+
+    original_implementation.signout_post = signout_post
+    return original_implementation
+
+session.init(
+    override=session.InputOverrideConfig(
+        functions=override_session_functions,
+        apis=override_session_apis
+    ),
+)
+```
+
+</TabItem>
+</BackendSDKTabs>

--- a/v2/session/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/session/common-customizations/sessions/anonymous-session.mdx
@@ -270,7 +270,7 @@ func main() {
 <TabItem value="python">
 
 ```python
-from supertokens_python import init, InputAppInfo
+from supertokens_python import init, InputAppInfo, get_request_from_user_context
 from supertokens_python.recipe import session
 from supertokens_python.recipe.session.interfaces import RecipeInterface
 from typing import Any, Dict, Optional
@@ -286,7 +286,7 @@ def override_functions(original_implementation: RecipeInterface):
                                  user_context: Dict[str, Any]):
 
         request=get_request_from_user_context(user_context)
-        jwt: Optional[str]
+        jwt: Optional[str] = None
 
         if request is not None:
             jwt=request.get_cookie("jwt")
@@ -297,6 +297,7 @@ def override_functions(original_implementation: RecipeInterface):
             # 
             # In this case set a reasonable default value to use
             #
+            jwt=None
 
         if jwt is not None:
             # verify JWT using a JWT verification library..

--- a/v2/session/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/session/common-customizations/sessions/anonymous-session.mdx
@@ -207,8 +207,6 @@ SuperTokens.init({
 
 ```go
 import (
-	"net/http"
-
 	"github.com/supertokens/supertokens-golang/recipe/session"
 	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"

--- a/v2/session/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/session/common-customizations/sessions/anonymous-session.mdx
@@ -174,9 +174,9 @@ SuperTokens.init({
                             } else {
                                 /**
                                  * This is possible if the function is triggerred from the user management dashboard
-                                 * OR if the function was called internally from the SDK
                                  * 
-                                 * In this case set a reasonable default value to use
+                                 * In this case because we cannot read the JWT, we create a session without the custom
+                                 * payload properties
                                  */
                             }
 
@@ -248,9 +248,9 @@ func main() {
                             } else {
                                 /**
                                 * This is possible if the function is triggerred from the user management dashboard
-                                * OR if the function was called internally from the SDK
                                 * 
-                                * In this case set a reasonable default value to use
+                                * In this case because we cannot read the JWT, we create a session without the custom
+                                * payload properties
                                 */
                             }
 
@@ -293,9 +293,9 @@ def override_functions(original_implementation: RecipeInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
-            # In this case set a reasonable default value to use
+            # In this case because we cannot read the JWT, we create a session without the custom
+            # payload properties
             #
             jwt=None
 

--- a/v2/session/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/session/common-customizations/sessions/anonymous-session.mdx
@@ -164,19 +164,33 @@ SuperTokens.init({
                         createNewSession: async function (input) {
                             let userId = input.userId;
 
-                            let jwt = input.userContext._default.request.getCookieValue("jwt");
+                            const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                            let jwt: string | undefined
+                            let jwtPayload = {}
+
+                            if (request !== undefined) {
+                                jwt = request.getCookieValue("jwt");
+                            } else {
+                                /**
+                                 * This is possible if the function is triggerred from the user management dashboard
+                                 * OR if the function was called internally from the SDK
+                                 * 
+                                 * In this case set a reasonable default value to use
+                                 */
+                            }
 
                             if (jwt !== undefined) {
                                 // verify JWT using a JWT verification library..
 
-                                let jwtPayload = { /* ... get from decoded jwt ... */};
-
-                                // This goes in the access token, and is availble to read on the frontend.
-                                input.accessTokenPayload = {
-                                    ...input.accessTokenPayload,
-                                    ...jwtPayload
-                                };
+                                jwtPayload = { /* ... get from decoded jwt ... */};
                             }
+
+                            // This goes in the access token, and is availble to read on the frontend.
+                            input.accessTokenPayload = {
+                                ...input.accessTokenPayload,
+                                ...jwtPayload
+                            };
 
                             return originalImplementation.createNewSession(input);
                         },
@@ -212,24 +226,35 @@ func main() {
 
 						// Now we override the CreateNewSession function
 						(*originalImplementation.CreateNewSession) = func(userID string, accessTokenPayload, sessionDataInDatabase map[string]interface{}, disableAntiCsrf *bool, userContext supertokens.UserContext) (sessmodels.SessionContainer, error) {
+                            request := supertokens.GetRequestFromUserContext(userContext)
 
-							jwt, err := (*userContext)["_default"].(map[string]interface{})["request"].(*http.Request).Cookie("jwt")
-							if err != nil {
-								return nil, err
-							}
+                            if (request != nil) {
+                                jwt, err := request.Cookie("jwt")
 
-							if jwt != nil {
-								// verify JWT using a jwt verification library..
-								decodedJWT := map[string]interface{}{
-									// from JWT verification lib
-								}
+                                if err != nil {
+                                    return nil, err
+                                }
 
-								// This goes in the access token, and is availble to read on the frontend.
-								if accessTokenPayload == nil {
-									accessTokenPayload = map[string]interface{}{}
-								}
-								accessTokenPayload["someKey"] = decodedJWT["someKey"]
-							}
+                                if jwt != nil {
+                                    // verify JWT using a jwt verification library..
+                                    decodedJWT := map[string]interface{}{
+                                        // from JWT verification lib
+                                    }
+
+                                    // This goes in the access token, and is availble to read on the frontend.
+                                    if accessTokenPayload == nil {
+                                        accessTokenPayload = map[string]interface{}{}
+                                    }
+                                    accessTokenPayload["someKey"] = decodedJWT["someKey"]
+                                }
+                            } else {
+                                /**
+                                * This is possible if the function is triggerred from the user management dashboard
+                                * OR if the function was called internally from the SDK
+                                * 
+                                * In this case set a reasonable default value to use
+                                */
+                            }
 
 							return originalCreateNewSession(userID, accessTokenPayload, sessionDataInDatabase, disableAntiCsrf, userContext)
 						}
@@ -262,7 +287,18 @@ def override_functions(original_implementation: RecipeInterface):
                                  disable_anti_csrf: Optional[bool],
                                  user_context: Dict[str, Any]):
 
-        jwt = user_context["_default"]["request"].get_cookie("jwt")
+        request=get_request_from_user_context(user_context)
+        jwt: Optional[str]
+
+        if request is not None:
+            jwt=request.get_cookie("jwt")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
 
         if jwt is not None:
             # verify JWT using a JWT verification library..

--- a/v2/session/sidebars.js
+++ b/v2/session/sidebars.js
@@ -225,6 +225,7 @@ module.exports = {
           label: 'Actions, Hooks and Custom API responses',
           items: [
             "advanced-customizations/overview",
+            "advanced-customizations/user-context/custom-request-properties",
             {
               type: 'category',
               label: 'Frontend functions override',

--- a/v2/src/plugins/codeTypeChecking/goEnv/go.mod
+++ b/v2/src/plugins/codeTypeChecking/goEnv/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-chi/cors v1.2.1
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
-	github.com/supertokens/supertokens-golang v0.12.0
+	github.com/supertokens/supertokens-golang v0.12.4
 )
 
 require (

--- a/v2/src/plugins/codeTypeChecking/goEnv/go.sum
+++ b/v2/src/plugins/codeTypeChecking/goEnv/go.sum
@@ -95,8 +95,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/supertokens/supertokens-golang v0.12.0 h1:uIk+dqQ8XofRbG7apk4ZeqjlErHE52/HOdd4L2cAMEQ=
-github.com/supertokens/supertokens-golang v0.12.0/go.mod h1:Gqo2Uqu6xJ1uswLR/KXKkpurVqVa1uFMevOSRgCNAMg=
+github.com/supertokens/supertokens-golang v0.12.4 h1:P/WMikMOK3jXAgD1SoDzWssB5RQ5sh50AZpycPxjivw=
+github.com/supertokens/supertokens-golang v0.12.4/go.mod h1:Gqo2Uqu6xJ1uswLR/KXKkpurVqVa1uFMevOSRgCNAMg=
 github.com/twilio/twilio-go v0.26.0 h1:wFW4oTe3/LKt6bvByP7eio8JsjtaLHjMQKOUEzQry7U=
 github.com/twilio/twilio-go v0.26.0/go.mod h1:lz62Hopu4vicpQ056H5TJ0JE4AP0rS3sQ35/ejmgOwE=
 github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=

--- a/v2/src/plugins/codeTypeChecking/jsEnv/package.json
+++ b/v2/src/plugins/codeTypeChecking/jsEnv/package.json
@@ -52,7 +52,7 @@
     "socket.io": "^4.6.1",
     "socketio": "^1.0.0",
     "supertokens-auth-react": "^0.32.3",
-    "supertokens-node": "^14.0.0",
+    "supertokens-node": "^14.1.0",
     "supertokens-node7": "npm:supertokens-node@7.3",
     "supertokens-react-native": "^4.0.0",
     "supertokens-web-js": "^0.5.0",

--- a/v2/src/plugins/codeTypeChecking/pythonEnv/requirements.txt
+++ b/v2/src/plugins/codeTypeChecking/pythonEnv/requirements.txt
@@ -70,7 +70,7 @@ six==1.16.0
 sniffio==1.3.0
 sqlparse==0.4.2
 starlette==0.14.2
-supertokens-python @ git+https://github.com/supertokens/supertokens-python.git@98efe744b4a5adc6c6f4489d28c2915ac6be9829
+supertokens-python @ git+https://github.com/supertokens/supertokens-python.git@v0.14.1
 tldextract==3.1.0
 toml==0.10.2
 tomli==2.0.1

--- a/v2/thirdparty/advanced-customizations/frontend-hooks/pre-api.mdx
+++ b/v2/thirdparty/advanced-customizations/frontend-hooks/pre-api.mdx
@@ -312,3 +312,13 @@ void main() {
 
 </PreBuiltOrCustomUISwitcher>
 
+<!-- COPY SECTION -->
+<!-- ./emailpassword/advanced-customizations/frontend-hooks/pre-api.mdx -->
+<!-- 1 -->
+
+## Reading custom request information in the backend
+
+Visit [this page](../user-context/custom-request-properties) to learn how to read custom headers etc from the request on the backend.
+
+<!-- END COPY SECTION -->
+

--- a/v2/thirdparty/advanced-customizations/user-context.mdx
+++ b/v2/thirdparty/advanced-customizations/user-context.mdx
@@ -6,7 +6,6 @@ hide_title: true
 
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import TabItem from '@theme/TabItem';
-import DefaultContext from "../../emailpassword/reusableMD/user-context-default.mdx"
 
 # User Context
 
@@ -463,6 +462,14 @@ As a summary, when the sign up API is called, the initial value of `userContext`
 
 When that is called, that function checks if `isSignUp === true`, and if it is, it doesn't call the original implementation, and instead, just returns an empty session. This way, we don't create a session if the user is signing up, but we do create one if the user is signing in.
 
+<!-- COPY SECTION -->
+<!-- ./emailpassword/advanced-customizations/user-context.mdx -->
+<!-- 1 -->
+
 ## Default information in the user context object
 
-<DefaultContext />
+By default the user context passed to APIs and functions contains the request object that can be used to read custom headers, body/query params etc.
+
+To learn more on how you can use the default user context to consume custom request information [visit this page](./user-context/custom-request-properties).
+
+<!-- END COPY SECTION -->

--- a/v2/thirdparty/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/thirdparty/advanced-customizations/user-context/custom-request-properties.mdx
@@ -145,9 +145,11 @@ Session.init({
 We use the `GetRequestFromUserContext` function provided by the SDK to get the request object from the user context.
 
 ```go
-"github.com/supertokens/supertokens-golang/recipe/session"
-"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
-"github.com/supertokens/supertokens-golang/supertokens"
+import (
+    "github.com/supertokens/supertokens-golang/recipe/session"
+    "github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+    "github.com/supertokens/supertokens-golang/supertokens"
+)
 
 func main() {
     session.Init(&sessmodels.TypeInput{

--- a/v2/thirdparty/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/thirdparty/advanced-customizations/user-context/custom-request-properties.mdx
@@ -87,7 +87,6 @@ Session.init({
                     } else {
                         /**
                          * This is possible if the function is triggerred from the user management dashboard
-                         * OR if the function was called internally from the SDK
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -120,7 +119,6 @@ Session.init({
                     } else {
                         /**
                          * This is possible if the function is triggerred from the user management dashboard
-                         * OR if the function was called internally from the SDK
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -167,7 +165,6 @@ func main() {
                     } else {
                         /**
                         * This is possible if the function is triggerred from the user management dashboard
-                        * OR if the function was called internally from the SDK
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -197,7 +194,6 @@ func main() {
                     } else {
                         /**
                         * This is possible if the function is triggerred from the user management dashboard
-                        * OR if the function was called internally from the SDK
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -243,7 +239,6 @@ def override_session_functions(original_implementation: RecipeInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
             # In this case set a reasonable default value to use
             #
@@ -271,7 +266,6 @@ def override_session_apis(original_implementation: APIInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
             # In this case set a reasonable default value to use
             #

--- a/v2/thirdparty/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/thirdparty/advanced-customizations/user-context/custom-request-properties.mdx
@@ -1,0 +1,296 @@
+---
+id: custom-request-properties
+title: Adding and reading custom request properties
+hide_title: true
+---
+
+<!-- COPY DOCS -->
+<!-- ./emailpassword/advanced-customizations/user-context/custom-request-properties.mdx -->
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
+import TabItem from '@theme/TabItem';
+
+# Adding and reading custom request properties
+
+When using the APIs exposed by the SuperTokens SDKs, you may want to pass custom information to your backend. You can leverage our pre api hook, overrides and user context features to achieve this by:
+1. Using the pre api hook to add custom information to network requests made by our frontend SDKs
+2. Using the overrides feature to provide custom handling for APIs and functions in the backend SDK
+3. Using the user context feature in the backend to access to original request and consuming any custom information
+
+## Adding custom information to requests on the frontend
+
+You can use our [pre api hook feature](../frontend-hooks/pre-api) to add custom information to network requests made by the frontend SDKs.
+
+For example let us consider a React app using `supertokens-auth-react` where we add some custom header whenever the user signs out:
+
+```tsx
+import Session from "supertokens-auth-react/recipe/session";
+
+Session.init({
+    preAPIHook: async (context) => {
+        let requestInit = context.requestInit;
+
+        if (context.action === "SIGN_OUT") {
+            let headers = {
+                ...requestInit.headers,
+                customHeader: "customvalue,"
+            };
+            requestInit = {
+                ...requestInit,
+                headers,
+            }
+        }
+
+        return {
+            url: context.url,
+            requestInit,
+        };
+    }
+})
+```
+
+:::info
+Refer to the [pre api hook documentation](../frontend-hooks/pre-api) to learn how to do this for our other frontend SDKs
+:::
+
+## Reading custom request information in the backend
+
+To read information on the backend we need to use either the [API overrides feature](../apis-override/about.mdx) or the [backend function override feature](../backend-functions-override/about.mdx). We override the API/function we want to read the information in, get the original request object and then read the query/body to consume the custom property.
+
+Let us continue the example we used above, we need to read the headers from the request and read the value of `customHeader`. This will involve:
+- Overriding either the `revokeSession` function or the `signOutPOST` API of the session recipe
+- Getting the request object from the user context
+- Reading the custom header value
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+We use the `getRequestFromUserContext` function provided by the SDK to get the request object from the user context.
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+Session.init({
+    override: {
+        functions: (oI) => {
+            return {
+                ...oI,
+                revokeSession: async (input) => {
+                    // highlight-start
+                    let customHeaderValue = "";
+                    const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                    if (request !== undefined) {
+                        //@ts-ignore
+                        customHeaderValue = request.getHeaderValue("customHeader");
+                    } else {
+                        /**
+                         * This is possible if the function is triggerred from the user management dashboard
+                         * OR if the function was called internally from the SDK
+                         * 
+                         * In this case set a reasonable default value to use
+                         */
+                        customHeaderValue = "default";
+                    }
+
+                    // highlight-end
+
+                    // Perform custom logic based on the value of customHeaderValue
+
+                    return oI.revokeSession(input);
+                },
+            };
+        },
+        apis: (oI) => {
+            return {
+                ...oI,
+                signOutPOST: async (input) => {
+                    if (oI.signOutPOST === undefined) {
+                        throw Error("Signout API is disabled");
+                    }
+
+                    // highlight-start
+                    let customHeaderValue = "";
+                    const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                    if (request !== undefined) {
+                        //@ts-ignore
+                        customHeaderValue = request.getHeaderValue("customHeader");
+                    } else {
+                        /**
+                         * This is possible if the function is triggerred from the user management dashboard
+                         * OR if the function was called internally from the SDK
+                         * 
+                         * In this case set a reasonable default value to use
+                         */
+                        customHeaderValue = "default";
+                    }
+
+                    // highlight-end
+
+                    // Perform custom logic based on the value of customHeaderValue
+
+                    return oI.signOutPOST(input);
+                },
+            };
+        }
+    },
+})
+```
+
+</TabItem>
+<TabItem value="go">
+
+We use the `GetRequestFromUserContext` function provided by the SDK to get the request object from the user context.
+
+```go
+"github.com/supertokens/supertokens-golang/recipe/session"
+"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+"github.com/supertokens/supertokens-golang/supertokens"
+
+func main() {
+    session.Init(&sessmodels.TypeInput{
+        Override: &sessmodels.OverrideStruct{
+            Functions: func(originalImplementation sessmodels.RecipeInterface) sessmodels.RecipeInterface {
+                originalRevokeSession := *originalImplementation.RevokeSession
+
+                *originalImplementation.RevokeSession = func(sessionHandle string, userContext supertokens.UserContext) (bool, error) {
+                    // highlight-start
+                    customHeadervalue := ""
+                    request := supertokens.GetRequestFromUserContext(userContext)
+
+                    if request != nil {
+                        customHeadervalue = request.Header.Get("customHeader")
+                    } else {
+                        /**
+                        * This is possible if the function is triggerred from the user management dashboard
+                        * OR if the function was called internally from the SDK
+                        * 
+                        * In this case set a reasonable default value to use
+                        */
+                        customHeadervalue = "default";
+                    }
+                    // highlight-end
+
+                    print(customHeadervalue)
+
+                    // Perform custom logic based on the value of customHeadervalue
+
+                    return originalRevokeSession(sessionHandle, userContext)
+                }
+
+                return originalImplementation
+            },
+            APIs: func(originalImplementation sessmodels.APIInterface) sessmodels.APIInterface {
+                originalSignOutPost := *originalImplementation.SignOutPOST
+
+                *originalImplementation.SignOutPOST = func(sessionContainer sessmodels.SessionContainer, options sessmodels.APIOptions, userContext supertokens.UserContext) (sessmodels.SignOutPOSTResponse, error) {
+                    // highlight-start
+                    customHeadervalue := ""
+                    request := supertokens.GetRequestFromUserContext(userContext)
+
+                    if request != nil {
+                        customHeadervalue = request.Header.Get("customHeader")
+                    } else {
+                        /**
+                        * This is possible if the function is triggerred from the user management dashboard
+                        * OR if the function was called internally from the SDK
+                        * 
+                        * In this case set a reasonable default value to use
+                        */
+                        customHeadervalue = "default";
+                    }
+                    // highlight-end
+
+                    print(customHeadervalue)
+
+                    // Perform custom logic based on the value of customHeadervalue
+
+                    return originalSignOutPost(sessionContainer, options, userContext)
+                }
+
+                return originalImplementation
+            },
+        },
+    })
+}
+```
+
+</TabItem>
+<TabItem value="python">
+
+We use the `get_request_from_user_context` function provided by the SDK to get the request object from the user context.
+
+```python
+from supertokens_python import get_request_from_user_context
+from supertokens_python.recipe import session
+from supertokens_python.recipe.session.interfaces import RecipeInterface, APIInterface, APIOptions
+from typing import Any, Dict, Optional
+
+def override_session_functions(original_implementation: RecipeInterface):
+    original_revoke_session = original_implementation.revoke_session
+
+    async def revoke_session(session_handle: str, user_context: Dict[str, Any]):
+        # highlight-start
+        request=get_request_from_user_context(user_context)
+        customHeaderValue=""
+
+        if request is not None:
+            customHeaderValue=request.get_header("customHeader")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
+            customHeaderValue="default"
+        # highlight-end
+        
+        print(customHeaderValue)
+        # Perform custom logic based on the value of customHeadervalue
+
+        return await original_revoke_session(session_handle, user_context)
+
+    original_implementation.revoke_session = revoke_session
+    return original_implementation
+
+def override_session_apis(original_implementation: APIInterface):
+    original_signout_post = original_implementation.signout_post
+
+    async def signout_post(session: Optional[session.SessionContainer], api_options: APIOptions, user_context: Dict[str, Any]):
+        # highlight-start
+        request=get_request_from_user_context(user_context)
+        customHeaderValue=""
+
+        if request is not None:
+            customHeaderValue=request.get_header("customHeader")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
+            customHeaderValue="default"
+        # highlight-end
+        
+        print(customHeaderValue)
+        # Perform custom logic based on the value of customHeadervalue
+
+        return await original_signout_post(session, api_options, user_context)
+
+    original_implementation.signout_post = signout_post
+    return original_implementation
+
+session.init(
+    override=session.InputOverrideConfig(
+        functions=override_session_functions,
+        apis=override_session_apis
+    ),
+)
+```
+
+</TabItem>
+</BackendSDKTabs>

--- a/v2/thirdparty/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdparty/common-customizations/sessions/anonymous-session.mdx
@@ -270,7 +270,7 @@ func main() {
 <TabItem value="python">
 
 ```python
-from supertokens_python import init, InputAppInfo
+from supertokens_python import init, InputAppInfo, get_request_from_user_context
 from supertokens_python.recipe import session
 from supertokens_python.recipe.session.interfaces import RecipeInterface
 from typing import Any, Dict, Optional
@@ -286,7 +286,7 @@ def override_functions(original_implementation: RecipeInterface):
                                  user_context: Dict[str, Any]):
 
         request=get_request_from_user_context(user_context)
-        jwt: Optional[str]
+        jwt: Optional[str] = None
 
         if request is not None:
             jwt=request.get_cookie("jwt")
@@ -297,6 +297,7 @@ def override_functions(original_implementation: RecipeInterface):
             # 
             # In this case set a reasonable default value to use
             #
+            jwt=None
 
         if jwt is not None:
             # verify JWT using a JWT verification library..

--- a/v2/thirdparty/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdparty/common-customizations/sessions/anonymous-session.mdx
@@ -207,8 +207,6 @@ SuperTokens.init({
 
 ```go
 import (
-	"net/http"
-
 	"github.com/supertokens/supertokens-golang/recipe/session"
 	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"

--- a/v2/thirdparty/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdparty/common-customizations/sessions/anonymous-session.mdx
@@ -174,9 +174,9 @@ SuperTokens.init({
                             } else {
                                 /**
                                  * This is possible if the function is triggerred from the user management dashboard
-                                 * OR if the function was called internally from the SDK
                                  * 
-                                 * In this case set a reasonable default value to use
+                                 * In this case because we cannot read the JWT, we create a session without the custom
+                                 * payload properties
                                  */
                             }
 
@@ -248,9 +248,9 @@ func main() {
                             } else {
                                 /**
                                 * This is possible if the function is triggerred from the user management dashboard
-                                * OR if the function was called internally from the SDK
                                 * 
-                                * In this case set a reasonable default value to use
+                                * In this case because we cannot read the JWT, we create a session without the custom
+                                * payload properties
                                 */
                             }
 
@@ -293,9 +293,9 @@ def override_functions(original_implementation: RecipeInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
-            # In this case set a reasonable default value to use
+            # In this case because we cannot read the JWT, we create a session without the custom
+            # payload properties
             #
             jwt=None
 

--- a/v2/thirdparty/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdparty/common-customizations/sessions/anonymous-session.mdx
@@ -164,19 +164,33 @@ SuperTokens.init({
                         createNewSession: async function (input) {
                             let userId = input.userId;
 
-                            let jwt = input.userContext._default.request.getCookieValue("jwt");
+                            const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                            let jwt: string | undefined
+                            let jwtPayload = {}
+
+                            if (request !== undefined) {
+                                jwt = request.getCookieValue("jwt");
+                            } else {
+                                /**
+                                 * This is possible if the function is triggerred from the user management dashboard
+                                 * OR if the function was called internally from the SDK
+                                 * 
+                                 * In this case set a reasonable default value to use
+                                 */
+                            }
 
                             if (jwt !== undefined) {
                                 // verify JWT using a JWT verification library..
 
-                                let jwtPayload = { /* ... get from decoded jwt ... */};
-
-                                // This goes in the access token, and is availble to read on the frontend.
-                                input.accessTokenPayload = {
-                                    ...input.accessTokenPayload,
-                                    ...jwtPayload
-                                };
+                                jwtPayload = { /* ... get from decoded jwt ... */};
                             }
+
+                            // This goes in the access token, and is availble to read on the frontend.
+                            input.accessTokenPayload = {
+                                ...input.accessTokenPayload,
+                                ...jwtPayload
+                            };
 
                             return originalImplementation.createNewSession(input);
                         },
@@ -212,24 +226,35 @@ func main() {
 
 						// Now we override the CreateNewSession function
 						(*originalImplementation.CreateNewSession) = func(userID string, accessTokenPayload, sessionDataInDatabase map[string]interface{}, disableAntiCsrf *bool, userContext supertokens.UserContext) (sessmodels.SessionContainer, error) {
+                            request := supertokens.GetRequestFromUserContext(userContext)
 
-							jwt, err := (*userContext)["_default"].(map[string]interface{})["request"].(*http.Request).Cookie("jwt")
-							if err != nil {
-								return nil, err
-							}
+                            if (request != nil) {
+                                jwt, err := request.Cookie("jwt")
 
-							if jwt != nil {
-								// verify JWT using a jwt verification library..
-								decodedJWT := map[string]interface{}{
-									// from JWT verification lib
-								}
+                                if err != nil {
+                                    return nil, err
+                                }
 
-								// This goes in the access token, and is availble to read on the frontend.
-								if accessTokenPayload == nil {
-									accessTokenPayload = map[string]interface{}{}
-								}
-								accessTokenPayload["someKey"] = decodedJWT["someKey"]
-							}
+                                if jwt != nil {
+                                    // verify JWT using a jwt verification library..
+                                    decodedJWT := map[string]interface{}{
+                                        // from JWT verification lib
+                                    }
+
+                                    // This goes in the access token, and is availble to read on the frontend.
+                                    if accessTokenPayload == nil {
+                                        accessTokenPayload = map[string]interface{}{}
+                                    }
+                                    accessTokenPayload["someKey"] = decodedJWT["someKey"]
+                                }
+                            } else {
+                                /**
+                                * This is possible if the function is triggerred from the user management dashboard
+                                * OR if the function was called internally from the SDK
+                                * 
+                                * In this case set a reasonable default value to use
+                                */
+                            }
 
 							return originalCreateNewSession(userID, accessTokenPayload, sessionDataInDatabase, disableAntiCsrf, userContext)
 						}
@@ -262,7 +287,18 @@ def override_functions(original_implementation: RecipeInterface):
                                  disable_anti_csrf: Optional[bool],
                                  user_context: Dict[str, Any]):
 
-        jwt = user_context["_default"]["request"].get_cookie("jwt")
+        request=get_request_from_user_context(user_context)
+        jwt: Optional[str]
+
+        if request is not None:
+            jwt=request.get_cookie("jwt")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
 
         if jwt is not None:
             # verify JWT using a JWT verification library..

--- a/v2/thirdparty/sidebars.js
+++ b/v2/thirdparty/sidebars.js
@@ -440,6 +440,7 @@ module.exports = {
           label: 'Actions, Hooks and Custom API responses',
           items: [
             "advanced-customizations/overview",
+            "advanced-customizations/user-context/custom-request-properties",
             {
               type: 'category',
               label: 'React component override',

--- a/v2/thirdpartyemailpassword/advanced-customizations/frontend-hooks/pre-api.mdx
+++ b/v2/thirdpartyemailpassword/advanced-customizations/frontend-hooks/pre-api.mdx
@@ -344,3 +344,13 @@ void main() {
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+
+<!-- COPY SECTION -->
+<!-- ./emailpassword/advanced-customizations/frontend-hooks/pre-api.mdx -->
+<!-- 1 -->
+
+## Reading custom request information in the backend
+
+Visit [this page](../user-context/custom-request-properties) to learn how to read custom headers etc from the request on the backend.
+
+<!-- END COPY SECTION -->

--- a/v2/thirdpartyemailpassword/advanced-customizations/user-context.mdx
+++ b/v2/thirdpartyemailpassword/advanced-customizations/user-context.mdx
@@ -6,7 +6,6 @@ hide_title: true
 
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import TabItem from '@theme/TabItem';
-import DefaultContext from "../../emailpassword/reusableMD/user-context-default.mdx"
 
 # User Context
 
@@ -495,6 +494,14 @@ When that is called, that function checks if `isSignUp === true`, and if it is, 
 
 Note that there are other ways of achiving this, but the above showcases how we can use user context to communicate across recipes and across API & Recipe functions.
 
+<!-- COPY SECTION -->
+<!-- ./emailpassword/advanced-customizations/user-context.mdx -->
+<!-- 1 -->
+
 ## Default information in the user context object
 
-<DefaultContext />
+By default the user context passed to APIs and functions contains the request object that can be used to read custom headers, body/query params etc.
+
+To learn more on how you can use the default user context to consume custom request information [visit this page](./user-context/custom-request-properties).
+
+<!-- END COPY SECTION -->

--- a/v2/thirdpartyemailpassword/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/thirdpartyemailpassword/advanced-customizations/user-context/custom-request-properties.mdx
@@ -145,9 +145,11 @@ Session.init({
 We use the `GetRequestFromUserContext` function provided by the SDK to get the request object from the user context.
 
 ```go
-"github.com/supertokens/supertokens-golang/recipe/session"
-"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
-"github.com/supertokens/supertokens-golang/supertokens"
+import (
+    "github.com/supertokens/supertokens-golang/recipe/session"
+    "github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+    "github.com/supertokens/supertokens-golang/supertokens"
+)
 
 func main() {
     session.Init(&sessmodels.TypeInput{

--- a/v2/thirdpartyemailpassword/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/thirdpartyemailpassword/advanced-customizations/user-context/custom-request-properties.mdx
@@ -87,7 +87,6 @@ Session.init({
                     } else {
                         /**
                          * This is possible if the function is triggerred from the user management dashboard
-                         * OR if the function was called internally from the SDK
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -120,7 +119,6 @@ Session.init({
                     } else {
                         /**
                          * This is possible if the function is triggerred from the user management dashboard
-                         * OR if the function was called internally from the SDK
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -167,7 +165,6 @@ func main() {
                     } else {
                         /**
                         * This is possible if the function is triggerred from the user management dashboard
-                        * OR if the function was called internally from the SDK
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -197,7 +194,6 @@ func main() {
                     } else {
                         /**
                         * This is possible if the function is triggerred from the user management dashboard
-                        * OR if the function was called internally from the SDK
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -243,7 +239,6 @@ def override_session_functions(original_implementation: RecipeInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
             # In this case set a reasonable default value to use
             #
@@ -271,7 +266,6 @@ def override_session_apis(original_implementation: APIInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
             # In this case set a reasonable default value to use
             #

--- a/v2/thirdpartyemailpassword/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/thirdpartyemailpassword/advanced-customizations/user-context/custom-request-properties.mdx
@@ -1,0 +1,296 @@
+---
+id: custom-request-properties
+title: Adding and reading custom request properties
+hide_title: true
+---
+
+<!-- COPY DOCS -->
+<!-- ./emailpassword/advanced-customizations/user-context/custom-request-properties.mdx -->
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
+import TabItem from '@theme/TabItem';
+
+# Adding and reading custom request properties
+
+When using the APIs exposed by the SuperTokens SDKs, you may want to pass custom information to your backend. You can leverage our pre api hook, overrides and user context features to achieve this by:
+1. Using the pre api hook to add custom information to network requests made by our frontend SDKs
+2. Using the overrides feature to provide custom handling for APIs and functions in the backend SDK
+3. Using the user context feature in the backend to access to original request and consuming any custom information
+
+## Adding custom information to requests on the frontend
+
+You can use our [pre api hook feature](../frontend-hooks/pre-api) to add custom information to network requests made by the frontend SDKs.
+
+For example let us consider a React app using `supertokens-auth-react` where we add some custom header whenever the user signs out:
+
+```tsx
+import Session from "supertokens-auth-react/recipe/session";
+
+Session.init({
+    preAPIHook: async (context) => {
+        let requestInit = context.requestInit;
+
+        if (context.action === "SIGN_OUT") {
+            let headers = {
+                ...requestInit.headers,
+                customHeader: "customvalue,"
+            };
+            requestInit = {
+                ...requestInit,
+                headers,
+            }
+        }
+
+        return {
+            url: context.url,
+            requestInit,
+        };
+    }
+})
+```
+
+:::info
+Refer to the [pre api hook documentation](../frontend-hooks/pre-api) to learn how to do this for our other frontend SDKs
+:::
+
+## Reading custom request information in the backend
+
+To read information on the backend we need to use either the [API overrides feature](../apis-override/about.mdx) or the [backend function override feature](../backend-functions-override/about.mdx). We override the API/function we want to read the information in, get the original request object and then read the query/body to consume the custom property.
+
+Let us continue the example we used above, we need to read the headers from the request and read the value of `customHeader`. This will involve:
+- Overriding either the `revokeSession` function or the `signOutPOST` API of the session recipe
+- Getting the request object from the user context
+- Reading the custom header value
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+We use the `getRequestFromUserContext` function provided by the SDK to get the request object from the user context.
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+Session.init({
+    override: {
+        functions: (oI) => {
+            return {
+                ...oI,
+                revokeSession: async (input) => {
+                    // highlight-start
+                    let customHeaderValue = "";
+                    const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                    if (request !== undefined) {
+                        //@ts-ignore
+                        customHeaderValue = request.getHeaderValue("customHeader");
+                    } else {
+                        /**
+                         * This is possible if the function is triggerred from the user management dashboard
+                         * OR if the function was called internally from the SDK
+                         * 
+                         * In this case set a reasonable default value to use
+                         */
+                        customHeaderValue = "default";
+                    }
+
+                    // highlight-end
+
+                    // Perform custom logic based on the value of customHeaderValue
+
+                    return oI.revokeSession(input);
+                },
+            };
+        },
+        apis: (oI) => {
+            return {
+                ...oI,
+                signOutPOST: async (input) => {
+                    if (oI.signOutPOST === undefined) {
+                        throw Error("Signout API is disabled");
+                    }
+
+                    // highlight-start
+                    let customHeaderValue = "";
+                    const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                    if (request !== undefined) {
+                        //@ts-ignore
+                        customHeaderValue = request.getHeaderValue("customHeader");
+                    } else {
+                        /**
+                         * This is possible if the function is triggerred from the user management dashboard
+                         * OR if the function was called internally from the SDK
+                         * 
+                         * In this case set a reasonable default value to use
+                         */
+                        customHeaderValue = "default";
+                    }
+
+                    // highlight-end
+
+                    // Perform custom logic based on the value of customHeaderValue
+
+                    return oI.signOutPOST(input);
+                },
+            };
+        }
+    },
+})
+```
+
+</TabItem>
+<TabItem value="go">
+
+We use the `GetRequestFromUserContext` function provided by the SDK to get the request object from the user context.
+
+```go
+"github.com/supertokens/supertokens-golang/recipe/session"
+"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+"github.com/supertokens/supertokens-golang/supertokens"
+
+func main() {
+    session.Init(&sessmodels.TypeInput{
+        Override: &sessmodels.OverrideStruct{
+            Functions: func(originalImplementation sessmodels.RecipeInterface) sessmodels.RecipeInterface {
+                originalRevokeSession := *originalImplementation.RevokeSession
+
+                *originalImplementation.RevokeSession = func(sessionHandle string, userContext supertokens.UserContext) (bool, error) {
+                    // highlight-start
+                    customHeadervalue := ""
+                    request := supertokens.GetRequestFromUserContext(userContext)
+
+                    if request != nil {
+                        customHeadervalue = request.Header.Get("customHeader")
+                    } else {
+                        /**
+                        * This is possible if the function is triggerred from the user management dashboard
+                        * OR if the function was called internally from the SDK
+                        * 
+                        * In this case set a reasonable default value to use
+                        */
+                        customHeadervalue = "default";
+                    }
+                    // highlight-end
+
+                    print(customHeadervalue)
+
+                    // Perform custom logic based on the value of customHeadervalue
+
+                    return originalRevokeSession(sessionHandle, userContext)
+                }
+
+                return originalImplementation
+            },
+            APIs: func(originalImplementation sessmodels.APIInterface) sessmodels.APIInterface {
+                originalSignOutPost := *originalImplementation.SignOutPOST
+
+                *originalImplementation.SignOutPOST = func(sessionContainer sessmodels.SessionContainer, options sessmodels.APIOptions, userContext supertokens.UserContext) (sessmodels.SignOutPOSTResponse, error) {
+                    // highlight-start
+                    customHeadervalue := ""
+                    request := supertokens.GetRequestFromUserContext(userContext)
+
+                    if request != nil {
+                        customHeadervalue = request.Header.Get("customHeader")
+                    } else {
+                        /**
+                        * This is possible if the function is triggerred from the user management dashboard
+                        * OR if the function was called internally from the SDK
+                        * 
+                        * In this case set a reasonable default value to use
+                        */
+                        customHeadervalue = "default";
+                    }
+                    // highlight-end
+
+                    print(customHeadervalue)
+
+                    // Perform custom logic based on the value of customHeadervalue
+
+                    return originalSignOutPost(sessionContainer, options, userContext)
+                }
+
+                return originalImplementation
+            },
+        },
+    })
+}
+```
+
+</TabItem>
+<TabItem value="python">
+
+We use the `get_request_from_user_context` function provided by the SDK to get the request object from the user context.
+
+```python
+from supertokens_python import get_request_from_user_context
+from supertokens_python.recipe import session
+from supertokens_python.recipe.session.interfaces import RecipeInterface, APIInterface, APIOptions
+from typing import Any, Dict, Optional
+
+def override_session_functions(original_implementation: RecipeInterface):
+    original_revoke_session = original_implementation.revoke_session
+
+    async def revoke_session(session_handle: str, user_context: Dict[str, Any]):
+        # highlight-start
+        request=get_request_from_user_context(user_context)
+        customHeaderValue=""
+
+        if request is not None:
+            customHeaderValue=request.get_header("customHeader")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
+            customHeaderValue="default"
+        # highlight-end
+        
+        print(customHeaderValue)
+        # Perform custom logic based on the value of customHeadervalue
+
+        return await original_revoke_session(session_handle, user_context)
+
+    original_implementation.revoke_session = revoke_session
+    return original_implementation
+
+def override_session_apis(original_implementation: APIInterface):
+    original_signout_post = original_implementation.signout_post
+
+    async def signout_post(session: Optional[session.SessionContainer], api_options: APIOptions, user_context: Dict[str, Any]):
+        # highlight-start
+        request=get_request_from_user_context(user_context)
+        customHeaderValue=""
+
+        if request is not None:
+            customHeaderValue=request.get_header("customHeader")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
+            customHeaderValue="default"
+        # highlight-end
+        
+        print(customHeaderValue)
+        # Perform custom logic based on the value of customHeadervalue
+
+        return await original_signout_post(session, api_options, user_context)
+
+    original_implementation.signout_post = signout_post
+    return original_implementation
+
+session.init(
+    override=session.InputOverrideConfig(
+        functions=override_session_functions,
+        apis=override_session_apis
+    ),
+)
+```
+
+</TabItem>
+</BackendSDKTabs>

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/anonymous-session.mdx
@@ -270,7 +270,7 @@ func main() {
 <TabItem value="python">
 
 ```python
-from supertokens_python import init, InputAppInfo
+from supertokens_python import init, InputAppInfo, get_request_from_user_context
 from supertokens_python.recipe import session
 from supertokens_python.recipe.session.interfaces import RecipeInterface
 from typing import Any, Dict, Optional
@@ -286,7 +286,7 @@ def override_functions(original_implementation: RecipeInterface):
                                  user_context: Dict[str, Any]):
 
         request=get_request_from_user_context(user_context)
-        jwt: Optional[str]
+        jwt: Optional[str] = None
 
         if request is not None:
             jwt=request.get_cookie("jwt")
@@ -297,6 +297,7 @@ def override_functions(original_implementation: RecipeInterface):
             # 
             # In this case set a reasonable default value to use
             #
+            jwt=None
 
         if jwt is not None:
             # verify JWT using a JWT verification library..

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/anonymous-session.mdx
@@ -207,8 +207,6 @@ SuperTokens.init({
 
 ```go
 import (
-	"net/http"
-
 	"github.com/supertokens/supertokens-golang/recipe/session"
 	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/anonymous-session.mdx
@@ -174,9 +174,9 @@ SuperTokens.init({
                             } else {
                                 /**
                                  * This is possible if the function is triggerred from the user management dashboard
-                                 * OR if the function was called internally from the SDK
                                  * 
-                                 * In this case set a reasonable default value to use
+                                 * In this case because we cannot read the JWT, we create a session without the custom
+                                 * payload properties
                                  */
                             }
 
@@ -248,9 +248,9 @@ func main() {
                             } else {
                                 /**
                                 * This is possible if the function is triggerred from the user management dashboard
-                                * OR if the function was called internally from the SDK
                                 * 
-                                * In this case set a reasonable default value to use
+                                * In this case because we cannot read the JWT, we create a session without the custom
+                                * payload properties
                                 */
                             }
 
@@ -293,9 +293,9 @@ def override_functions(original_implementation: RecipeInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
-            # In this case set a reasonable default value to use
+            # In this case because we cannot read the JWT, we create a session without the custom
+            # payload properties
             #
             jwt=None
 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/anonymous-session.mdx
@@ -164,19 +164,33 @@ SuperTokens.init({
                         createNewSession: async function (input) {
                             let userId = input.userId;
 
-                            let jwt = input.userContext._default.request.getCookieValue("jwt");
+                            const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                            let jwt: string | undefined
+                            let jwtPayload = {}
+
+                            if (request !== undefined) {
+                                jwt = request.getCookieValue("jwt");
+                            } else {
+                                /**
+                                 * This is possible if the function is triggerred from the user management dashboard
+                                 * OR if the function was called internally from the SDK
+                                 * 
+                                 * In this case set a reasonable default value to use
+                                 */
+                            }
 
                             if (jwt !== undefined) {
                                 // verify JWT using a JWT verification library..
 
-                                let jwtPayload = { /* ... get from decoded jwt ... */};
-
-                                // This goes in the access token, and is availble to read on the frontend.
-                                input.accessTokenPayload = {
-                                    ...input.accessTokenPayload,
-                                    ...jwtPayload
-                                };
+                                jwtPayload = { /* ... get from decoded jwt ... */};
                             }
+
+                            // This goes in the access token, and is availble to read on the frontend.
+                            input.accessTokenPayload = {
+                                ...input.accessTokenPayload,
+                                ...jwtPayload
+                            };
 
                             return originalImplementation.createNewSession(input);
                         },
@@ -212,24 +226,35 @@ func main() {
 
 						// Now we override the CreateNewSession function
 						(*originalImplementation.CreateNewSession) = func(userID string, accessTokenPayload, sessionDataInDatabase map[string]interface{}, disableAntiCsrf *bool, userContext supertokens.UserContext) (sessmodels.SessionContainer, error) {
+                            request := supertokens.GetRequestFromUserContext(userContext)
 
-							jwt, err := (*userContext)["_default"].(map[string]interface{})["request"].(*http.Request).Cookie("jwt")
-							if err != nil {
-								return nil, err
-							}
+                            if (request != nil) {
+                                jwt, err := request.Cookie("jwt")
 
-							if jwt != nil {
-								// verify JWT using a jwt verification library..
-								decodedJWT := map[string]interface{}{
-									// from JWT verification lib
-								}
+                                if err != nil {
+                                    return nil, err
+                                }
 
-								// This goes in the access token, and is availble to read on the frontend.
-								if accessTokenPayload == nil {
-									accessTokenPayload = map[string]interface{}{}
-								}
-								accessTokenPayload["someKey"] = decodedJWT["someKey"]
-							}
+                                if jwt != nil {
+                                    // verify JWT using a jwt verification library..
+                                    decodedJWT := map[string]interface{}{
+                                        // from JWT verification lib
+                                    }
+
+                                    // This goes in the access token, and is availble to read on the frontend.
+                                    if accessTokenPayload == nil {
+                                        accessTokenPayload = map[string]interface{}{}
+                                    }
+                                    accessTokenPayload["someKey"] = decodedJWT["someKey"]
+                                }
+                            } else {
+                                /**
+                                * This is possible if the function is triggerred from the user management dashboard
+                                * OR if the function was called internally from the SDK
+                                * 
+                                * In this case set a reasonable default value to use
+                                */
+                            }
 
 							return originalCreateNewSession(userID, accessTokenPayload, sessionDataInDatabase, disableAntiCsrf, userContext)
 						}
@@ -262,7 +287,18 @@ def override_functions(original_implementation: RecipeInterface):
                                  disable_anti_csrf: Optional[bool],
                                  user_context: Dict[str, Any]):
 
-        jwt = user_context["_default"]["request"].get_cookie("jwt")
+        request=get_request_from_user_context(user_context)
+        jwt: Optional[str]
+
+        if request is not None:
+            jwt=request.get_cookie("jwt")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
 
         if jwt is not None:
             # verify JWT using a JWT verification library..

--- a/v2/thirdpartyemailpassword/sidebars.js
+++ b/v2/thirdpartyemailpassword/sidebars.js
@@ -481,6 +481,7 @@ module.exports = {
           label: 'Actions, Hooks and Custom API responses',
           items: [
             "advanced-customizations/overview",
+            "advanced-customizations/user-context/custom-request-properties",
             {
               type: 'category',
               label: 'React component override',

--- a/v2/thirdpartypasswordless/advanced-customizations/frontend-hooks/pre-api.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/frontend-hooks/pre-api.mdx
@@ -332,3 +332,13 @@ void main() {
 
 </PreBuiltOrCustomUISwitcher>
 
+<!-- COPY SECTION -->
+<!-- ./emailpassword/advanced-customizations/frontend-hooks/pre-api.mdx -->
+<!-- 1 -->
+
+## Reading custom request information in the backend
+
+Visit [this page](../user-context/custom-request-properties) to learn how to read custom headers etc from the request on the backend.
+
+<!-- END COPY SECTION -->
+

--- a/v2/thirdpartypasswordless/advanced-customizations/user-context.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/user-context.mdx
@@ -6,7 +6,6 @@ hide_title: true
 
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import TabItem from '@theme/TabItem';
-import DefaultContext from "../../emailpassword/reusableMD/user-context-default.mdx"
 
 # User Context
 
@@ -527,6 +526,14 @@ As a summary, when the sign up API is called, the initial value of `userContext`
 
 When that is called, that function checks if `isSignUp === true`, and if it is, it doesn't call the original implementation, and instead, just returns an empty session. This way, we don't create a session if the user is signing up, but we do create one if the user is signing in.
 
+<!-- COPY SECTION -->
+<!-- ./emailpassword/advanced-customizations/user-context.mdx -->
+<!-- 1 -->
+
 ## Default information in the user context object
 
-<DefaultContext />
+By default the user context passed to APIs and functions contains the request object that can be used to read custom headers, body/query params etc.
+
+To learn more on how you can use the default user context to consume custom request information [visit this page](./user-context/custom-request-properties).
+
+<!-- END COPY SECTION -->

--- a/v2/thirdpartypasswordless/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/user-context/custom-request-properties.mdx
@@ -145,9 +145,11 @@ Session.init({
 We use the `GetRequestFromUserContext` function provided by the SDK to get the request object from the user context.
 
 ```go
-"github.com/supertokens/supertokens-golang/recipe/session"
-"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
-"github.com/supertokens/supertokens-golang/supertokens"
+import (
+    "github.com/supertokens/supertokens-golang/recipe/session"
+    "github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+    "github.com/supertokens/supertokens-golang/supertokens"
+)
 
 func main() {
     session.Init(&sessmodels.TypeInput{

--- a/v2/thirdpartypasswordless/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/user-context/custom-request-properties.mdx
@@ -87,7 +87,6 @@ Session.init({
                     } else {
                         /**
                          * This is possible if the function is triggerred from the user management dashboard
-                         * OR if the function was called internally from the SDK
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -120,7 +119,6 @@ Session.init({
                     } else {
                         /**
                          * This is possible if the function is triggerred from the user management dashboard
-                         * OR if the function was called internally from the SDK
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -167,7 +165,6 @@ func main() {
                     } else {
                         /**
                         * This is possible if the function is triggerred from the user management dashboard
-                        * OR if the function was called internally from the SDK
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -197,7 +194,6 @@ func main() {
                     } else {
                         /**
                         * This is possible if the function is triggerred from the user management dashboard
-                        * OR if the function was called internally from the SDK
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -243,7 +239,6 @@ def override_session_functions(original_implementation: RecipeInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
             # In this case set a reasonable default value to use
             #
@@ -271,7 +266,6 @@ def override_session_apis(original_implementation: APIInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
             # In this case set a reasonable default value to use
             #

--- a/v2/thirdpartypasswordless/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/user-context/custom-request-properties.mdx
@@ -1,0 +1,296 @@
+---
+id: custom-request-properties
+title: Adding and reading custom request properties
+hide_title: true
+---
+
+<!-- COPY DOCS -->
+<!-- ./emailpassword/advanced-customizations/user-context/custom-request-properties.mdx -->
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
+import TabItem from '@theme/TabItem';
+
+# Adding and reading custom request properties
+
+When using the APIs exposed by the SuperTokens SDKs, you may want to pass custom information to your backend. You can leverage our pre api hook, overrides and user context features to achieve this by:
+1. Using the pre api hook to add custom information to network requests made by our frontend SDKs
+2. Using the overrides feature to provide custom handling for APIs and functions in the backend SDK
+3. Using the user context feature in the backend to access to original request and consuming any custom information
+
+## Adding custom information to requests on the frontend
+
+You can use our [pre api hook feature](../frontend-hooks/pre-api) to add custom information to network requests made by the frontend SDKs.
+
+For example let us consider a React app using `supertokens-auth-react` where we add some custom header whenever the user signs out:
+
+```tsx
+import Session from "supertokens-auth-react/recipe/session";
+
+Session.init({
+    preAPIHook: async (context) => {
+        let requestInit = context.requestInit;
+
+        if (context.action === "SIGN_OUT") {
+            let headers = {
+                ...requestInit.headers,
+                customHeader: "customvalue,"
+            };
+            requestInit = {
+                ...requestInit,
+                headers,
+            }
+        }
+
+        return {
+            url: context.url,
+            requestInit,
+        };
+    }
+})
+```
+
+:::info
+Refer to the [pre api hook documentation](../frontend-hooks/pre-api) to learn how to do this for our other frontend SDKs
+:::
+
+## Reading custom request information in the backend
+
+To read information on the backend we need to use either the [API overrides feature](../apis-override/about.mdx) or the [backend function override feature](../backend-functions-override/about.mdx). We override the API/function we want to read the information in, get the original request object and then read the query/body to consume the custom property.
+
+Let us continue the example we used above, we need to read the headers from the request and read the value of `customHeader`. This will involve:
+- Overriding either the `revokeSession` function or the `signOutPOST` API of the session recipe
+- Getting the request object from the user context
+- Reading the custom header value
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+We use the `getRequestFromUserContext` function provided by the SDK to get the request object from the user context.
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+Session.init({
+    override: {
+        functions: (oI) => {
+            return {
+                ...oI,
+                revokeSession: async (input) => {
+                    // highlight-start
+                    let customHeaderValue = "";
+                    const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                    if (request !== undefined) {
+                        //@ts-ignore
+                        customHeaderValue = request.getHeaderValue("customHeader");
+                    } else {
+                        /**
+                         * This is possible if the function is triggerred from the user management dashboard
+                         * OR if the function was called internally from the SDK
+                         * 
+                         * In this case set a reasonable default value to use
+                         */
+                        customHeaderValue = "default";
+                    }
+
+                    // highlight-end
+
+                    // Perform custom logic based on the value of customHeaderValue
+
+                    return oI.revokeSession(input);
+                },
+            };
+        },
+        apis: (oI) => {
+            return {
+                ...oI,
+                signOutPOST: async (input) => {
+                    if (oI.signOutPOST === undefined) {
+                        throw Error("Signout API is disabled");
+                    }
+
+                    // highlight-start
+                    let customHeaderValue = "";
+                    const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                    if (request !== undefined) {
+                        //@ts-ignore
+                        customHeaderValue = request.getHeaderValue("customHeader");
+                    } else {
+                        /**
+                         * This is possible if the function is triggerred from the user management dashboard
+                         * OR if the function was called internally from the SDK
+                         * 
+                         * In this case set a reasonable default value to use
+                         */
+                        customHeaderValue = "default";
+                    }
+
+                    // highlight-end
+
+                    // Perform custom logic based on the value of customHeaderValue
+
+                    return oI.signOutPOST(input);
+                },
+            };
+        }
+    },
+})
+```
+
+</TabItem>
+<TabItem value="go">
+
+We use the `GetRequestFromUserContext` function provided by the SDK to get the request object from the user context.
+
+```go
+"github.com/supertokens/supertokens-golang/recipe/session"
+"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+"github.com/supertokens/supertokens-golang/supertokens"
+
+func main() {
+    session.Init(&sessmodels.TypeInput{
+        Override: &sessmodels.OverrideStruct{
+            Functions: func(originalImplementation sessmodels.RecipeInterface) sessmodels.RecipeInterface {
+                originalRevokeSession := *originalImplementation.RevokeSession
+
+                *originalImplementation.RevokeSession = func(sessionHandle string, userContext supertokens.UserContext) (bool, error) {
+                    // highlight-start
+                    customHeadervalue := ""
+                    request := supertokens.GetRequestFromUserContext(userContext)
+
+                    if request != nil {
+                        customHeadervalue = request.Header.Get("customHeader")
+                    } else {
+                        /**
+                        * This is possible if the function is triggerred from the user management dashboard
+                        * OR if the function was called internally from the SDK
+                        * 
+                        * In this case set a reasonable default value to use
+                        */
+                        customHeadervalue = "default";
+                    }
+                    // highlight-end
+
+                    print(customHeadervalue)
+
+                    // Perform custom logic based on the value of customHeadervalue
+
+                    return originalRevokeSession(sessionHandle, userContext)
+                }
+
+                return originalImplementation
+            },
+            APIs: func(originalImplementation sessmodels.APIInterface) sessmodels.APIInterface {
+                originalSignOutPost := *originalImplementation.SignOutPOST
+
+                *originalImplementation.SignOutPOST = func(sessionContainer sessmodels.SessionContainer, options sessmodels.APIOptions, userContext supertokens.UserContext) (sessmodels.SignOutPOSTResponse, error) {
+                    // highlight-start
+                    customHeadervalue := ""
+                    request := supertokens.GetRequestFromUserContext(userContext)
+
+                    if request != nil {
+                        customHeadervalue = request.Header.Get("customHeader")
+                    } else {
+                        /**
+                        * This is possible if the function is triggerred from the user management dashboard
+                        * OR if the function was called internally from the SDK
+                        * 
+                        * In this case set a reasonable default value to use
+                        */
+                        customHeadervalue = "default";
+                    }
+                    // highlight-end
+
+                    print(customHeadervalue)
+
+                    // Perform custom logic based on the value of customHeadervalue
+
+                    return originalSignOutPost(sessionContainer, options, userContext)
+                }
+
+                return originalImplementation
+            },
+        },
+    })
+}
+```
+
+</TabItem>
+<TabItem value="python">
+
+We use the `get_request_from_user_context` function provided by the SDK to get the request object from the user context.
+
+```python
+from supertokens_python import get_request_from_user_context
+from supertokens_python.recipe import session
+from supertokens_python.recipe.session.interfaces import RecipeInterface, APIInterface, APIOptions
+from typing import Any, Dict, Optional
+
+def override_session_functions(original_implementation: RecipeInterface):
+    original_revoke_session = original_implementation.revoke_session
+
+    async def revoke_session(session_handle: str, user_context: Dict[str, Any]):
+        # highlight-start
+        request=get_request_from_user_context(user_context)
+        customHeaderValue=""
+
+        if request is not None:
+            customHeaderValue=request.get_header("customHeader")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
+            customHeaderValue="default"
+        # highlight-end
+        
+        print(customHeaderValue)
+        # Perform custom logic based on the value of customHeadervalue
+
+        return await original_revoke_session(session_handle, user_context)
+
+    original_implementation.revoke_session = revoke_session
+    return original_implementation
+
+def override_session_apis(original_implementation: APIInterface):
+    original_signout_post = original_implementation.signout_post
+
+    async def signout_post(session: Optional[session.SessionContainer], api_options: APIOptions, user_context: Dict[str, Any]):
+        # highlight-start
+        request=get_request_from_user_context(user_context)
+        customHeaderValue=""
+
+        if request is not None:
+            customHeaderValue=request.get_header("customHeader")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
+            customHeaderValue="default"
+        # highlight-end
+        
+        print(customHeaderValue)
+        # Perform custom logic based on the value of customHeadervalue
+
+        return await original_signout_post(session, api_options, user_context)
+
+    original_implementation.signout_post = signout_post
+    return original_implementation
+
+session.init(
+    override=session.InputOverrideConfig(
+        functions=override_session_functions,
+        apis=override_session_apis
+    ),
+)
+```
+
+</TabItem>
+</BackendSDKTabs>

--- a/v2/thirdpartypasswordless/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/anonymous-session.mdx
@@ -270,7 +270,7 @@ func main() {
 <TabItem value="python">
 
 ```python
-from supertokens_python import init, InputAppInfo
+from supertokens_python import init, InputAppInfo, get_request_from_user_context
 from supertokens_python.recipe import session
 from supertokens_python.recipe.session.interfaces import RecipeInterface
 from typing import Any, Dict, Optional
@@ -286,7 +286,7 @@ def override_functions(original_implementation: RecipeInterface):
                                  user_context: Dict[str, Any]):
 
         request=get_request_from_user_context(user_context)
-        jwt: Optional[str]
+        jwt: Optional[str] = None
 
         if request is not None:
             jwt=request.get_cookie("jwt")
@@ -297,6 +297,7 @@ def override_functions(original_implementation: RecipeInterface):
             # 
             # In this case set a reasonable default value to use
             #
+            jwt=None
 
         if jwt is not None:
             # verify JWT using a JWT verification library..

--- a/v2/thirdpartypasswordless/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/anonymous-session.mdx
@@ -207,8 +207,6 @@ SuperTokens.init({
 
 ```go
 import (
-	"net/http"
-
 	"github.com/supertokens/supertokens-golang/recipe/session"
 	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"

--- a/v2/thirdpartypasswordless/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/anonymous-session.mdx
@@ -174,9 +174,9 @@ SuperTokens.init({
                             } else {
                                 /**
                                  * This is possible if the function is triggerred from the user management dashboard
-                                 * OR if the function was called internally from the SDK
                                  * 
-                                 * In this case set a reasonable default value to use
+                                 * In this case because we cannot read the JWT, we create a session without the custom
+                                 * payload properties
                                  */
                             }
 
@@ -248,9 +248,9 @@ func main() {
                             } else {
                                 /**
                                 * This is possible if the function is triggerred from the user management dashboard
-                                * OR if the function was called internally from the SDK
                                 * 
-                                * In this case set a reasonable default value to use
+                                * In this case because we cannot read the JWT, we create a session without the custom
+                                * payload properties
                                 */
                             }
 
@@ -293,9 +293,9 @@ def override_functions(original_implementation: RecipeInterface):
         else:
             #
             # This is possible if the function is triggerred from the user management dashboard
-            # OR if the function was called internally from the SDK
             # 
-            # In this case set a reasonable default value to use
+            # In this case because we cannot read the JWT, we create a session without the custom
+            # payload properties
             #
             jwt=None
 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/anonymous-session.mdx
@@ -164,19 +164,33 @@ SuperTokens.init({
                         createNewSession: async function (input) {
                             let userId = input.userId;
 
-                            let jwt = input.userContext._default.request.getCookieValue("jwt");
+                            const request = SuperTokens.getRequestFromUserContext(input.userContext);
+
+                            let jwt: string | undefined
+                            let jwtPayload = {}
+
+                            if (request !== undefined) {
+                                jwt = request.getCookieValue("jwt");
+                            } else {
+                                /**
+                                 * This is possible if the function is triggerred from the user management dashboard
+                                 * OR if the function was called internally from the SDK
+                                 * 
+                                 * In this case set a reasonable default value to use
+                                 */
+                            }
 
                             if (jwt !== undefined) {
                                 // verify JWT using a JWT verification library..
 
-                                let jwtPayload = { /* ... get from decoded jwt ... */};
-
-                                // This goes in the access token, and is availble to read on the frontend.
-                                input.accessTokenPayload = {
-                                    ...input.accessTokenPayload,
-                                    ...jwtPayload
-                                };
+                                jwtPayload = { /* ... get from decoded jwt ... */};
                             }
+
+                            // This goes in the access token, and is availble to read on the frontend.
+                            input.accessTokenPayload = {
+                                ...input.accessTokenPayload,
+                                ...jwtPayload
+                            };
 
                             return originalImplementation.createNewSession(input);
                         },
@@ -212,24 +226,35 @@ func main() {
 
 						// Now we override the CreateNewSession function
 						(*originalImplementation.CreateNewSession) = func(userID string, accessTokenPayload, sessionDataInDatabase map[string]interface{}, disableAntiCsrf *bool, userContext supertokens.UserContext) (sessmodels.SessionContainer, error) {
+                            request := supertokens.GetRequestFromUserContext(userContext)
 
-							jwt, err := (*userContext)["_default"].(map[string]interface{})["request"].(*http.Request).Cookie("jwt")
-							if err != nil {
-								return nil, err
-							}
+                            if (request != nil) {
+                                jwt, err := request.Cookie("jwt")
 
-							if jwt != nil {
-								// verify JWT using a jwt verification library..
-								decodedJWT := map[string]interface{}{
-									// from JWT verification lib
-								}
+                                if err != nil {
+                                    return nil, err
+                                }
 
-								// This goes in the access token, and is availble to read on the frontend.
-								if accessTokenPayload == nil {
-									accessTokenPayload = map[string]interface{}{}
-								}
-								accessTokenPayload["someKey"] = decodedJWT["someKey"]
-							}
+                                if jwt != nil {
+                                    // verify JWT using a jwt verification library..
+                                    decodedJWT := map[string]interface{}{
+                                        // from JWT verification lib
+                                    }
+
+                                    // This goes in the access token, and is availble to read on the frontend.
+                                    if accessTokenPayload == nil {
+                                        accessTokenPayload = map[string]interface{}{}
+                                    }
+                                    accessTokenPayload["someKey"] = decodedJWT["someKey"]
+                                }
+                            } else {
+                                /**
+                                * This is possible if the function is triggerred from the user management dashboard
+                                * OR if the function was called internally from the SDK
+                                * 
+                                * In this case set a reasonable default value to use
+                                */
+                            }
 
 							return originalCreateNewSession(userID, accessTokenPayload, sessionDataInDatabase, disableAntiCsrf, userContext)
 						}
@@ -262,7 +287,18 @@ def override_functions(original_implementation: RecipeInterface):
                                  disable_anti_csrf: Optional[bool],
                                  user_context: Dict[str, Any]):
 
-        jwt = user_context["_default"]["request"].get_cookie("jwt")
+        request=get_request_from_user_context(user_context)
+        jwt: Optional[str]
+
+        if request is not None:
+            jwt=request.get_cookie("jwt")
+        else:
+            #
+            # This is possible if the function is triggerred from the user management dashboard
+            # OR if the function was called internally from the SDK
+            # 
+            # In this case set a reasonable default value to use
+            #
 
         if jwt is not None:
             # verify JWT using a JWT verification library..

--- a/v2/thirdpartypasswordless/sidebars.js
+++ b/v2/thirdpartypasswordless/sidebars.js
@@ -470,6 +470,7 @@ module.exports = {
           label: 'Actions, Hooks and Custom API responses',
           items: [
             "advanced-customizations/overview",
+            "advanced-customizations/user-context/custom-request-properties",
             {
               type: 'category',
               label: 'React component override',


### PR DESCRIPTION
## Summary of change
- Updates existing docs to not read usercontext[_default][request] and use the new helper function instead
- Adds a new page that explains how to get the request object from user context and how that can be used
- Updates existing user context docs to link to the new page

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] ...