### PR TITLE
fix: Typo in websocket documentation

### DIFF
--- a/v2/thirdpartyemailpassword/common-customizations/sessions/with-websocket.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/with-websocket.mdx
@@ -118,7 +118,7 @@ async function initSocketConnection() {
 Make sure to close the socket connection whenever appropriate to avoid sending stale JWTs.
 :::
 
-## Step 3: Veriy the JWT
+## Step 3: Verify the JWT
 Verify the JWT on socket connection initialisation on the backend:
 
 <AppInfoForm askForAPIDomain>


### PR DESCRIPTION
## Summary of change

Fixed a typo

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
