### PR TITLE
docs: added admonition clarifying dashboard url

### DIFF
--- a/v2/emailpassword/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/emailpassword/custom-ui/init/user-management-dashboard/setup.mdx
@@ -116,6 +116,10 @@ The user management dashboard is served by the backend SDK, you have to use your
 
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
+:::note
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+:::
+
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />
 
 ## Creating dashboard credentials

--- a/v2/emailpassword/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/emailpassword/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}^/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/emailpassword/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/emailpassword/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}^/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/emailpassword/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/emailpassword/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/emailpassword/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/emailpassword/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/emailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/emailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -116,6 +116,10 @@ The user management dashboard is served by the backend SDK, you have to use your
 
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
+:::note
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+:::
+
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />
 
 ## Creating dashboard credentials

--- a/v2/emailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/emailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/emailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/emailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/emailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/emailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/passwordless/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/passwordless/custom-ui/init/user-management-dashboard/setup.mdx
@@ -116,6 +116,10 @@ The user management dashboard is served by the backend SDK, you have to use your
 
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
+:::note
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+:::
+
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />
 
 ## Creating dashboard credentials

--- a/v2/passwordless/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/passwordless/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/passwordless/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/passwordless/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/passwordless/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/passwordless/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/passwordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/passwordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -116,6 +116,10 @@ The user management dashboard is served by the backend SDK, you have to use your
 
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
+:::note
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+:::
+
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />
 
 ## Creating dashboard credentials

--- a/v2/passwordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/passwordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/passwordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/passwordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/passwordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/passwordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdparty/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/thirdparty/custom-ui/init/user-management-dashboard/setup.mdx
@@ -116,6 +116,10 @@ The user management dashboard is served by the backend SDK, you have to use your
 
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
+:::note
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+:::
+
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />
 
 ## Creating dashboard credentials

--- a/v2/thirdparty/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/thirdparty/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdparty/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/thirdparty/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdparty/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/thirdparty/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdparty/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/thirdparty/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -116,6 +116,10 @@ The user management dashboard is served by the backend SDK, you have to use your
 
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
+:::note
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+:::
+
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />
 
 ## Creating dashboard credentials

--- a/v2/thirdparty/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/thirdparty/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdparty/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/thirdparty/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdparty/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/thirdparty/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdpartyemailpassword/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartyemailpassword/custom-ui/init/user-management-dashboard/setup.mdx
@@ -116,6 +116,10 @@ The user management dashboard is served by the backend SDK, you have to use your
 
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
+:::note
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+:::
+
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />
 
 ## Creating dashboard credentials

--- a/v2/thirdpartyemailpassword/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartyemailpassword/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdpartyemailpassword/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartyemailpassword/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdpartyemailpassword/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartyemailpassword/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdpartyemailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartyemailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -116,6 +116,10 @@ The user management dashboard is served by the backend SDK, you have to use your
 
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
+:::note
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+:::
+
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />
 
 ## Creating dashboard credentials

--- a/v2/thirdpartyemailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartyemailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdpartyemailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartyemailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdpartyemailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartyemailpassword/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdpartypasswordless/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartypasswordless/custom-ui/init/user-management-dashboard/setup.mdx
@@ -116,6 +116,10 @@ The user management dashboard is served by the backend SDK, you have to use your
 
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
+:::note
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+:::
+
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />
 
 ## Creating dashboard credentials

--- a/v2/thirdpartypasswordless/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartypasswordless/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdpartypasswordless/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartypasswordless/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdpartypasswordless/custom-ui/init/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartypasswordless/custom-ui/init/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdpartypasswordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartypasswordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -116,6 +116,10 @@ The user management dashboard is served by the backend SDK, you have to use your
 
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
+:::note
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+:::
+
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />
 
 ## Creating dashboard credentials

--- a/v2/thirdpartypasswordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartypasswordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdpartypasswordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartypasswordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/thirdpartypasswordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
+++ b/v2/thirdpartypasswordless/pre-built-ui/setup/user-management-dashboard/setup.mdx
@@ -117,7 +117,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/userdashboard/about.mdx
+++ b/v2/userdashboard/about.mdx
@@ -123,7 +123,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/userdashboard/about.mdx
+++ b/v2/userdashboard/about.mdx
@@ -122,6 +122,10 @@ The user management dashboard is served by the backend SDK, you have to use your
 
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
+:::note
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+:::
+
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />
 
 ## Creating dashboard credentials

--- a/v2/userdashboard/about.mdx
+++ b/v2/userdashboard/about.mdx
@@ -123,7 +123,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />

--- a/v2/userdashboard/about.mdx
+++ b/v2/userdashboard/about.mdx
@@ -123,7 +123,7 @@ The user management dashboard is served by the backend SDK, you have to use your
 Navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to view the dashboard.
 
 :::note
-If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
+If you are using Next.js, upon integrating our backend SDK into your Next.js API folder, the dashboard will be accessible by default at `^{form_apiDomain}/api/auth/dashboard`. For frameworks other than Next.js, it can be accessed at `^{form_apiDomain}/auth/dashboard`. Should you have customized the `apiBasePath` configuration property, simply navigate to `^{form_apiDomain}^{form_apiBasePath}/dashboard` to access the dashboard.
 :::
 
 <img src="/img/dashboard/login.png" alt="Dashboard login screen UI" />


### PR DESCRIPTION
## Summary of change
Based on user feedback, I have added an admonition to specify the location of the dashboard in Next.js vs. other frameworks.

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
