### PR TITLE
fix: webpack css ruleset warning.

### DIFF
--- a/v2/src/theme/TOC/styles.module.css
+++ b/v2/src/theme/TOC/styles.module.css
@@ -25,7 +25,7 @@
 .tocOldDOcsTop {
   display: flex;
   flex-direction: row;
-  align-items: start;
+  align-items: flex-start;
 }
 
 .tocOldDocsIcon {


### PR DESCRIPTION
## Summary of change
Fixes webpack css ruleset warning in development.


<img width="854" alt="Screenshot 2023-12-06 at 4 09 54 PM" src="https://github.com/supertokens/docs/assets/87567452/7fd424e0-39d2-4825-a8b9-261ed8b624c9">



## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2