### PR TITLE
fix: Tabs taking full width in docs

### DIFF
--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -136,7 +136,7 @@ html[data-theme="dark"] .markdown p {
   margin: 0 0 20px;
 }
 
-html[data-theme="dark"] .tabs-container p {
+html[data-theme="dark"] .docs-tabs-container p {
   margin: 16px 0px 20px;
 }
 
@@ -451,37 +451,37 @@ html[data-theme='dark'] main>.container>.row .table-of-contents .table-of-conten
 }
 
 /* tabs */
-html[data-theme='dark'] .tabs-container:not(.sub-tab) {
+html[data-theme='dark'] .docs-tabs-container:not(.sub-tab) {
   border-radius: 6px;
   margin-bottom: 20px;
 }
 
-html[data-theme="dark"] .tabs-container div[role="tabpanel"]>div[class^="codeBlockContainer"]:last-child,
-html[data-theme="dark"] .tabs-container div[role="tabpanel"]>.app-info-form-container:last-child,
-html[data-theme="dark"] .tabs-container div[role="tabpanel"]>.app-info-form-question-container:last-child {
+html[data-theme="dark"] .docs-tabs-container div[role="tabpanel"]>div[class^="codeBlockContainer"]:last-child,
+html[data-theme="dark"] .docs-tabs-container div[role="tabpanel"]>.app-info-form-container:last-child,
+html[data-theme="dark"] .docs-tabs-container div[role="tabpanel"]>.app-info-form-question-container:last-child {
   margin-bottom: 20px;
 }
 
-html[data-theme="dark"] .tabs-container div[role="tabpanel"]>img:first-child {
+html[data-theme="dark"] .docs-tabs-container div[role="tabpanel"]>img:first-child {
   margin-top: 0px;
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
 }
 
-html[data-theme="dark"] .tabs-container div[role="tabpanel"]>*:last-child {
+html[data-theme="dark"] .docs-tabs-container div[role="tabpanel"]>*:last-child {
   margin-bottom: 0px;
 }
 
-html[data-theme='dark'] .tabs-container:not(.sub-tab)>ul[role="tablist"] {
+html[data-theme='dark'] .docs-tabs-container:not(.sub-tab)>ul[role="tablist"] {
   border: 1px solid rgb(51, 51, 51);
   box-shadow: var(--container-box-shadow);
 }
 
-html[data-theme='dark'] .tabs-container p {
+html[data-theme='dark'] .docs-tabs-container p {
   margin: 16px 0px 20px;
 }
 
-html[data-theme='dark'] .tabs-container:not(.sub-tab)>.tabs>.tabs__item {
+html[data-theme='dark'] .docs-tabs-container:not(.sub-tab)>.tabs>.tabs__item {
   font-size: 16px;
   padding: 16px;
   font-weight: bold;
@@ -489,33 +489,33 @@ html[data-theme='dark'] .tabs-container:not(.sub-tab)>.tabs>.tabs__item {
   border-radius: 0px;
 }
 
-html[data-theme='dark'] .tabs-container.sub-tab>.tabs>.tabs__item {
+html[data-theme='dark'] .docs-tabs-container.sub-tab>.tabs>.tabs__item {
   font-size: 13px;
   padding: 16px 10px;
   white-space: nowrap;
   border-radius: 0px;
 }
 
-html[data-theme='dark'] .tabs-container.sub-tab>.tabs {
+html[data-theme='dark'] .docs-tabs-container.sub-tab>.tabs {
   background-color: rgb(21, 21, 21);
   border: 1px solid rgb(51, 51, 51);
   border-top: 0px;
   box-shadow: var(--container-box-shadow);
 }
 
-html[data-theme='dark'] .tabs-container.sub-tab:not(:first-child)>.tabs {
+html[data-theme='dark'] .docs-tabs-container.sub-tab:not(:first-child)>.tabs {
   border-top: 1px solid rgb(51, 51, 51);
   border-radius: 6px;
 }
 
-html[data-theme='dark'] .tabs-container ol:not(.tabs),
-html[data-theme='dark'] .tabs-container ul:not(.tabs) {
+html[data-theme='dark'] .docs-tabs-container ol:not(.tabs),
+html[data-theme='dark'] .docs-tabs-container ul:not(.tabs) {
   margin-bottom: 0px;
   padding-bottom: 16px;
 }
 
-html[data-theme="dark"] .tabs-container div[role="tabpanel"]>ol:not(.tabs):first-child,
-html[data-theme="dark"] .tabs-container div[role="tabpanel"]>ul:not(.tabs):first-child {
+html[data-theme="dark"] .docs-tabs-container div[role="tabpanel"]>ol:not(.tabs):first-child,
+html[data-theme="dark"] .docs-tabs-container div[role="tabpanel"]>ul:not(.tabs):first-child {
   margin-top: 20px;
   margin-bottom: 20px;
   padding-bottom: 0px;
@@ -527,23 +527,23 @@ html[data-theme="dark"] .app-info-form-container {
   box-shadow: var(--container-box-shadow);
 }
 
-html[data-theme='dark'] .tabs-container .app-info-form-question-container {
+html[data-theme='dark'] .docs-tabs-container .app-info-form-question-container {
   border: 1px solid #404040;
 }
 
-html[data-theme='dark'] .tabs-container .app-info-form-container {
+html[data-theme='dark'] .docs-tabs-container .app-info-form-container {
   border: 0px;
 }
 
-html[data-theme='dark'] .tabs-container .app-info-form-question-container:first-child,
-html[data-theme='dark'] .tabs-container .app-info-form-container:first-child {
+html[data-theme='dark'] .docs-tabs-container .app-info-form-question-container:first-child,
+html[data-theme='dark'] .docs-tabs-container .app-info-form-container:first-child {
   border: 1px solid #404040;
   border-top: 0px;
   border-top-left-radius: 0px !important;
   border-top-right-radius: 0px;
 }
 
-html[data-theme="dark"] .tabs-container div[role="tabpanel"] div[class^="codeBlockContainer"]:first-child .prism-code {
+html[data-theme="dark"] .docs-tabs-container div[role="tabpanel"] div[class^="codeBlockContainer"]:first-child .prism-code {
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
 }

--- a/v2/src/theme/Tabs/index.js
+++ b/v2/src/theme/Tabs/index.js
@@ -95,7 +95,7 @@ function Tabs(props) {
   return (
     <div
       className={clsx(
-        'tabs-container',
+        'docs-tabs-container',
         {
           'sub-tab': isSubTab
         }


### PR DESCRIPTION
## Summary of change

Change the name of the tabs-container class to docs-tabs-container for tabs to prevent conflicts with the SaaS dashboard CSS introduced with this PR: https://github.com/supertokens/main-website/pull/1239

The above PR added the SaaS dashboard CSS to all the pages which also had a `tabs-container` class which apart from a few other things set the width to 60vw as shown in the below screenshot:

<img width="346" alt="image" src="https://github.com/supertokens/docs/assets/21277179/8d6149c7-f730-4cae-a52f-5a12335d5b9e">

This PR resolves that by removing the conflict in class name.


## Related issues
N/A

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
N/A