### PR TITLE
Remove second extra "r" in "triggered"

### DIFF
--- a/v2/emailpassword/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/emailpassword/advanced-customizations/user-context/custom-request-properties.mdx
@@ -86,7 +86,7 @@ Session.init({
                         customHeaderValue = request.getHeaderValue("customHeader");
                     } else {
                         /**
-                         * This is possible if the function is triggerred from the user management dashboard
+                         * This is possible if the function is triggered from the user management dashboard
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -118,7 +118,7 @@ Session.init({
                         customHeaderValue = request.getHeaderValue("customHeader");
                     } else {
                         /**
-                         * This is possible if the function is triggerred from the user management dashboard
+                         * This is possible if the function is triggered from the user management dashboard
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -164,7 +164,7 @@ func main() {
                         customHeadervalue = request.Header.Get("customHeader")
                     } else {
                         /**
-                        * This is possible if the function is triggerred from the user management dashboard
+                        * This is possible if the function is triggered from the user management dashboard
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -193,7 +193,7 @@ func main() {
                         customHeadervalue = request.Header.Get("customHeader")
                     } else {
                         /**
-                        * This is possible if the function is triggerred from the user management dashboard
+                        * This is possible if the function is triggered from the user management dashboard
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -238,7 +238,7 @@ def override_session_functions(original_implementation: RecipeInterface):
             customHeaderValue=request.get_header("customHeader")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case set a reasonable default value to use
             #
@@ -265,7 +265,7 @@ def override_session_apis(original_implementation: APIInterface):
             customHeaderValue=request.get_header("customHeader")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case set a reasonable default value to use
             #

--- a/v2/emailpassword/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/emailpassword/common-customizations/sessions/anonymous-session.mdx
@@ -177,7 +177,7 @@ SuperTokens.init({
                                 jwt = request.getCookieValue("jwt");
                             } else {
                                 /**
-                                 * This is possible if the function is triggerred from the user management dashboard
+                                 * This is possible if the function is triggered from the user management dashboard
                                  * 
                                  * In this case because we cannot read the JWT, we create a session without the custom
                                  * payload properties
@@ -251,7 +251,7 @@ func main() {
                                 }
                             } else {
                                 /**
-                                * This is possible if the function is triggerred from the user management dashboard
+                                * This is possible if the function is triggered from the user management dashboard
                                 * 
                                 * In this case because we cannot read the JWT, we create a session without the custom
                                 * payload properties
@@ -297,7 +297,7 @@ def override_functions(original_implementation: RecipeInterface):
             jwt=request.get_cookie("jwt")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case because we cannot read the JWT, we create a session without the custom
             # payload properties

--- a/v2/passwordless/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/passwordless/advanced-customizations/user-context/custom-request-properties.mdx
@@ -86,7 +86,7 @@ Session.init({
                         customHeaderValue = request.getHeaderValue("customHeader");
                     } else {
                         /**
-                         * This is possible if the function is triggerred from the user management dashboard
+                         * This is possible if the function is triggered from the user management dashboard
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -118,7 +118,7 @@ Session.init({
                         customHeaderValue = request.getHeaderValue("customHeader");
                     } else {
                         /**
-                         * This is possible if the function is triggerred from the user management dashboard
+                         * This is possible if the function is triggered from the user management dashboard
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -164,7 +164,7 @@ func main() {
                         customHeadervalue = request.Header.Get("customHeader")
                     } else {
                         /**
-                        * This is possible if the function is triggerred from the user management dashboard
+                        * This is possible if the function is triggered from the user management dashboard
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -193,7 +193,7 @@ func main() {
                         customHeadervalue = request.Header.Get("customHeader")
                     } else {
                         /**
-                        * This is possible if the function is triggerred from the user management dashboard
+                        * This is possible if the function is triggered from the user management dashboard
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -238,7 +238,7 @@ def override_session_functions(original_implementation: RecipeInterface):
             customHeaderValue=request.get_header("customHeader")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case set a reasonable default value to use
             #
@@ -265,7 +265,7 @@ def override_session_apis(original_implementation: APIInterface):
             customHeaderValue=request.get_header("customHeader")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case set a reasonable default value to use
             #

--- a/v2/passwordless/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/passwordless/common-customizations/sessions/anonymous-session.mdx
@@ -177,7 +177,7 @@ SuperTokens.init({
                                 jwt = request.getCookieValue("jwt");
                             } else {
                                 /**
-                                 * This is possible if the function is triggerred from the user management dashboard
+                                 * This is possible if the function is triggered from the user management dashboard
                                  * 
                                  * In this case because we cannot read the JWT, we create a session without the custom
                                  * payload properties
@@ -251,7 +251,7 @@ func main() {
                                 }
                             } else {
                                 /**
-                                * This is possible if the function is triggerred from the user management dashboard
+                                * This is possible if the function is triggered from the user management dashboard
                                 * 
                                 * In this case because we cannot read the JWT, we create a session without the custom
                                 * payload properties
@@ -297,7 +297,7 @@ def override_functions(original_implementation: RecipeInterface):
             jwt=request.get_cookie("jwt")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case because we cannot read the JWT, we create a session without the custom
             # payload properties

--- a/v2/session/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/session/advanced-customizations/user-context/custom-request-properties.mdx
@@ -86,7 +86,7 @@ Session.init({
                         customHeaderValue = request.getHeaderValue("customHeader");
                     } else {
                         /**
-                         * This is possible if the function is triggerred from the user management dashboard
+                         * This is possible if the function is triggered from the user management dashboard
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -118,7 +118,7 @@ Session.init({
                         customHeaderValue = request.getHeaderValue("customHeader");
                     } else {
                         /**
-                         * This is possible if the function is triggerred from the user management dashboard
+                         * This is possible if the function is triggered from the user management dashboard
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -164,7 +164,7 @@ func main() {
                         customHeadervalue = request.Header.Get("customHeader")
                     } else {
                         /**
-                        * This is possible if the function is triggerred from the user management dashboard
+                        * This is possible if the function is triggered from the user management dashboard
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -193,7 +193,7 @@ func main() {
                         customHeadervalue = request.Header.Get("customHeader")
                     } else {
                         /**
-                        * This is possible if the function is triggerred from the user management dashboard
+                        * This is possible if the function is triggered from the user management dashboard
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -238,7 +238,7 @@ def override_session_functions(original_implementation: RecipeInterface):
             customHeaderValue=request.get_header("customHeader")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case set a reasonable default value to use
             #
@@ -265,7 +265,7 @@ def override_session_apis(original_implementation: APIInterface):
             customHeaderValue=request.get_header("customHeader")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case set a reasonable default value to use
             #

--- a/v2/session/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/session/common-customizations/sessions/anonymous-session.mdx
@@ -177,7 +177,7 @@ SuperTokens.init({
                                 jwt = request.getCookieValue("jwt");
                             } else {
                                 /**
-                                 * This is possible if the function is triggerred from the user management dashboard
+                                 * This is possible if the function is triggered from the user management dashboard
                                  * 
                                  * In this case because we cannot read the JWT, we create a session without the custom
                                  * payload properties
@@ -251,7 +251,7 @@ func main() {
                                 }
                             } else {
                                 /**
-                                * This is possible if the function is triggerred from the user management dashboard
+                                * This is possible if the function is triggered from the user management dashboard
                                 * 
                                 * In this case because we cannot read the JWT, we create a session without the custom
                                 * payload properties
@@ -297,7 +297,7 @@ def override_functions(original_implementation: RecipeInterface):
             jwt=request.get_cookie("jwt")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case because we cannot read the JWT, we create a session without the custom
             # payload properties

--- a/v2/thirdparty/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/thirdparty/advanced-customizations/user-context/custom-request-properties.mdx
@@ -86,7 +86,7 @@ Session.init({
                         customHeaderValue = request.getHeaderValue("customHeader");
                     } else {
                         /**
-                         * This is possible if the function is triggerred from the user management dashboard
+                         * This is possible if the function is triggered from the user management dashboard
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -118,7 +118,7 @@ Session.init({
                         customHeaderValue = request.getHeaderValue("customHeader");
                     } else {
                         /**
-                         * This is possible if the function is triggerred from the user management dashboard
+                         * This is possible if the function is triggered from the user management dashboard
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -164,7 +164,7 @@ func main() {
                         customHeadervalue = request.Header.Get("customHeader")
                     } else {
                         /**
-                        * This is possible if the function is triggerred from the user management dashboard
+                        * This is possible if the function is triggered from the user management dashboard
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -193,7 +193,7 @@ func main() {
                         customHeadervalue = request.Header.Get("customHeader")
                     } else {
                         /**
-                        * This is possible if the function is triggerred from the user management dashboard
+                        * This is possible if the function is triggered from the user management dashboard
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -238,7 +238,7 @@ def override_session_functions(original_implementation: RecipeInterface):
             customHeaderValue=request.get_header("customHeader")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case set a reasonable default value to use
             #
@@ -265,7 +265,7 @@ def override_session_apis(original_implementation: APIInterface):
             customHeaderValue=request.get_header("customHeader")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case set a reasonable default value to use
             #

--- a/v2/thirdparty/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdparty/common-customizations/sessions/anonymous-session.mdx
@@ -177,7 +177,7 @@ SuperTokens.init({
                                 jwt = request.getCookieValue("jwt");
                             } else {
                                 /**
-                                 * This is possible if the function is triggerred from the user management dashboard
+                                 * This is possible if the function is triggered from the user management dashboard
                                  * 
                                  * In this case because we cannot read the JWT, we create a session without the custom
                                  * payload properties
@@ -251,7 +251,7 @@ func main() {
                                 }
                             } else {
                                 /**
-                                * This is possible if the function is triggerred from the user management dashboard
+                                * This is possible if the function is triggered from the user management dashboard
                                 * 
                                 * In this case because we cannot read the JWT, we create a session without the custom
                                 * payload properties
@@ -297,7 +297,7 @@ def override_functions(original_implementation: RecipeInterface):
             jwt=request.get_cookie("jwt")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case because we cannot read the JWT, we create a session without the custom
             # payload properties

--- a/v2/thirdpartyemailpassword/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/thirdpartyemailpassword/advanced-customizations/user-context/custom-request-properties.mdx
@@ -86,7 +86,7 @@ Session.init({
                         customHeaderValue = request.getHeaderValue("customHeader");
                     } else {
                         /**
-                         * This is possible if the function is triggerred from the user management dashboard
+                         * This is possible if the function is triggered from the user management dashboard
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -118,7 +118,7 @@ Session.init({
                         customHeaderValue = request.getHeaderValue("customHeader");
                     } else {
                         /**
-                         * This is possible if the function is triggerred from the user management dashboard
+                         * This is possible if the function is triggered from the user management dashboard
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -164,7 +164,7 @@ func main() {
                         customHeadervalue = request.Header.Get("customHeader")
                     } else {
                         /**
-                        * This is possible if the function is triggerred from the user management dashboard
+                        * This is possible if the function is triggered from the user management dashboard
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -193,7 +193,7 @@ func main() {
                         customHeadervalue = request.Header.Get("customHeader")
                     } else {
                         /**
-                        * This is possible if the function is triggerred from the user management dashboard
+                        * This is possible if the function is triggered from the user management dashboard
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -238,7 +238,7 @@ def override_session_functions(original_implementation: RecipeInterface):
             customHeaderValue=request.get_header("customHeader")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case set a reasonable default value to use
             #
@@ -265,7 +265,7 @@ def override_session_apis(original_implementation: APIInterface):
             customHeaderValue=request.get_header("customHeader")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case set a reasonable default value to use
             #

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/anonymous-session.mdx
@@ -177,7 +177,7 @@ SuperTokens.init({
                                 jwt = request.getCookieValue("jwt");
                             } else {
                                 /**
-                                 * This is possible if the function is triggerred from the user management dashboard
+                                 * This is possible if the function is triggered from the user management dashboard
                                  * 
                                  * In this case because we cannot read the JWT, we create a session without the custom
                                  * payload properties
@@ -251,7 +251,7 @@ func main() {
                                 }
                             } else {
                                 /**
-                                * This is possible if the function is triggerred from the user management dashboard
+                                * This is possible if the function is triggered from the user management dashboard
                                 * 
                                 * In this case because we cannot read the JWT, we create a session without the custom
                                 * payload properties
@@ -297,7 +297,7 @@ def override_functions(original_implementation: RecipeInterface):
             jwt=request.get_cookie("jwt")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case because we cannot read the JWT, we create a session without the custom
             # payload properties

--- a/v2/thirdpartypasswordless/advanced-customizations/user-context/custom-request-properties.mdx
+++ b/v2/thirdpartypasswordless/advanced-customizations/user-context/custom-request-properties.mdx
@@ -86,7 +86,7 @@ Session.init({
                         customHeaderValue = request.getHeaderValue("customHeader");
                     } else {
                         /**
-                         * This is possible if the function is triggerred from the user management dashboard
+                         * This is possible if the function is triggered from the user management dashboard
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -118,7 +118,7 @@ Session.init({
                         customHeaderValue = request.getHeaderValue("customHeader");
                     } else {
                         /**
-                         * This is possible if the function is triggerred from the user management dashboard
+                         * This is possible if the function is triggered from the user management dashboard
                          * 
                          * In this case set a reasonable default value to use
                          */
@@ -164,7 +164,7 @@ func main() {
                         customHeadervalue = request.Header.Get("customHeader")
                     } else {
                         /**
-                        * This is possible if the function is triggerred from the user management dashboard
+                        * This is possible if the function is triggered from the user management dashboard
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -193,7 +193,7 @@ func main() {
                         customHeadervalue = request.Header.Get("customHeader")
                     } else {
                         /**
-                        * This is possible if the function is triggerred from the user management dashboard
+                        * This is possible if the function is triggered from the user management dashboard
                         * 
                         * In this case set a reasonable default value to use
                         */
@@ -238,7 +238,7 @@ def override_session_functions(original_implementation: RecipeInterface):
             customHeaderValue=request.get_header("customHeader")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case set a reasonable default value to use
             #
@@ -265,7 +265,7 @@ def override_session_apis(original_implementation: APIInterface):
             customHeaderValue=request.get_header("customHeader")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case set a reasonable default value to use
             #

--- a/v2/thirdpartypasswordless/common-customizations/sessions/anonymous-session.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/anonymous-session.mdx
@@ -177,7 +177,7 @@ SuperTokens.init({
                                 jwt = request.getCookieValue("jwt");
                             } else {
                                 /**
-                                 * This is possible if the function is triggerred from the user management dashboard
+                                 * This is possible if the function is triggered from the user management dashboard
                                  * 
                                  * In this case because we cannot read the JWT, we create a session without the custom
                                  * payload properties
@@ -251,7 +251,7 @@ func main() {
                                 }
                             } else {
                                 /**
-                                * This is possible if the function is triggerred from the user management dashboard
+                                * This is possible if the function is triggered from the user management dashboard
                                 * 
                                 * In this case because we cannot read the JWT, we create a session without the custom
                                 * payload properties
@@ -297,7 +297,7 @@ def override_functions(original_implementation: RecipeInterface):
             jwt=request.get_cookie("jwt")
         else:
             #
-            # This is possible if the function is triggerred from the user management dashboard
+            # This is possible if the function is triggered from the user management dashboard
             # 
             # In this case because we cannot read the JWT, we create a session without the custom
             # payload properties


### PR DESCRIPTION
## Summary of change
Replaced all occurrences of "triggerred" with "triggered".

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?