### PR TITLE
fix: guides page images rendering issue

### DIFF
--- a/v2/src/components/recipeBoxes/add_ons.tsx
+++ b/v2/src/components/recipeBoxes/add_ons.tsx
@@ -1,16 +1,12 @@
-import React, {useState, useEffect} from "react";
+import React, { useState } from "react";
 import "./recipeBox.css"
 
-type size = "small" | "large"
 
 export default function Addons(props: { text: string, path: string, icon: string, img?: string }) {
-    const [image, setImage] = useState({default: ""});
-    const [imageOnHover, setImageOnHover] = useState({default: ""});
     const [hover, setHover] = useState(false);
-    useEffect(() => {
-        setImage(require(`../../../static/img/guides/${props.icon}.svg`));
-        setImageOnHover(require(`../../../static/img/guides/${props.icon}-orange.svg`));
-    },);
+    
+    const regularIconPath = `/img/guides/${props.icon}.svg`;
+    const onHoverIconPath = `/img/guides/${props.icon}-orange.svg`;
 
     const handleMouseOver = () => {
         setHover(true);
@@ -21,7 +17,7 @@ export default function Addons(props: { text: string, path: string, icon: string
 
     return <a href={props.path} className={`recipe_box`} onMouseOver={handleMouseOver} onMouseOut={handleMouseOut}>
         <div className="recipe_box__icon_wrapper">
-            <img src={hover ? imageOnHover.default : image.default} alt={props.text} />
+            <img src={hover ? onHoverIconPath : regularIconPath} alt={props.text} />
         </div>
         <div className="recipe_box__text">{props.text}</div>
     </a>

--- a/v2/src/components/recipeBoxes/authMode.tsx
+++ b/v2/src/components/recipeBoxes/authMode.tsx
@@ -1,20 +1,13 @@
-import React, {useState, useEffect} from "react";
+import React, {useState } from "react";
 import "./recipeBox.css"
 
-type size = "small" | "large"
+type Size = "small" | "large"
 
-export default function AuthMode(props: { text: string, size: size, path: string, icon: string, img?: string }) {
-    const [image, setImage] = useState({default: ""});
-    const [imageOnHover, setImageOnHover] = useState({default: ""});
-    const [imageToShow, setImageToShow] = useState({default: ""});
+export default function AuthMode(props: { text: string, size: Size, path: string, icon: string, img?: string }) {
     const [hover, setHover] = useState(false);
-    useEffect(() => {
-        setImage(require(`../../../static/img/guides/${props.icon}.svg`));
-        setImageOnHover(require(`../../../static/img/guides/${props.icon}-orange.svg`));
-        if(props.size == "large" && props.img) {
-            setImageToShow(require(`../../../static/img/guides/${props.img}.png`))
-        }
-    }, [props.size]);
+    
+    const regularIconPath = `/img/guides/${props.icon}.svg`;
+    const onHoverIconPath = `/img/guides/${props.icon}-orange.svg`;
 
     const handleMouseOver = () => {
         setHover(true);
@@ -25,7 +18,7 @@ export default function AuthMode(props: { text: string, size: size, path: string
 
     return <a href={props.path} className={`recipe_box ${props.size}`} onMouseOver={handleMouseOver} onMouseOut={handleMouseOut}>
         <div className="recipe_box__icon_wrapper">
-            <img src={hover ? imageOnHover.default : image.default} alt={props.text} />
+            <img src={hover ? onHoverIconPath : regularIconPath} alt={props.text} />
         </div>
         <div className="recipe_box__text">{props.text}</div>
         <div className="recipe_box__full_image">

--- a/v2/src/components/recipeBoxes/refs.tsx
+++ b/v2/src/components/recipeBoxes/refs.tsx
@@ -1,27 +1,23 @@
-import React, {useState, useEffect} from "react";
+import React, { useState } from "react";
 import "./recipeBox.css"
 
-type size = "small" | "large"
-
 export default function Refs(props: { text: string, path: string, icon: string, img?: string }) {
-    const [image, setImage] = useState({default: ""});
-    const [imageOnHover, setImageOnHover] = useState({default: ""});
     const [hover, setHover] = useState(false);
-    useEffect(() => {
-        setImage(require(`../../../static/img/guides/${props.icon}.svg`));
-        setImageOnHover(require(`../../../static/img/guides/${props.icon}-orange.svg`));
-    },);
+
+    const regularIconPath = `/img/guides/${props.icon}.svg`;
+    const onHoverIconPath = `/img/guides/${props.icon}-orange.svg`;
 
     const handleMouseOver = () => {
         setHover(true);
     }
+
     const handleMouseOut = () => {
         setHover(false);
     }
 
     return <a href={props.path} className={`recipe_box`} onMouseOver={handleMouseOver} onMouseOut={handleMouseOut}>
         <div className="recipe_box__icon_wrapper">
-            <img src={hover ? imageOnHover.default : image.default} alt={props.text} />
+            <img src={hover ? onHoverIconPath : regularIconPath} alt={props.text} />
         </div>
         <div className="recipe_box__text">{props.text}</div>
     </a>


### PR DESCRIPTION
## Summary of change

Using normal JS variables in the place react state to store the icons paths.

### Cause for the issue.
The reason why the flicker was happening in the first place is that the src url for the image tag is provided on the client side some time after rendering the html.

### Why this behaviour?
So last week we have fixed missing/duplicate alt attribute to images so that's when this bug got introduced. Since before that there were no alt tags this behaviour never observed.

Previous build `guides.html` output
![Screenshot 2024-01-08 at 6 26 35 PM](https://github.com/supertokens/docs/assets/87567452/a7ff7d4f-2f00-4a64-bba8-3bb66a7d5f50)

after fix 
![Screenshot 2024-01-08 at 6 28 08 PM](https://github.com/supertokens/docs/assets/87567452/d928e8f2-249b-429d-8825-7c2f4039b17a)



## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2