### PR TITLE
Fix styling of recipe selected icon in the recipe selectopn dropdown

### DIFF
--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -730,6 +730,7 @@ details:not([open]) > *:not(summary) { /* Workaround to make the details' conten
   border-radius: 4px;
   padding: 3px 0;
   padding-left: 10px;
+  padding-right: 10px;
   width: 100%;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary of change
- Adds some space to the right of the icon to not make it touch the edge of its parent container when the recipe text is long (third party email password for example)

## Related issues
- 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] ...