### PR TITLE
Update testing-with-postman.mdx

### DIFF
--- a/v2/emailpassword/testing/testing-with-postman.mdx
+++ b/v2/emailpassword/testing/testing-with-postman.mdx
@@ -153,7 +153,7 @@ By default, for `GET` APIs, you don't need to provide the `anti-csrf` request he
 
 <img alt="Request to change user data in postman" width="600px" src="/img/^{rid}/change-user.png" />
 
-In case you query the `/sessionInfo` API with an expired access token, you will get a `401` response with the message `uauthorized`. 
+In case you query the `/sessionInfo` API with an expired access token, you will get a `401` response with the message `unauthorized`. 
 
 <img alt="Failed query due to expired access token in postman" width="600px" src="/img/emailpassword/st-user-unauthorized.png" />
 

--- a/v2/emailpassword/testing/testing-with-postman.mdx
+++ b/v2/emailpassword/testing/testing-with-postman.mdx
@@ -153,7 +153,7 @@ By default, for `GET` APIs, you don't need to provide the `anti-csrf` request he
 
 <img alt="Request to change user data in postman" width="600px" src="/img/^{rid}/change-user.png" />
 
-In case you query the `/sessionInfo` API with an expired access token, you will get a `401` response with the message `try refresh token`. 
+In case you query the `/sessionInfo` API with an expired access token, you will get a `401` response with the message `uauthorized`. 
 
 <img alt="Failed query due to expired access token in postman" width="600px" src="/img/emailpassword/st-user-unauthorized.png" />
 

--- a/v2/emailpassword/testing/testing-with-postman.mdx
+++ b/v2/emailpassword/testing/testing-with-postman.mdx
@@ -141,8 +141,8 @@ async def change_user_data(session: SessionContainer = Depends(verify_session())
 </TabItem>
 </BackendSDKTabs>
 
-- In Postman, set the request type to `POST`.
-- Set the URL to `http://localhost:3001/change-user-data`
+- In Postman, set the request type to `GET`.
+- Set the URL to `http://localhost:3001/sessionInfo`
 - In the Header tab, set key `rid` with value `^{rid}`.
 - If you have the `antiCsrf` attribute set to `VIA_TOKEN` in your backend SuperTokens config, then, in the Postman Header tab, set the key as `anti-csrf` and value as the `anti-csrf` token retrieved from the login response.
 - On a successful response, the response body will contain user data
@@ -153,7 +153,7 @@ By default, for `GET` APIs, you don't need to provide the `anti-csrf` request he
 
 <img alt="Request to change user data in postman" width="600px" src="/img/^{rid}/change-user.png" />
 
-In case you query the `/change-user-data` API with an expired access token, you will get a `401` response with the message `try refresh token`. 
+In case you query the `/sessionInfo` API with an expired access token, you will get a `401` response with the message `try refresh token`. 
 
 <img alt="Failed query due to expired access token in postman" width="600px" src="/img/emailpassword/st-user-unauthorized.png" />
 


### PR DESCRIPTION
Corrected the Postman Example to use the **GET** `/sessionInfo` API where **POST** `/change-user-data` is being used

## Summary of change
The Documentation for Testing with Postman mentions the use of a **POST** `/change-user-data` API. The said API has been updated to **GET** `/sessionInfo` but the same does not reflect in the Documentation.

The documentation also states an incorrect response message to the **GET** `/sessionInfo` API which says `try refresh token` instead of `unauthorized`

This pull request updates the documentation to reflect the same.