### PR TITLE
fix: inaccurate text references in nodejs snippets

### DIFF
--- a/v2/emailpassword/common-customizations/get-user-info.mdx
+++ b/v2/emailpassword/common-customizations/get-user-info.mdx
@@ -112,6 +112,8 @@ func main() {
 
 <TabItem value="asyncio">
 
+You can get a user's information on the backend using the `^{getUserByEmailPython}` function:
+
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.asyncio import ^{getUserByEmailPython}
 
@@ -123,6 +125,8 @@ async def some_func():
 
 </TabItem>
 <TabItem value="syncio">
+
+You can get a user's information on the backend using the `^{getUserByEmailPython}` function:
 
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.syncio import ^{getUserByEmailPython}
@@ -154,7 +158,13 @@ If you are using our multi-tenancy feature, you can pass in a different `tenantI
 
 ## Fetching information using the user's ID
 
-### Using the `getUserById` function
+Retrieve the user's ID by calling:
+
+- the `getUser` function for **NodeJS**
+- the `GetUserById` function for **GoLang**
+- the `get_user_by_id` function for **Python**
+
+Refer to the code snippets below for example usage:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">

--- a/v2/emailpassword/common-customizations/get-user-info.mdx
+++ b/v2/emailpassword/common-customizations/get-user-info.mdx
@@ -4,12 +4,15 @@ title: Get User info
 hide_title: true
 ---
 
+import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- -1 -->
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import NodeJSFrameworkSubTabs from "/src/components/tabs/NodeJSFrameworkSubTabs";
 import TabItem from '@theme/TabItem';
 import GoFrameworkSubTabs from "/src/components/tabs/GoFrameworkSubTabs"
-import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import FrontendReactContextSubTabs from "/src/components/tabs/FrontendReactContextSubTabs"
 import PythonSyncAsyncSubTabs from "/src/components/tabs/PythonSyncAsyncSubTabs"
 import PythonFrameworkSubTabs from "/src/components/tabs/PythonFrameworkSubTabs"
@@ -20,11 +23,13 @@ import FrontendCustomUITabs from "/src/components/tabs/FrontendCustomUITabs"
 import FrontendMobileSubTabs from "/src/components/tabs/FrontendMobileSubTabs"
 import CustomAdmonition from "/src/components/customAdmonition"
 
-# Get User Info
+<!-- END COPY SECTION -->
 
 <!-- COPY SECTION -->
 <!-- ./passwordless/common-customizations/get-user-info.mdx -->
 <!-- 0 -->
+
+# Get User Info
 
 There are several ways to fetch information about a user:
 - Using their user ID, you can get their email ID, time joined, and metadata that is saved in the user metadata recipe.
@@ -32,12 +37,16 @@ There are several ways to fetch information about a user:
 
 <!-- END COPY SECTION -->
 
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- 0a -->
+
 ## Fetching information using the user's email
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
 
-You can get a user's information on the backend using the `listUsersByAccountInfo` function:
+Use the `listUsersByAccountInfo` function to retrieve a user's data, specifying the account type and providing the user's email as criteria.
 
 ```tsx
 import supertokens from "supertokens-node";
@@ -67,7 +76,13 @@ async function getUserInfo() {
 
 <TabItem value="go">
 
+<!-- END COPY SECTION -->
+
 You can get a user's information on the backend using the `^{getUserByEmailGo}` and `GetUserById` functions:
+
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- 0b -->
 
 ```go
 import (
@@ -78,14 +93,14 @@ import (
 
 func main() {
 
-	// Note that usersInfo has type User
+	// Note that usersInfo has type User[]
 	// You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki
-	usersInfo, err := ^{codeImportRecipeName}.^{getUserByEmailGo}("public", "test@example.com")
+	userInfo, err := ^{codeImportRecipeName}.^{getUserByEmailGo}("public", "test@example.com")
 	if err != nil {
 		// TODO: Handle error
 		return
 	}
-	fmt.Println(usersInfo)
+	fmt.Println(userInfo)
 	//...
 }
 ```
@@ -101,7 +116,7 @@ func main() {
 from supertokens_python.recipe.^{codeImportRecipeName}.asyncio import ^{getUserByEmailPython}
 
 async def some_func():
-    # Note that user_info has type User
+    # Note that users_info has type List[User]
     user_info = await ^{getUserByEmailPython}("public", "test@example.com")
     print(user_info)
 ```
@@ -112,7 +127,7 @@ async def some_func():
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.syncio import ^{getUserByEmailPython}
 
-# Note that user_info has type User
+# Note that users_info has type List[User]
 # You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki 
 user_info = ^{getUserByEmailPython}("public", "test@example.com")
 ```
@@ -123,15 +138,15 @@ user_info = ^{getUserByEmailPython}("public", "test@example.com")
 </TabItem>
 </BackendSDKTabs>
 
-
 <CustomAdmonition type="multi-tenancy">
 
-Notice that the first argument of the above function is `"public"`. This is the default tenantId which means that SuperTokens will return information about the user whose email is `"test@example.com"` in the `"public"` tenant. 
+Notice that the first argument of the above function is `"public"`. This is the default `tenantId` which means that SuperTokens will return information about the user whose email is `"test@example.com"` in the `"public"` tenant. 
 
-If you are using our multi tenancy feature, you can pass in a different tenantId to get information about a user in a different tenant.
+If you are using our multi-tenancy feature, you can pass in a different `tenantId` to get information about a user in a different tenant.
 
 </CustomAdmonition>
 
+<!-- END COPY SECTION -->
 
 <!-- COPY SECTION -->
 <!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->

--- a/v2/passwordless/common-customizations/get-user-info.mdx
+++ b/v2/passwordless/common-customizations/get-user-info.mdx
@@ -113,6 +113,8 @@ func main() {
 
 <TabItem value="asyncio">
 
+You can get a user's information on the backend using the `^{getUserByEmailPython}` function:
+
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.asyncio import ^{getUserByEmailPython}
 
@@ -124,6 +126,8 @@ async def some_func():
 
 </TabItem>
 <TabItem value="syncio">
+
+You can get a user's information on the backend using the `^{getUserByEmailPython}` function:
 
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.syncio import ^{getUserByEmailPython}
@@ -249,7 +253,13 @@ Notice that we pass in the `"public"` tenantId to the function call above. This 
 
 ## Fetching information using the user's ID
 
-### Using the `getUserById` function
+Retrieve the user's ID by calling:
+
+- the `getUser` function for **NodeJS**
+- the `GetUserById` function for **GoLang**
+- the `get_user_by_id` function for **Python**
+
+Refer to the code snippets below for example usage:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">

--- a/v2/passwordless/common-customizations/get-user-info.mdx
+++ b/v2/passwordless/common-customizations/get-user-info.mdx
@@ -4,11 +4,16 @@ title: Get User info
 hide_title: true
 ---
 
+import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
+import { Answer } from "/src/components/question"
+
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- -1 -->
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import NodeJSFrameworkSubTabs from "/src/components/tabs/NodeJSFrameworkSubTabs";
 import TabItem from '@theme/TabItem';
 import GoFrameworkSubTabs from "/src/components/tabs/GoFrameworkSubTabs"
-import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import FrontendReactContextSubTabs from "/src/components/tabs/FrontendReactContextSubTabs"
 import PythonSyncAsyncSubTabs from "/src/components/tabs/PythonSyncAsyncSubTabs"
 import PythonFrameworkSubTabs from "/src/components/tabs/PythonFrameworkSubTabs"
@@ -17,14 +22,15 @@ import { PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent } from "
 import FrontendPreBuiltUITabs from "/src/components/tabs/FrontendPreBuiltUITabs"
 import FrontendCustomUITabs from "/src/components/tabs/FrontendCustomUITabs"
 import FrontendMobileSubTabs from "/src/components/tabs/FrontendMobileSubTabs"
-import { Answer } from "/src/components/question"
 import CustomAdmonition from "/src/components/customAdmonition"
 
-# Get User Info
+<!-- END COPY SECTION -->
 
 <!-- COPY SECTION -->
 <!-- ./passwordless/common-customizations/get-user-info.mdx -->
 <!-- 0 -->
+
+# Get User Info
 
 There are several ways to fetch information about a user:
 - Using their user ID, you can get their email ID, time joined, and metadata that is saved in the user metadata recipe.
@@ -32,17 +38,21 @@ There are several ways to fetch information about a user:
 
 <!-- END COPY SECTION -->
 
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- 0a -->
+
 ## Fetching information using the user's email
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
 
-You can get a user's information on the backend using the `^{getUserByEmailNode}`, `getUserByPhoneNumber` and `getUserById` functions:
+Use the `listUsersByAccountInfo` function to retrieve a user's data, specifying the account type and providing the user's email as criteria.
 
 ```tsx
 import supertokens from "supertokens-node";
 
-async function handler() {
+async function getUserInfo() {
     let usersInfo = await supertokens.listUsersByAccountInfo("public", {
         email: "test@example.com"
     });
@@ -67,24 +77,31 @@ async function handler() {
 
 <TabItem value="go">
 
+<!-- END COPY SECTION -->
+
 You can get a user's information on the backend using the `GetUserByEmail`, `GetUserByPhoneNumber` and `GetUserById` functions:
+
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- 0b -->
 
 ```go
 import (
 	"fmt"
 
-	"github.com/supertokens/supertokens-golang/recipe/passwordless"
+	"github.com/supertokens/supertokens-golang/recipe/^{codeImportRecipeName}"
 )
 
 func main() {
 
-	tenantId := "public"
-	userInfo, err := passwordless.GetUserByEmail(tenantId, "test@example.com")
+	// Note that usersInfo has type User[]
+	// You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki
+	userInfo, err := ^{codeImportRecipeName}.^{getUserByEmailGo}("public", "test@example.com")
 	if err != nil {
 		// TODO: Handle error
 		return
 	}
-    fmt.Println(userInfo)
+	fmt.Println(userInfo)
 	//...
 }
 ```
@@ -97,10 +114,12 @@ func main() {
 <TabItem value="asyncio">
 
 ```python
-from supertokens_python.recipe.passwordless.asyncio import get_user_by_email
+from supertokens_python.recipe.^{codeImportRecipeName}.asyncio import ^{getUserByEmailPython}
 
 async def some_func():
-    _ = await get_user_by_email("public", "test@example.com")
+    # Note that users_info has type List[User]
+    user_info = await ^{getUserByEmailPython}("public", "test@example.com")
+    print(user_info)
 ```
 
 </TabItem>
@@ -109,6 +128,8 @@ async def some_func():
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.syncio import ^{getUserByEmailPython}
 
+# Note that users_info has type List[User]
+# You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki 
 user_info = ^{getUserByEmailPython}("public", "test@example.com")
 ```
 
@@ -120,9 +141,17 @@ user_info = ^{getUserByEmailPython}("public", "test@example.com")
 
 <CustomAdmonition type="multi-tenancy">
 
-Notice that we pass in the `"public"` tenantId to the function call above. This is the default tenantID and will return the user with the given email that belongs to the `public` tenant. You can provide a different tenantID if required.
+Notice that the first argument of the above function is `"public"`. This is the default `tenantId` which means that SuperTokens will return information about the user whose email is `"test@example.com"` in the `"public"` tenant. 
+
+If you are using our multi-tenancy feature, you can pass in a different `tenantId` to get information about a user in a different tenant.
 
 </CustomAdmonition>
+
+<!-- END COPY SECTION -->
+
+<!-- COPY SECTION -->
+<!-- ./passwordless/common-customizations/get-user-info.mdx -->
+<!-- 0c -->
 
 ## Fetching information using the user's phone number
 
@@ -161,7 +190,7 @@ async function handler() {
 import (
 	"fmt"
 
-	"github.com/supertokens/supertokens-golang/recipe/passwordless"
+	"github.com/supertokens/supertokens-golang/recipe/^{codeImportRecipeName}"
 )
 
 func main() {
@@ -212,6 +241,12 @@ Notice that we pass in the `"public"` tenantId to the function call above. This 
 
 </CustomAdmonition>
 
+<!-- END COPY SECTION -->
+
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- 1 -->
+
 ## Fetching information using the user's ID
 
 ### Using the `getUserById` function
@@ -223,14 +258,14 @@ Notice that we pass in the `"public"` tenantId to the function call above. This 
 
 ```tsx
 import express from "express";
-import supertokens from "supertokens-node";
 import { verifySession } from "supertokens-node/recipe/session/framework/express";
 import { SessionRequest } from 'supertokens-node/framework/express';
+import supertokens from "supertokens-node";
 
 let app = express();
 app.get("/get-user-info", verifySession(), async (req: SessionRequest, res) => {
     let userId = req.session!.getUserId();
-
+    
     // highlight-next-line
     let userInfo = await supertokens.getUser(userId)
 
@@ -254,10 +289,10 @@ app.get("/get-user-info", verifySession(), async (req: SessionRequest, res) => {
 <TabItem value="hapi">
 
 ```tsx
-import supertokens from "supertokens-node";
 import { verifySession } from "supertokens-node/recipe/session/framework/hapi";
 import Hapi from "@hapi/hapi";
 import { SessionRequest } from "supertokens-node/framework/hapi";
+import supertokens from "supertokens-node";
 
 let server = Hapi.server({ port: 8000 });
 
@@ -274,22 +309,23 @@ server.route({
     // @ts-ignore
     handler: async (req: SessionRequest, res) => {
         let userId = req.session!.getUserId();
-        // highlight-next-line
-		let userInfo = await supertokens.getUser(userId)
 
-		/**
-		* 
-		* userInfo contains the following info:
-		* - emails
-		* - id
-		* - timeJoined
-		* - tenantIds
-		* - phone numbers
-		* - third party login info
-		* - all the login methods associated with this user.
-		* - information about if the user's email is verified or not.
-		* 
-		*/
+        // highlight-next-line
+        let userInfo = await supertokens.getUser(userId)
+
+        /**
+        * 
+        * userInfo contains the following info:
+        * - emails
+        * - id
+        * - timeJoined
+        * - tenantIds
+        * - phone numbers
+        * - third party login info
+        * - all the login methods associated with this user.
+        * - information about if the user's email is verified or not.
+        * 
+        */
     }
 })
 ```
@@ -300,9 +336,9 @@ server.route({
 
 ```tsx
 import Fastify from "fastify";
-import supertokens from "supertokens-node";
 import { verifySession } from "supertokens-node/recipe/session/framework/fastify";
 import { SessionRequest } from 'supertokens-node/framework/fastify';
+import supertokens from "supertokens-node";
 
 const fastify = Fastify();
 
@@ -310,21 +346,22 @@ fastify.post("/like-comment", {
     preHandler: verifySession(),
 }, async (req: SessionRequest, res) => {
     let userId = req.session!.getUserId();
+
     // highlight-next-line
     let userInfo = await supertokens.getUser(userId)
 
     /**
-     * 
-     * userInfo contains the following info:
-     * - emails
-     * - id
-     * - timeJoined
-     * - tenantIds
-     * - phone numbers
-     * - third party login info
-     * - all the login methods associated with this user.
-     * - information about if the user's email is verified or not.
-     * 
+    * 
+    * userInfo contains the following info:
+    * - emails
+    * - id
+    * - timeJoined
+    * - tenantIds
+    * - phone numbers
+    * - third party login info
+    * - all the login methods associated with this user.
+    * - information about if the user's email is verified or not.
+    * 
     */
 });
 ```
@@ -334,27 +371,28 @@ fastify.post("/like-comment", {
 <TabItem value="awsLambda">
 
 ```tsx
-import supertokens from "supertokens-node";
 import { verifySession } from "supertokens-node/recipe/session/framework/awsLambda";
 import { SessionEvent } from "supertokens-node/framework/awsLambda";
+import supertokens from "supertokens-node";
 
 async function getUserInfo(awsEvent: SessionEvent) {
     let userId = awsEvent.session!.getUserId();
+    
     // highlight-next-line
     let userInfo = await supertokens.getUser(userId)
 
     /**
-     * 
-     * userInfo contains the following info:
-     * - emails
-     * - id
-     * - timeJoined
-     * - tenantIds
-     * - phone numbers
-     * - third party login info
-     * - all the login methods associated with this user.
-     * - information about if the user's email is verified or not.
-     * 
+    * 
+    * userInfo contains the following info:
+    * - emails
+    * - id
+    * - timeJoined
+    * - tenantIds
+    * - phone numbers
+    * - third party login info
+    * - all the login methods associated with this user.
+    * - information about if the user's email is verified or not.
+    * 
     */
 };
 
@@ -367,29 +405,30 @@ exports.handler = verifySession(getUserInfo);
 
 ```tsx
 import KoaRouter from "koa-router";
-import supertokens from "supertokens-node";
 import { verifySession } from "supertokens-node/recipe/session/framework/koa";
 import { SessionContext } from "supertokens-node/framework/koa";
+import supertokens from "supertokens-node";
 
 let router = new KoaRouter();
 
 router.get("/get-user-info", verifySession(), async (ctx: SessionContext, next) => {
     let userId = ctx.session!.getUserId();
+    
     // highlight-next-line
     let userInfo = await supertokens.getUser(userId)
 
     /**
-     * 
-     * userInfo contains the following info:
-     * - emails
-     * - id
-     * - timeJoined
-     * - tenantIds
-     * - phone numbers
-     * - third party login info
-     * - all the login methods associated with this user.
-     * - information about if the user's email is verified or not.
-     * 
+    * 
+    * userInfo contains the following info:
+    * - emails
+    * - id
+    * - timeJoined
+    * - tenantIds
+    * - phone numbers
+    * - third party login info
+    * - all the login methods associated with this user.
+    * - information about if the user's email is verified or not.
+    * 
     */
 });
 ```
@@ -401,10 +440,10 @@ router.get("/get-user-info", verifySession(), async (ctx: SessionContext, next) 
 ```tsx
 import { inject, intercept } from "@loopback/core";
 import { RestBindings, MiddlewareContext, get, response } from "@loopback/rest";
-import supertokens from "supertokens-node";
 import { verifySession } from "supertokens-node/recipe/session/framework/loopback";
 import Session from "supertokens-node/recipe/session";
 import { SessionContext } from "supertokens-node/framework/loopback";
+import supertokens from "supertokens-node";
 
 class GetUserInfo {
     constructor(@inject(RestBindings.Http.CONTEXT) private ctx: MiddlewareContext) {}
@@ -413,22 +452,23 @@ class GetUserInfo {
     @response(200)
     async handler() {
         let userId = ((this.ctx as any).session as Session.SessionContainer).getUserId();
+        
         // highlight-next-line
-		let userInfo = await supertokens.getUser(userId)
+        let userInfo = await supertokens.getUser(userId)
 
-		/**
-		* 
-		* userInfo contains the following info:
-		* - emails
-		* - id
-		* - timeJoined
-		* - tenantIds
-		* - phone numbers
-		* - third party login info
-		* - all the login methods associated with this user.
-		* - information about if the user's email is verified or not.
-		* 
-		*/
+        /**
+        * 
+        * userInfo contains the following info:
+        * - emails
+        * - id
+        * - timeJoined
+        * - tenantIds
+        * - phone numbers
+        * - third party login info
+        * - all the login methods associated with this user.
+        * - information about if the user's email is verified or not.
+        * 
+        */
     }
 }
 ```
@@ -438,10 +478,10 @@ class GetUserInfo {
 <TabItem value="nextjs">
 
 ```tsx
-import supertokens from "supertokens-node";
 import { superTokensNextWrapper } from 'supertokens-node/nextjs'
 import { verifySession } from "supertokens-node/recipe/session/framework/express";
 import { SessionRequest } from "supertokens-node/framework/express";
+import supertokens from "supertokens-node";
 
 export default async function likeComment(req: SessionRequest, res: any) {
     await superTokensNextWrapper(
@@ -453,21 +493,22 @@ export default async function likeComment(req: SessionRequest, res: any) {
     )
 
     let userId = req.session!.getUserId();
+    
     // highlight-next-line
     let userInfo = await supertokens.getUser(userId)
 
     /**
-     * 
-     * userInfo contains the following info:
-     * - emails
-     * - id
-     * - timeJoined
-     * - tenantIds
-     * - phone numbers
-     * - third party login info
-     * - all the login methods associated with this user.
-     * - information about if the user's email is verified or not.
-     * 
+    * 
+    * userInfo contains the following info:
+    * - emails
+    * - id
+    * - timeJoined
+    * - tenantIds
+    * - phone numbers
+    * - third party login info
+    * - all the login methods associated with this user.
+    * - information about if the user's email is verified or not.
+    * 
     */
 }
 ```
@@ -512,6 +553,7 @@ export function POST(request: NextRequest) {
 }
 ```
 </TabItem>
+
 <TabItem value="nestjs">
 
 ```tsx
@@ -520,8 +562,8 @@ import { Controller, Post, UseGuards, Request, Response } from "@nestjs/common";
 import { AuthGuard } from './auth/auth.guard';
 // @ts-ignore
 import { Session } from './auth/session.decorator';
-import supertokens from "supertokens-node";
 import { SessionRequest } from "supertokens-node/framework/express";
+import supertokens from "supertokens-node";
 
 @Controller()
 export class ExampleController {
@@ -529,23 +571,24 @@ export class ExampleController {
   @UseGuards(new AuthGuard()) // For more information about this guard please read our NestJS guide.
   async postExample(@Request() req: SessionRequest, @Session() session: Session, @Response({passthrough: true}) res: Response): Promise<boolean> {
     let userId = session.getUserId();
+    
     // highlight-next-line
     let userInfo = await supertokens.getUser(userId)
 
     /**
-     * 
-     * userInfo contains the following info:
-     * - emails
-     * - id
-     * - timeJoined
-     * - tenantIds
-     * - phone numbers
-     * - third party login info
-     * - all the login methods associated with this user.
-     * - information about if the user's email is verified or not.
-     * 
+    * 
+    * userInfo contains the following info:
+    * - emails
+    * - id
+    * - timeJoined
+    * - tenantIds
+    * - phone numbers
+    * - third party login info
+    * - all the login methods associated with this user.
+    * - information about if the user's email is verified or not.
+    * 
     */
-	return true;
+    return true;
   }
 }
 ```
@@ -789,3 +832,5 @@ Checkout the [user metadata recipe docs](./usermetadata/about) which shows you h
 The user's session contains their user ID and the session's payload. You can access this on the backend and frontend as well as whilst the user is online or offline.
 
 More information about this can be found in the [session docs](./sessions/claims/access-token-payload#read-the-access-token-payload).
+
+<!-- END COPY SECTION -->

--- a/v2/thirdparty/common-customizations/get-user-info.mdx
+++ b/v2/thirdparty/common-customizations/get-user-info.mdx
@@ -4,11 +4,15 @@ title: Get User info
 hide_title: true
 ---
 
+import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
+
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- -1 -->
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import NodeJSFrameworkSubTabs from "/src/components/tabs/NodeJSFrameworkSubTabs";
 import TabItem from '@theme/TabItem';
 import GoFrameworkSubTabs from "/src/components/tabs/GoFrameworkSubTabs"
-import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import FrontendReactContextSubTabs from "/src/components/tabs/FrontendReactContextSubTabs"
 import PythonSyncAsyncSubTabs from "/src/components/tabs/PythonSyncAsyncSubTabs"
 import PythonFrameworkSubTabs from "/src/components/tabs/PythonFrameworkSubTabs"
@@ -19,11 +23,13 @@ import FrontendCustomUITabs from "/src/components/tabs/FrontendCustomUITabs"
 import FrontendMobileSubTabs from "/src/components/tabs/FrontendMobileSubTabs"
 import CustomAdmonition from "/src/components/customAdmonition"
 
-# Get User Info
+<!-- END COPY SECTION -->
 
 <!-- COPY SECTION -->
 <!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
 <!-- 0 -->
+
+# Get User Info
 
 There are several ways to fetch information about a user:
 - Using their user ID, you can get their email ID, time joined, and metadata that is saved in the user metadata recipe.
@@ -32,12 +38,16 @@ There are several ways to fetch information about a user:
 
 <!-- END COPY SECTION -->
 
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- 0a -->
+
 ## Fetching information using the user's email
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
 
-You can get a user's information on the backend using the `listUsersByAccountInfo` functions:
+Use the `listUsersByAccountInfo` function to retrieve a user's data, specifying the account type and providing the user's email as criteria.
 
 ```tsx
 import supertokens from "supertokens-node";
@@ -67,7 +77,13 @@ async function getUserInfo() {
 
 <TabItem value="go">
 
+<!-- END COPY SECTION -->
+
 You can get a user's information on the backend using the `^{getUserByEmailGo}` and `GetUserById` functions:
+
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- 0b -->
 
 ```go
 import (
@@ -80,13 +96,12 @@ func main() {
 
 	// Note that usersInfo has type User[]
 	// You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki
-    tenantId := "public"
-	usersInfo, err := ^{codeImportRecipeName}.^{getUserByEmailGo}(tenantId, "test@example.com")
+	userInfo, err := ^{codeImportRecipeName}.^{getUserByEmailGo}("public", "test@example.com")
 	if err != nil {
 		// TODO: Handle error
 		return
 	}
-	fmt.Println(usersInfo)
+	fmt.Println(userInfo)
 	//...
 }
 ```
@@ -103,8 +118,8 @@ from supertokens_python.recipe.^{codeImportRecipeName}.asyncio import ^{getUserB
 
 async def some_func():
     # Note that users_info has type List[User]
-    users_info = await ^{getUserByEmailPython}("public", "test@example.com")
-    print(users_info)
+    user_info = await ^{getUserByEmailPython}("public", "test@example.com")
+    print(user_info)
 ```
 
 </TabItem>
@@ -115,7 +130,7 @@ from supertokens_python.recipe.^{codeImportRecipeName}.syncio import ^{getUserBy
 
 # Note that users_info has type List[User]
 # You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki 
-users_info = ^{getUserByEmailPython}("public", "test@example.com")
+user_info = ^{getUserByEmailPython}("public", "test@example.com")
 ```
 
 </TabItem>
@@ -126,9 +141,13 @@ users_info = ^{getUserByEmailPython}("public", "test@example.com")
 
 <CustomAdmonition type="multi-tenancy">
 
-Notice that we pass in the `"public"` tenantId to the function call above. This is the default tenantID and will return the user with the given email that belongs to the `public` tenant. You can provide a different tenantID if required.
+Notice that the first argument of the above function is `"public"`. This is the default `tenantId` which means that SuperTokens will return information about the user whose email is `"test@example.com"` in the `"public"` tenant. 
+
+If you are using our multi-tenancy feature, you can pass in a different `tenantId` to get information about a user in a different tenant.
 
 </CustomAdmonition>
+
+<!-- END COPY SECTION -->
 
 <!-- COPY SECTION -->
 <!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->

--- a/v2/thirdparty/common-customizations/get-user-info.mdx
+++ b/v2/thirdparty/common-customizations/get-user-info.mdx
@@ -113,6 +113,8 @@ func main() {
 
 <TabItem value="asyncio">
 
+You can get a user's information on the backend using the `^{getUserByEmailPython}` function:
+
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.asyncio import ^{getUserByEmailPython}
 
@@ -124,6 +126,8 @@ async def some_func():
 
 </TabItem>
 <TabItem value="syncio">
+
+You can get a user's information on the backend using the `^{getUserByEmailPython}` function:
 
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.syncio import ^{getUserByEmailPython}
@@ -155,7 +159,13 @@ If you are using our multi-tenancy feature, you can pass in a different `tenantI
 
 ## Fetching information using the user's ID
 
-### Using the `getUserById` function
+Retrieve the user's ID by calling:
+
+- the `getUser` function for **NodeJS**
+- the `GetUserById` function for **GoLang**
+- the `get_user_by_id` function for **Python**
+
+Refer to the code snippets below for example usage:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -746,7 +756,7 @@ More information about this can be found in the [session docs](./sessions/claims
 <!-- 2 -->
 
 ## Getting the user's third party provider information and access token
-If the user used a third party provider to login, you can access their info via SuperTokens as shown below. You can then save the OAuthTokens in your own db or in SuperTokens (using the [user metadata recipe](./usermetadata/store-data)) and use them to fetch / change info about the logged in user from the third party provider
+If the user used a third party provider to login, you can access their info via SuperTokens as shown below. You can then save the OAuthTokens in your own db or in SuperTokens (using the [user metadata recipe](./usermetadata/store-data)) and use them to fetch / change info about the logged in user from the third party provider.
 
 <BackendSDKTabs>
 <TabItem value="nodejs">

--- a/v2/thirdpartyemailpassword/common-customizations/get-user-info.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/get-user-info.mdx
@@ -4,12 +4,15 @@ title: Get User info
 hide_title: true
 ---
 
+import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- -1 -->
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import NodeJSFrameworkSubTabs from "/src/components/tabs/NodeJSFrameworkSubTabs";
 import TabItem from '@theme/TabItem';
 import GoFrameworkSubTabs from "/src/components/tabs/GoFrameworkSubTabs"
-import FrontendSDKTabs from "/src/components/tabs/FrontendSDKTabs"
 import FrontendReactContextSubTabs from "/src/components/tabs/FrontendReactContextSubTabs"
 import PythonSyncAsyncSubTabs from "/src/components/tabs/PythonSyncAsyncSubTabs"
 import PythonFrameworkSubTabs from "/src/components/tabs/PythonFrameworkSubTabs"
@@ -20,11 +23,13 @@ import FrontendCustomUITabs from "/src/components/tabs/FrontendCustomUITabs"
 import FrontendMobileSubTabs from "/src/components/tabs/FrontendMobileSubTabs"
 import CustomAdmonition from "/src/components/customAdmonition"
 
-# Get User Info
+<!-- END COPY SECTION -->
 
 <!-- COPY SECTION -->
 <!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
 <!-- 0 -->
+
+# Get User Info
 
 There are several ways to fetch information about a user:
 - Using their user ID, you can get their email ID, time joined, and metadata that is saved in the user metadata recipe.
@@ -33,12 +38,16 @@ There are several ways to fetch information about a user:
 
 <!-- END COPY SECTION -->
 
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- 0a -->
+
 ## Fetching information using the user's email
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
 
-You can get a user's information on the backend using the `listUsersByAccountInfo` functions:
+Use the `listUsersByAccountInfo` function to retrieve a user's data, specifying the account type and providing the user's email as criteria.
 
 ```tsx
 import supertokens from "supertokens-node";
@@ -68,7 +77,13 @@ async function getUserInfo() {
 
 <TabItem value="go">
 
+<!-- END COPY SECTION -->
+
 You can get a user's information on the backend using the `^{getUserByEmailGo}` and `GetUserById` functions:
+
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- 0b -->
 
 ```go
 import (
@@ -81,12 +96,12 @@ func main() {
 
 	// Note that usersInfo has type User[]
 	// You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki
-	usersInfo, err := ^{codeImportRecipeName}.^{getUserByEmailGo}("public", "test@example.com")
+	userInfo, err := ^{codeImportRecipeName}.^{getUserByEmailGo}("public", "test@example.com")
 	if err != nil {
 		// TODO: Handle error
 		return
 	}
-	fmt.Println(usersInfo)
+	fmt.Println(userInfo)
 	//...
 }
 ```
@@ -103,8 +118,8 @@ from supertokens_python.recipe.^{codeImportRecipeName}.asyncio import ^{getUserB
 
 async def some_func():
     # Note that users_info has type List[User]
-    users_info = await ^{getUserByEmailPython}("public", "test@example.com")
-    print(users_info)
+    user_info = await ^{getUserByEmailPython}("public", "test@example.com")
+    print(user_info)
 ```
 
 </TabItem>
@@ -115,7 +130,7 @@ from supertokens_python.recipe.^{codeImportRecipeName}.syncio import ^{getUserBy
 
 # Note that users_info has type List[User]
 # You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki 
-users_info = ^{getUserByEmailPython}("public", "test@example.com")
+user_info = ^{getUserByEmailPython}("public", "test@example.com")
 ```
 
 </TabItem>
@@ -126,9 +141,13 @@ users_info = ^{getUserByEmailPython}("public", "test@example.com")
 
 <CustomAdmonition type="multi-tenancy">
 
-Notice that we pass in the `"public"` tenantId to the function call above. This is the default tenantID and will return the user with the given email that belongs to the `public` tenant. You can provide a different tenantID if required.
+Notice that the first argument of the above function is `"public"`. This is the default `tenantId` which means that SuperTokens will return information about the user whose email is `"test@example.com"` in the `"public"` tenant. 
+
+If you are using our multi-tenancy feature, you can pass in a different `tenantId` to get information about a user in a different tenant.
 
 </CustomAdmonition>
+
+<!-- END COPY SECTION -->
 
 <!-- COPY SECTION -->
 <!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->

--- a/v2/thirdpartyemailpassword/common-customizations/get-user-info.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/get-user-info.mdx
@@ -79,7 +79,7 @@ async function getUserInfo() {
 
 <!-- END COPY SECTION -->
 
-You can get a user's information on the backend using the `^{getUserByEmailGo}` and `GetUserById` functions:
+You can get a user's information on the backend using the `^{getUserByEmailGo}` function:
 
 <!-- COPY SECTION -->
 <!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
@@ -113,6 +113,8 @@ func main() {
 
 <TabItem value="asyncio">
 
+You can get a user's information on the backend using the `^{getUserByEmailPython}` function:
+
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.asyncio import ^{getUserByEmailPython}
 
@@ -124,6 +126,8 @@ async def some_func():
 
 </TabItem>
 <TabItem value="syncio">
+
+You can get a user's information on the backend using the `^{getUserByEmailPython}` function:
 
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.syncio import ^{getUserByEmailPython}
@@ -155,7 +159,13 @@ If you are using our multi-tenancy feature, you can pass in a different `tenantI
 
 ## Fetching information using the user's ID
 
-### Using the `getUserById` function
+Retrieve the user's ID by calling:
+
+- the `getUser` function for **NodeJS**
+- the `GetUserById` function for **GoLang**
+- the `get_user_by_id` function for **Python**
+
+Refer to the code snippets below for example usage:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -746,7 +756,7 @@ More information about this can be found in the [session docs](./sessions/claims
 <!-- 2 -->
 
 ## Getting the user's third party provider information and access token
-If the user used a third party provider to login, you can access their info via SuperTokens as shown below. You can then save the OAuthTokens in your own db or in SuperTokens (using the [user metadata recipe](./usermetadata/store-data)) and use them to fetch / change info about the logged in user from the third party provider
+If the user used a third party provider to login, you can access their info via SuperTokens as shown below. You can then save the OAuthTokens in your own db or in SuperTokens (using the [user metadata recipe](./usermetadata/store-data)) and use them to fetch / change info about the logged in user from the third party provider.
 
 <BackendSDKTabs>
 <TabItem value="nodejs">

--- a/v2/thirdpartypasswordless/common-customizations/get-user-info.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/get-user-info.mdx
@@ -111,6 +111,8 @@ func main() {
 
 <TabItem value="asyncio">
 
+You can get a user's information on the backend using the `^{getUserByEmailPython}` function:
+
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.asyncio import ^{getUserByEmailPython}
 
@@ -122,6 +124,8 @@ async def some_func():
 
 </TabItem>
 <TabItem value="syncio">
+
+You can get a user's information on the backend using the `^{getUserByEmailPython}` function:
 
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.syncio import ^{getUserByEmailPython}
@@ -247,7 +251,13 @@ Notice that we pass in the `"public"` tenantId to the function call above. This 
 
 ## Fetching information using the user's ID
 
-### Using the `getUserById` function
+Retrieve the user's ID by calling:
+
+- the `getUser` function for **NodeJS**
+- the `GetUserById` function for **GoLang**
+- the `get_user_by_id` function for **Python**
+
+Refer to the code snippets below for example usage:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -838,7 +848,7 @@ More information about this can be found in the [session docs](./sessions/claims
 <!-- 2 -->
 
 ## Getting the user's third party provider information and access token
-If the user used a third party provider to login, you can access their info via SuperTokens as shown below. You can then save the OAuthTokens in your own db or in SuperTokens (using the [user metadata recipe](./usermetadata/store-data)) and use them to fetch / change info about the logged in user from the third party provider
+If the user used a third party provider to login, you can access their info via SuperTokens as shown below. You can then save the OAuthTokens in your own db or in SuperTokens (using the [user metadata recipe](./usermetadata/store-data)) and use them to fetch / change info about the logged in user from the third party provider.
 
 <BackendSDKTabs>
 <TabItem value="nodejs">

--- a/v2/thirdpartypasswordless/common-customizations/get-user-info.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/get-user-info.mdx
@@ -4,6 +4,9 @@ title: Get User info
 hide_title: true
 ---
 
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- -1 -->
 import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs"
 import NodeJSFrameworkSubTabs from "/src/components/tabs/NodeJSFrameworkSubTabs";
 import TabItem from '@theme/TabItem';
@@ -18,11 +21,13 @@ import FrontendCustomUITabs from "/src/components/tabs/FrontendCustomUITabs"
 import FrontendMobileSubTabs from "/src/components/tabs/FrontendMobileSubTabs"
 import CustomAdmonition from "/src/components/customAdmonition"
 
-# Get User Info
+<!-- END COPY SECTION -->
 
 <!-- COPY SECTION -->
 <!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
 <!-- 0 -->
+
+# Get User Info
 
 There are several ways to fetch information about a user:
 - Using their user ID, you can get their email ID, time joined, and metadata that is saved in the user metadata recipe.
@@ -31,18 +36,21 @@ There are several ways to fetch information about a user:
 
 <!-- END COPY SECTION -->
 
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- 0a -->
+
 ## Fetching information using the user's email
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
 
-You can get a user's information on the backend using the `listUsersByAccountInfo` function:
+Use the `listUsersByAccountInfo` function to retrieve a user's data, specifying the account type and providing the user's email as criteria.
 
 ```tsx
-
 import supertokens from "supertokens-node";
 
-async function handler() {
+async function getUserInfo() {
     let usersInfo = await supertokens.listUsersByAccountInfo("public", {
         email: "test@example.com"
     });
@@ -61,30 +69,37 @@ async function handler() {
      * 
     */
 }
-
 ```
 
 </TabItem>
 
 <TabItem value="go">
 
+<!-- END COPY SECTION -->
+
 You can get a user's information on the backend using the `GetUserByEmail`, `GetUserByPhoneNumber` and `GetUserById` functions:
+
+<!-- COPY SECTION -->
+<!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->
+<!-- 0b -->
 
 ```go
 import (
 	"fmt"
 
-	"github.com/supertokens/supertokens-golang/recipe/thirdpartypasswordless"
+	"github.com/supertokens/supertokens-golang/recipe/^{codeImportRecipeName}"
 )
 
 func main() {
 
-	userInfo, err := thirdpartypasswordless.GetUsersByEmail("public", "test@example.com")
+	// Note that usersInfo has type User[]
+	// You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki
+	userInfo, err := ^{codeImportRecipeName}.^{getUserByEmailGo}("public", "test@example.com")
 	if err != nil {
 		// TODO: Handle error
 		return
 	}
-    fmt.Println(userInfo)
+	fmt.Println(userInfo)
 	//...
 }
 ```
@@ -97,10 +112,12 @@ func main() {
 <TabItem value="asyncio">
 
 ```python
-from supertokens_python.recipe.thirdpartypasswordless.asyncio import get_users_by_email
+from supertokens_python.recipe.^{codeImportRecipeName}.asyncio import ^{getUserByEmailPython}
 
 async def some_func():
-    _ = await get_users_by_email("public", "test@example.com")
+    # Note that users_info has type List[User]
+    user_info = await ^{getUserByEmailPython}("public", "test@example.com")
+    print(user_info)
 ```
 
 </TabItem>
@@ -109,6 +126,8 @@ async def some_func():
 ```python
 from supertokens_python.recipe.^{codeImportRecipeName}.syncio import ^{getUserByEmailPython}
 
+# Note that users_info has type List[User]
+# You can learn more about the `User` object over here https://github.com/supertokens/core-driver-interface/wiki 
 user_info = ^{getUserByEmailPython}("public", "test@example.com")
 ```
 
@@ -120,9 +139,17 @@ user_info = ^{getUserByEmailPython}("public", "test@example.com")
 
 <CustomAdmonition type="multi-tenancy">
 
-Notice that we pass in the `"public"` tenantId to the function call above. This is the default tenantID and will return the user with the given email that belongs to the `public` tenant. You can provide a different tenantID if required.
+Notice that the first argument of the above function is `"public"`. This is the default `tenantId` which means that SuperTokens will return information about the user whose email is `"test@example.com"` in the `"public"` tenant. 
+
+If you are using our multi-tenancy feature, you can pass in a different `tenantId` to get information about a user in a different tenant.
 
 </CustomAdmonition>
+
+<!-- END COPY SECTION -->
+
+<!-- COPY SECTION -->
+<!-- ./passwordless/common-customizations/get-user-info.mdx -->
+<!-- 0c -->
 
 ## Fetching information using the user's phone number
 
@@ -130,11 +157,11 @@ Notice that we pass in the `"public"` tenantId to the function call above. This 
 <TabItem value="nodejs">
 
 ```tsx
-import supertokens from "supertokens-node"
+import supertokens from "supertokens-node";
 
 async function handler() {
     let usersInfo = await supertokens.listUsersByAccountInfo("public", {
-        phoneNumber: "+1234567891"
+        phoneNumber: "+1234567890"
     });
 
     /**
@@ -161,12 +188,13 @@ async function handler() {
 import (
 	"fmt"
 
-	"github.com/supertokens/supertokens-golang/recipe/thirdpartypasswordless"
+	"github.com/supertokens/supertokens-golang/recipe/^{codeImportRecipeName}"
 )
 
 func main() {
 
-	userInfo, err := thirdpartypasswordless.GetUserByPhoneNumber("public", "+1234567890")
+	tenantId := "public"
+	userInfo, err := passwordless.GetUserByPhoneNumber(tenantId, "+1234567890")
 	if err != nil {
 		// TODO: Handle error
 		return
@@ -184,7 +212,7 @@ func main() {
 <TabItem value="asyncio">
 
 ```python
-from supertokens_python.recipe.thirdpartypasswordless.asyncio import get_user_by_phone_number
+from supertokens_python.recipe.passwordless.asyncio import get_user_by_phone_number
 
 async def some_func():
     _ = await get_user_by_phone_number("public", "+1234567890")
@@ -210,6 +238,8 @@ user_info = get_user_by_phone_number("public", "+1234567890")
 Notice that we pass in the `"public"` tenantId to the function call above. This is the default tenantID and will return the user with the given phone number that belongs to the `public` tenant. You can provide a different tenantID if required.
 
 </CustomAdmonition>
+
+<!-- END COPY SECTION -->
 
 <!-- COPY SECTION -->
 <!-- ./thirdpartyemailpassword/common-customizations/get-user-info.mdx -->


### PR DESCRIPTION
## Summary of change

On this page (https://supertokens.com/docs/passwordless/common-customizations/get-user-info#fetching-information-using-the-users-email), fixed text references to getUserByEmail, getUserById in text around node-related snippets since those are not being used in the code snippets.

I used COPY SECTION since there was a lot of duplication among all recipes, which I believe made this slip by.

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
