### PR TITLE
Fix incorrect instructions for Next.js app router

### DIFF
--- a/v2/emailpassword/nextjs/app-directory/setting-up-backend.mdx
+++ b/v2/emailpassword/nextjs/app-directory/setting-up-backend.mdx
@@ -15,10 +15,10 @@ import AppInfoForm from "/src/components/appInfoForm"
 
 We will add all the backend APIs for auth on `/api/auth`. This can be changed by setting the `apiBasePath` property in the `appInfo` object in the `appInfo.ts` file. For the rest of this page, we will assume you are using `/api/auth`.
 
-## 1) Create the API folder
-- Be sure to create the `auth` folder in the `app/api/` folder.
-- `[[...path]].tsx` will use the `getAppDirRequestHandler` helper function exposed by `supertokens-node` which helps in calling all the APIs like sign in, sign up etc. (the full folder path should be `/app/api/auth/[[...path]].tsx`).
-- An example of this can be found [here](https://github.com/supertokens/next.js/tree/canary/examples/with-supertokens/app/api/auth/%5B...path%5D).
+## 1) Create the `app/api/auth/[[...path]]/route.ts` route
+- Be sure to create the `auth/[[...path]]` folder in the `app/api/` folder.
+- `route.ts` will use the `getAppDirRequestHandler` helper function exposed by `supertokens-node` which helps in calling all the APIs like sign in, sign up etc. (the full folder path should be `/app/api/auth/[[...path]]/route.ts`).
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/app/api/auth/%5B...path%5D/route.ts).
 
 ## 2) Expose the SuperTokens APIs
 
@@ -28,12 +28,12 @@ We will add all the backend APIs for auth on `/api/auth`. This can be changed by
   showNextJSAPIRouteCheckbox
 >
 
-```tsx title="app/api/auth/[[...path]].ts"
+```tsx title="app/api/auth/[[...path]]/route.ts"
 declare let ensureSuperTokensInit: () => void; // typecheck-only, removed from output
 import { getAppDirRequestHandler } from 'supertokens-node/nextjs';
 import { NextRequest, NextResponse } from 'next/server';
 // @ts-ignore
-import { ensureSuperTokensInit } from '../../../config/backend';
+import { ensureSuperTokensInit } from '../../../../config/backend';
 
 ensureSuperTokensInit();
 

--- a/v2/emailpassword/nextjs/app-directory/setting-up-frontend.mdx
+++ b/v2/emailpassword/nextjs/app-directory/setting-up-frontend.mdx
@@ -24,14 +24,14 @@ import AppInfoForm from "/src/components/appInfoForm";
 
 <PreBuiltUIContent>
 
-## 1) Create the `app/auth/[[...path]].tsx` page
-- Be sure to create the `auth` folder in the `app` folder.
-- `[[...path]].tsx` will contain the component for showing SuperTokens UI
-- An example of this can be found [here](https://github.com/supertokens/next.js/tree/canary/examples/with-supertokens/app/auth/%5B%5B...path%5D%5D).
+## 1) Create the `app/auth/[[...path]]/page.tsx` page
+- Be sure to create the `auth/[[...path]]` folder in the `app` folder.
+- `page.tsx` will contain the component for showing SuperTokens UI
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/app/auth/%5B%5B...path%5D%5D/page.tsx).
 
 ## 2) Create the `Auth` component:
 
-```tsx title="app/auth/[[...path]].tsx"
+```tsx title="app/auth/[[...path]]/page.tsx"
 'use client';
 
 import { useEffect } from 'react';

--- a/v2/passwordless/nextjs/app-directory/setting-up-backend.mdx
+++ b/v2/passwordless/nextjs/app-directory/setting-up-backend.mdx
@@ -15,9 +15,9 @@ import AppInfoForm from "/src/components/appInfoForm"
 
 We will add all the backend APIs for auth on `/api/auth`. This can be changed by setting the `apiBasePath` property in the `appInfo` object in the `appInfo.ts` file. For the rest of this page, we will assume you are using `/api/auth`.
 
-## 1) Create the API folder
-- Be sure to create the `auth` folder in the `app/api/` folder.
-- `[[...path]].tsx` will use the `getAppDirRequestHandler` helper function exposed by `supertokens-node` which helps in calling all the APIs like sign in, sign up etc. (the full folder path should be `/app/api/auth/[[...path]].tsx`).
+## 1) Create the `app/api/auth/[[...path]]/route.ts` route
+- Be sure to create the `auth/[[...path]]` folder in the `app/api/` folder.
+- `route.ts` will use the `getAppDirRequestHandler` helper function exposed by `supertokens-node` which helps in calling all the APIs like sign in, sign up etc. (the full folder path should be `/app/api/auth/[[...path]]/route.ts`).
 - An example of this can be found [here](https://github.com/supertokens/next.js/tree/canary/examples/with-supertokens/app/api/auth/%5B...path%5D).
 
 ## 2) Expose the SuperTokens APIs
@@ -28,12 +28,12 @@ We will add all the backend APIs for auth on `/api/auth`. This can be changed by
   showNextJSAPIRouteCheckbox
 >
 
-```tsx title="app/api/auth/[[...path]].ts"
+```tsx title="app/api/auth/[[...path]]/route.ts"
 declare let ensureSuperTokensInit: () => void; // typecheck-only, removed from output
 import { getAppDirRequestHandler } from 'supertokens-node/nextjs';
 import { NextRequest, NextResponse } from 'next/server';
 // @ts-ignore
-import { ensureSuperTokensInit } from '../../../config/backend';
+import { ensureSuperTokensInit } from '../../../../config/backend';
 
 ensureSuperTokensInit();
 

--- a/v2/passwordless/nextjs/app-directory/setting-up-backend.mdx
+++ b/v2/passwordless/nextjs/app-directory/setting-up-backend.mdx
@@ -18,7 +18,7 @@ We will add all the backend APIs for auth on `/api/auth`. This can be changed by
 ## 1) Create the `app/api/auth/[[...path]]/route.ts` route
 - Be sure to create the `auth/[[...path]]` folder in the `app/api/` folder.
 - `route.ts` will use the `getAppDirRequestHandler` helper function exposed by `supertokens-node` which helps in calling all the APIs like sign in, sign up etc. (the full folder path should be `/app/api/auth/[[...path]]/route.ts`).
-- An example of this can be found [here](https://github.com/supertokens/next.js/tree/canary/examples/with-supertokens/app/api/auth/%5B...path%5D).
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/app/api/auth/%5B...path%5D/route.ts).
 
 ## 2) Expose the SuperTokens APIs
 

--- a/v2/passwordless/nextjs/app-directory/setting-up-frontend.mdx
+++ b/v2/passwordless/nextjs/app-directory/setting-up-frontend.mdx
@@ -24,14 +24,14 @@ import AppInfoForm from "/src/components/appInfoForm";
 
 <PreBuiltUIContent>
 
-## 1) Create the `app/auth/[[...path]].tsx` page
-- Be sure to create the `auth` folder in the `app` folder.
-- `[[...path]].tsx` will contain the component for showing SuperTokens UI
+## 1) Create the `app/auth/[[...path]]/page.tsx` page
+- Be sure to create the `auth/[[...path]]` folder in the `app` folder.
+- `page.tsx` will contain the component for showing SuperTokens UI
 - An example of this can be found [here](https://github.com/supertokens/next.js/tree/canary/examples/with-supertokens/app/auth/%5B%5B...path%5D%5D).
 
 ## 2) Create the `Auth` component:
 
-```tsx title="app/auth/[[...path]].tsx"
+```tsx title="app/auth/[[...path]]/page.tsx"
 'use client';
 
 import { useEffect } from 'react';

--- a/v2/passwordless/nextjs/app-directory/setting-up-frontend.mdx
+++ b/v2/passwordless/nextjs/app-directory/setting-up-frontend.mdx
@@ -27,7 +27,7 @@ import AppInfoForm from "/src/components/appInfoForm";
 ## 1) Create the `app/auth/[[...path]]/page.tsx` page
 - Be sure to create the `auth/[[...path]]` folder in the `app` folder.
 - `page.tsx` will contain the component for showing SuperTokens UI
-- An example of this can be found [here](https://github.com/supertokens/next.js/tree/canary/examples/with-supertokens/app/auth/%5B%5B...path%5D%5D).
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/app/auth/%5B%5B...path%5D%5D/page.tsx).
 
 ## 2) Create the `Auth` component:
 

--- a/v2/thirdparty/nextjs/app-directory/setting-up-backend.mdx
+++ b/v2/thirdparty/nextjs/app-directory/setting-up-backend.mdx
@@ -15,10 +15,10 @@ import AppInfoForm from "/src/components/appInfoForm"
 
 We will add all the backend APIs for auth on `/api/auth`. This can be changed by setting the `apiBasePath` property in the `appInfo` object in the `appInfo.ts` file. For the rest of this page, we will assume you are using `/api/auth`.
 
-## 1) Create the API folder
-- Be sure to create the `auth` folder in the `app/api/` folder.
-- `[[...path]].tsx` will use the `getAppDirRequestHandler` helper function exposed by `supertokens-node` which helps in calling all the APIs like sign in, sign up etc. (the full folder path should be `/app/api/auth/[[...path]].tsx`).
-- An example of this can be found [here](https://github.com/supertokens/next.js/tree/canary/examples/with-supertokens/app/api/auth/%5B...path%5D).
+## 1) Create the `app/api/auth/[[...path]]/route.ts` route
+- Be sure to create the `auth/[[...path]]` folder in the `app/api/` folder.
+- `route.ts` will use the `getAppDirRequestHandler` helper function exposed by `supertokens-node` which helps in calling all the APIs like sign in, sign up etc. (the full folder path should be `/app/api/auth/[[...path]]/route.ts`).
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/app/api/auth/%5B...path%5D/route.ts).
 
 ## 2) Expose the SuperTokens APIs
 
@@ -28,12 +28,12 @@ We will add all the backend APIs for auth on `/api/auth`. This can be changed by
   showNextJSAPIRouteCheckbox
 >
 
-```tsx title="app/api/auth/[[...path]].ts"
+```tsx title="app/api/auth/[[...path]]/route.ts"
 declare let ensureSuperTokensInit: () => void; // typecheck-only, removed from output
 import { getAppDirRequestHandler } from 'supertokens-node/nextjs';
 import { NextRequest, NextResponse } from 'next/server';
 // @ts-ignore
-import { ensureSuperTokensInit } from '../../../config/backend';
+import { ensureSuperTokensInit } from '../../../../config/backend';
 
 ensureSuperTokensInit();
 

--- a/v2/thirdparty/nextjs/app-directory/setting-up-frontend.mdx
+++ b/v2/thirdparty/nextjs/app-directory/setting-up-frontend.mdx
@@ -24,14 +24,14 @@ import AppInfoForm from "/src/components/appInfoForm";
 
 <PreBuiltUIContent>
 
-## 1) Create the `app/auth/[[...path]].tsx` page
-- Be sure to create the `auth` folder in the `app` folder.
-- `[[...path]].tsx` will contain the component for showing SuperTokens UI
-- An example of this can be found [here](https://github.com/supertokens/next.js/tree/canary/examples/with-supertokens/app/auth/%5B%5B...path%5D%5D).
+## 1) Create the `app/auth/[[...path]]/page.tsx` page
+- Be sure to create the `auth/[[...path]]` folder in the `app` folder.
+- `page.tsx` will contain the component for showing SuperTokens UI
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/app/auth/%5B%5B...path%5D%5D/page.tsx).
 
 ## 2) Create the `Auth` component:
 
-```tsx title="app/auth/[[...path]].tsx"
+```tsx title="app/auth/[[...path]]/page.tsx"
 'use client';
 
 import { useEffect } from 'react';

--- a/v2/thirdpartyemailpassword/nextjs/app-directory/setting-up-backend.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/app-directory/setting-up-backend.mdx
@@ -15,10 +15,10 @@ import AppInfoForm from "/src/components/appInfoForm"
 
 We will add all the backend APIs for auth on `/api/auth`. This can be changed by setting the `apiBasePath` property in the `appInfo` object in the `appInfo.ts` file. For the rest of this page, we will assume you are using `/api/auth`.
 
-## 1) Create the API folder
-- Be sure to create the `auth` folder in the `app/api/` folder.
-- `[[...path]].tsx` will use the `getAppDirRequestHandler` helper function exposed by `supertokens-node` which helps in calling all the APIs like sign in, sign up etc. (the full folder path should be `/app/api/auth/[[...path]].tsx`).
-- An example of this can be found [here](https://github.com/supertokens/next.js/tree/canary/examples/with-supertokens/app/api/auth/%5B...path%5D).
+## 1) Create the `app/api/auth/[[...path]]/route.ts` route
+- Be sure to create the `auth/[[...path]]` folder in the `app/api/` folder.
+- `route.ts` will use the `getAppDirRequestHandler` helper function exposed by `supertokens-node` which helps in calling all the APIs like sign in, sign up etc. (the full folder path should be `/app/api/auth/[[...path]]/route.ts`).
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/app/api/auth/%5B...path%5D/route.ts).
 
 ## 2) Expose the SuperTokens APIs
 
@@ -28,12 +28,12 @@ We will add all the backend APIs for auth on `/api/auth`. This can be changed by
   showNextJSAPIRouteCheckbox
 >
 
-```tsx title="app/api/auth/[[...path]].ts"
+```tsx title="app/api/auth/[[...path]]/route.ts"
 declare let ensureSuperTokensInit: () => void; // typecheck-only, removed from output
 import { getAppDirRequestHandler } from 'supertokens-node/nextjs';
 import { NextRequest, NextResponse } from 'next/server';
 // @ts-ignore
-import { ensureSuperTokensInit } from '../../../config/backend';
+import { ensureSuperTokensInit } from '../../../../config/backend';
 
 ensureSuperTokensInit();
 

--- a/v2/thirdpartyemailpassword/nextjs/app-directory/setting-up-frontend.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/app-directory/setting-up-frontend.mdx
@@ -24,14 +24,14 @@ import AppInfoForm from "/src/components/appInfoForm";
 
 <PreBuiltUIContent>
 
-## 1) Create the `app/auth/[[...path]].tsx` page
-- Be sure to create the `auth` folder in the `app` folder.
-- `[[...path]].tsx` will contain the component for showing SuperTokens UI
-- An example of this can be found [here](https://github.com/supertokens/next.js/tree/canary/examples/with-supertokens/app/auth/%5B%5B...path%5D%5D).
+## 1) Create the `app/auth/[[...path]]/page.tsx` page
+- Be sure to create the `auth/[[...path]]` folder in the `app` folder.
+- `page.tsx` will contain the component for showing SuperTokens UI
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/app/auth/%5B%5B...path%5D%5D/page.tsx).
 
 ## 2) Create the `Auth` component:
 
-```tsx title="app/auth/[[...path]].tsx"
+```tsx title="app/auth/[[...path]]/page.tsx"
 'use client';
 
 import { useEffect } from 'react';

--- a/v2/thirdpartypasswordless/nextjs/app-directory/setting-up-backend.mdx
+++ b/v2/thirdpartypasswordless/nextjs/app-directory/setting-up-backend.mdx
@@ -15,10 +15,10 @@ import AppInfoForm from "/src/components/appInfoForm"
 
 We will add all the backend APIs for auth on `/api/auth`. This can be changed by setting the `apiBasePath` property in the `appInfo` object in the `appInfo.ts` file. For the rest of this page, we will assume you are using `/api/auth`.
 
-## 1) Create the API folder
-- Be sure to create the `auth` folder in the `app/api/` folder.
-- `[[...path]].tsx` will use the `getAppDirRequestHandler` helper function exposed by `supertokens-node` which helps in calling all the APIs like sign in, sign up etc. (the full folder path should be `/app/api/auth/[[...path]].tsx`).
-- An example of this can be found [here](https://github.com/supertokens/next.js/tree/canary/examples/with-supertokens/app/api/auth/%5B...path%5D).
+## 1) Create the `app/api/auth/[[...path]]/route.ts` route
+- Be sure to create the `auth/[[...path]]` folder in the `app/api/` folder.
+- `route.ts` will use the `getAppDirRequestHandler` helper function exposed by `supertokens-node` which helps in calling all the APIs like sign in, sign up etc. (the full folder path should be `/app/api/auth/[[...path]]/route.ts`).
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/app/api/auth/%5B...path%5D/route.ts).
 
 ## 2) Expose the SuperTokens APIs
 
@@ -28,12 +28,12 @@ We will add all the backend APIs for auth on `/api/auth`. This can be changed by
   showNextJSAPIRouteCheckbox
 >
 
-```tsx title="app/api/auth/[[...path]].ts"
+```tsx title="app/api/auth/[[...path]]/route.ts"
 declare let ensureSuperTokensInit: () => void; // typecheck-only, removed from output
 import { getAppDirRequestHandler } from 'supertokens-node/nextjs';
 import { NextRequest, NextResponse } from 'next/server';
 // @ts-ignore
-import { ensureSuperTokensInit } from '../../../config/backend';
+import { ensureSuperTokensInit } from '../../../../config/backend';
 
 ensureSuperTokensInit();
 

--- a/v2/thirdpartypasswordless/nextjs/app-directory/setting-up-frontend.mdx
+++ b/v2/thirdpartypasswordless/nextjs/app-directory/setting-up-frontend.mdx
@@ -24,14 +24,14 @@ import AppInfoForm from "/src/components/appInfoForm";
 
 <PreBuiltUIContent>
 
-## 1) Create the `app/auth/[[...path]].tsx` page
-- Be sure to create the `auth` folder in the `app` folder.
-- `[[...path]].tsx` will contain the component for showing SuperTokens UI
-- An example of this can be found [here](https://github.com/supertokens/next.js/tree/canary/examples/with-supertokens/app/auth/%5B%5B...path%5D%5D).
+## 1) Create the `app/auth/[[...path]]/page.tsx` page
+- Be sure to create the `auth/[[...path]]` folder in the `app` folder.
+- `page.tsx` will contain the component for showing SuperTokens UI
+- An example of this can be found [here](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/app/auth/%5B%5B...path%5D%5D/page.tsx).
 
 ## 2) Create the `Auth` component:
 
-```tsx title="app/auth/[[...path]].tsx"
+```tsx title="app/auth/[[...path]]/page.tsx"
 'use client';
 
 import { useEffect } from 'react';


### PR DESCRIPTION
## Summary of change

In App Router, the correct way to create a catch-all segment is through `[[...segmentName]]/page.tsx`, as you can no longer use dynamic routing on the leaf of directories. [Supertokens' app directory example](https://github.com/supertokens/next.js/blob/canary/examples/with-supertokens/app/auth/%5B%5B...path%5D%5D/page.tsx) is correct. 

## Related commits

Seems like the example was also super new, documentation typo, I presume. 

- https://github.com/supertokens/next.js/commit/9e7d2d011121dd6fa90c491c9e81ee7c7552b710#diff-401e3d26e1b3958c21cd08b9146e1e9cc9f4db8652c259644b96693e433217f5

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
