### PR TITLE
fix: Update docs for olderCookieDomain config

### DIFF
--- a/v2/emailpassword/common-customizations/sessions/error-handling.mdx
+++ b/v2/emailpassword/common-customizations/sessions/error-handling.mdx
@@ -38,7 +38,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onUnauthorised: async (message, request, response) => {
+                onUnauthorised: async (message, request, response, userContext) => {
                     // TODO: Write your own logic and then send a 401 response to the frontend
                 },
             }
@@ -132,7 +132,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onInvalidClaim: async (message, request, response) => {
+                onInvalidClaim: async (validatorErrors, request, response, userContext) => {
                     // TODO: Write your own logic and then send a 403 response to the frontend
                 },
             }
@@ -231,7 +231,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onTokenTheftDetected: async (sessionHandle, userId, req, res) => {
+                onTokenTheftDetected: async (sessionHandle, userId, req, res, userContext) => {
                     // TODO: Write your own logic and then send a 401 response to the frontend
                 },
             }
@@ -299,5 +299,193 @@ init(
 )
 ```
 
+</TabItem>
+</BackendSDKTabs>
+
+
+### Try Refresh Token
+
+- Thrown when the access token is expired or invalid. This can also be thrown from the session refresh endpoint if multiple access tokens are present in the request cookies.
+- The default bahaviour of this is to send a 401 to the frontend.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            //highlight-start
+            errorHandlers: {
+                onTryRefreshToken: async (message, request, response, userContext) => {
+                    // TODO: Write your own logic and then send a 401 response to the frontend
+                },
+            }
+            //highlight-end
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"net/http"
+
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				//highlight-start
+				ErrorHandlers: &sessmodels.ErrorHandlers{
+					OnTryRefreshToken: func(message string, req *http.Request, res http.ResponseWriter) error {
+						// TODO: Write your own logic and then send a 401 response to the frontend
+						return nil
+					},
+				},
+				//highlight-end
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+from supertokens_python.framework import BaseRequest, BaseResponse
+
+async def try_refresh_callback(req: BaseRequest, err: str, response: BaseResponse):
+    # TODO: Write your own logic and then send a 401 response to the frontend
+    return response
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            error_handlers=session.InputErrorHandlers(
+                on_try_refresh_token=try_refresh_callback
+            )
+            # highlight-end
+        )
+    ]
+)
+```
+ 
+</TabItem>
+</BackendSDKTabs>
+
+
+### Clear Duplicate Session Cookies
+
+- Thrown when the refresh session API clears session cookies from the `olderCookieDomain` because multiple access tokens were found in the request cookies. See [this issue](https://github.com/supertokens/supertokens-node/issues/826) for more information.
+- The default bahaviour of this is to send a 200 to the frontend.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            //highlight-start
+            errorHandlers: {
+                onClearDuplicateSessionCookies: async (message, request, response, userContext) => {
+                    // TODO: Write your own logic and then send a 200 response to the frontend
+                },
+            }
+            //highlight-end
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"net/http"
+
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				//highlight-start
+				ErrorHandlers: &sessmodels.ErrorHandlers{
+					OnClearDuplicateSessionCookies: func(message string, req *http.Request, res http.ResponseWriter) error {
+						// TODO: Write your own logic and then send a 200 response to the frontend
+						return nil
+					},
+				},
+				//highlight-end
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+from supertokens_python.framework import BaseRequest, BaseResponse
+
+async def on_clear_duplication_session_cookies_callback(req: BaseRequest, err: str, response: BaseResponse):
+    # TODO: Write your own logic and then send a 200 response to the frontend
+    return response
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            error_handlers=session.InputErrorHandlers(
+                on_clear_duplicate_session_cookies=on_clear_duplication_session_cookies_callback
+            )
+            # highlight-end
+        )
+    ]
+)
+```
+ 
 </TabItem>
 </BackendSDKTabs>

--- a/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -52,6 +52,7 @@ SuperTokens.init({
         Session.init({
             // highlight-next-line
             cookieDomain: ".example.com",
+            olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
     ]
 });
@@ -69,12 +70,14 @@ import (
 func main() {
 	// highlight-next-line
 	cookieDomain := ".example.com"
+	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
+				OlderCookieDomain: &olderCookieDomain,
 			}),
 		},
 	})
@@ -95,6 +98,7 @@ init(
         session.init(
             # highlight-start
             cookie_domain='.example.com'
+            older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
     ]
@@ -110,6 +114,10 @@ The above will set the session cookies' domain to `.example.com`, allowing them 
 Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
 
 For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
+:::
+
+:::important
+The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
 ## Step 2) Frontend config

--- a/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -28,9 +28,9 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 - `sessionTokenBackendDomain` in the frontend config must match the `cookieDomain` set in the backend config.
 :::
 
-## Step 1) Backend config
+## Step 1) Set Cookie Domain in the Backend Config
 
-You need to set the `sessionTokenBackendDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -52,6 +52,95 @@ SuperTokens.init({
         Session.init({
             // highlight-next-line
             cookieDomain: ".example.com",
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	// highlight-next-line
+	cookieDomain := ".example.com"
+
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				// highlight-next-line
+				CookieDomain: &cookieDomain,
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            cookie_domain='.example.com'
+            # highlight-end
+        )
+    ]
+)
+```
+
+</TabItem>
+</BackendSDKTabs>
+
+The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
+
+:::note
+Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
+
+For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
+:::
+
+## Step 2) Set Older Cookie Domain in the Backend Config
+
+:::caution
+If `olderCookieDomain` isn't set, users with older sessions will be locked out until the `olderCookieDomain` is set correctly or they clear their cookies.
+:::
+
+To avoid locking out users with existing sessions, set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            // highlight-next-line
+            cookieDomain: ".example.com",
+            // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
     ]
@@ -70,14 +159,15 @@ import (
 func main() {
 	// highlight-next-line
 	cookieDomain := ".example.com"
-	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
+    olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
-				OlderCookieDomain: &olderCookieDomain,
+                // highlight-next-line
+                OlderCookieDomain: &olderCookieDomain
 			}),
 		},
 	})
@@ -108,19 +198,15 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
-
-:::note
-Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
-
-For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
-:::
-
-:::important
+:::info
 The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
-## Step 2) Frontend config
+:::info
+Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+:::
+
+## Step 3) Frontend config
 
 You need to set the same value for `sessionTokenBackendDomain` on the frontend. This will allow the frontend SDK to apply interception and automatic refreshing across all your API calls:
 

--- a/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -114,14 +114,6 @@ For local development, you should not set the `cookieDomain` to an IP address ba
 
 ## Step 2) Set Older Cookie Domain in the Backend Config
 
-:::caution
-- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
-
-- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year.
-
-- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
-:::
-
 To avoid locking out users with existing sessions (they will get a 500 error when try to refresh their session), set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
 
 <BackendSDKTabs>
@@ -202,10 +194,18 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-:::info
-- The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
+:::caution
+- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
+
+- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year (even though the JWT expiry is a few hours).
+
+- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
 
 - Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+:::
+
+:::info
+The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
 ## Step 3) Frontend config

--- a/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -30,7 +30,7 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 
 ## Step 1) Set Cookie Domain in the Backend Config
 
-You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is NOT important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -51,7 +51,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: ".example.com",
+            cookieDomain: "example.com", // or ".example.com" (they both work)
         })
     ]
 });
@@ -68,7 +68,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := ".example.com"
+	cookieDomain := "example.com" // or ".example.com" (they both work)
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
@@ -94,7 +94,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='.example.com'
+            cookie_domain='example.com' # or ".example.com" (they both work)
             # highlight-end
         )
     ]
@@ -104,7 +104,7 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
+The above will set the session cookies' domain to `example.com`, allowing them to be sent to `*.example.com`.
 
 :::note
 Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
@@ -115,10 +115,14 @@ For local development, you should not set the `cookieDomain` to an IP address ba
 ## Step 2) Set Older Cookie Domain in the Backend Config
 
 :::caution
-If `olderCookieDomain` isn't set, users with older sessions will be locked out until the `olderCookieDomain` is set correctly or they clear their cookies.
+- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
+
+- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year.
+
+- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
 :::
 
-To avoid locking out users with existing sessions, set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
+To avoid locking out users with existing sessions (they will get a 500 error when try to refresh their session), set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -139,7 +143,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: ".example.com",
+            cookieDomain: "example.com", // or ".example.com" (they both work)
             // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
@@ -158,16 +162,16 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := ".example.com"
-    olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
+	cookieDomain := "example.com"  // or ".example.com" (they both work)
+	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
-                // highlight-next-line
-                OlderCookieDomain: &olderCookieDomain
+				// highlight-next-line
+				OlderCookieDomain: &olderCookieDomain,
 			}),
 		},
 	})
@@ -187,7 +191,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='.example.com'
+            cookie_domain='example.com'  # or ".example.com" (they both work)
             older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
@@ -199,11 +203,9 @@ init(
 </BackendSDKTabs>
 
 :::info
-The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
-:::
+- The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 
-:::info
-Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+- Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
 :::
 
 ## Step 3) Frontend config
@@ -231,7 +233,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line 
-            sessionTokenBackendDomain: ".example.com" 
+            sessionTokenBackendDomain: "example.com"  // or ".example.com" (they both work)
         })
     ]
 });
@@ -262,7 +264,7 @@ SuperTokens.init({
     },
     recipeList: [
         Session.init({
-            sessionTokenBackendDomain: ".example.com"
+            sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
         }),
     ],
 });
@@ -281,7 +283,7 @@ supertokens.init({
     },
     recipeList: [
         supertokensSession.init({
-            sessionTokenBackendDomain: ".example.com",
+            sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
         })
     ],
 });
@@ -303,7 +305,7 @@ import SuperTokens from 'supertokens-react-native';
 
 SuperTokens.init({
     apiDomain: "...",
-    sessionTokenBackendDomain: ".example.com"
+    sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
 });
 ```
 
@@ -321,7 +323,7 @@ class MainApplication: Application() {
         
         SuperTokens.Builder(this, "...")
             // highlight-next-line
-            .sessionTokenBackendDomain(".example.com")
+            .sessionTokenBackendDomain("example.com") // or ".example.com" (they both work)
             .build()
     }
 }
@@ -342,7 +344,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
             try SuperTokens.initialize(
                 apiDomain: "...",
                 // highlight-next-line
-                sessionTokenBackendDomain: ".example.com"
+                sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
             )
         } catch SuperTokensError.initError(let message) {
             // TODO: Handle initialization error
@@ -366,7 +368,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        sessionTokenBackendDomain: ".example.com",
+        sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
     );
 }
 ```

--- a/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -24,7 +24,7 @@ Sharing sessions across multiple sub domains in SuperTokens can be configured by
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
- - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `.example.com`
+ - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `example.com` or `.example.com`.
 
 
 <PreBuiltOrCustomUISwitcher>
@@ -50,7 +50,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com" // or ".example.com" (they both work)
         })
     ]
 });
@@ -97,7 +97,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-start
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
             // highlight-end 
         }),
     ],
@@ -119,7 +119,7 @@ supertokens.init({
         supertokensSession.init({
             // ...
             // highlight-start
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
             // highlight-end
         })
     ],

--- a/v2/emailpassword/nextjs/app-directory/protecting-route.mdx
+++ b/v2/emailpassword/nextjs/app-directory/protecting-route.mdx
@@ -239,6 +239,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             * 
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }
@@ -411,6 +413,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             * 
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }

--- a/v2/emailpassword/nextjs/app-directory/protecting-route.mdx
+++ b/v2/emailpassword/nextjs/app-directory/protecting-route.mdx
@@ -240,7 +240,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -412,7 +412,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 

--- a/v2/emailpassword/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/emailpassword/nextjs/app-directory/server-components-requests.mdx
@@ -66,6 +66,7 @@ export async function HomePage() {
         if (hasInvalidClaims) {
             return <SessionAuthForNextJS />;
         } else {
+            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
             return <TryRefreshComponent key={Date.now()} />;
         }
     }
@@ -89,6 +90,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
+        // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
         return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         // SessionAuthForNextJS will redirect based on which claim is invalid
@@ -176,6 +178,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             *
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }
@@ -200,6 +204,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
+        // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
         return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         /**

--- a/v2/emailpassword/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/emailpassword/nextjs/app-directory/server-components-requests.mdx
@@ -66,7 +66,7 @@ export async function HomePage() {
         if (hasInvalidClaims) {
             return <SessionAuthForNextJS />;
         } else {
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -89,7 +89,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
-        return <TryRefreshComponent />
+        return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         // SessionAuthForNextJS will redirect based on which claim is invalid
         return <SessionAuthForNextJS />;
@@ -177,7 +177,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -200,7 +200,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
-        return <TryRefreshComponent />
+        return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         /**
          * This means that one of the session claims is invalid. You should redirect the user to

--- a/v2/passwordless/common-customizations/sessions/error-handling.mdx
+++ b/v2/passwordless/common-customizations/sessions/error-handling.mdx
@@ -38,7 +38,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onUnauthorised: async (message, request, response) => {
+                onUnauthorised: async (message, request, response, userContext) => {
                     // TODO: Write your own logic and then send a 401 response to the frontend
                 },
             }
@@ -132,7 +132,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onInvalidClaim: async (message, request, response) => {
+                onInvalidClaim: async (validatorErrors, request, response, userContext) => {
                     // TODO: Write your own logic and then send a 403 response to the frontend
                 },
             }
@@ -231,7 +231,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onTokenTheftDetected: async (sessionHandle, userId, req, res) => {
+                onTokenTheftDetected: async (sessionHandle, userId, req, res, userContext) => {
                     // TODO: Write your own logic and then send a 401 response to the frontend
                 },
             }
@@ -299,5 +299,193 @@ init(
 )
 ```
 
+</TabItem>
+</BackendSDKTabs>
+
+
+### Try Refresh Token
+
+- Thrown when the access token is expired or invalid. This can also be thrown from the session refresh endpoint if multiple access tokens are present in the request cookies.
+- The default bahaviour of this is to send a 401 to the frontend.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            //highlight-start
+            errorHandlers: {
+                onTryRefreshToken: async (message, request, response, userContext) => {
+                    // TODO: Write your own logic and then send a 401 response to the frontend
+                },
+            }
+            //highlight-end
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"net/http"
+
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				//highlight-start
+				ErrorHandlers: &sessmodels.ErrorHandlers{
+					OnTryRefreshToken: func(message string, req *http.Request, res http.ResponseWriter) error {
+						// TODO: Write your own logic and then send a 401 response to the frontend
+						return nil
+					},
+				},
+				//highlight-end
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+from supertokens_python.framework import BaseRequest, BaseResponse
+
+async def try_refresh_callback(req: BaseRequest, err: str, response: BaseResponse):
+    # TODO: Write your own logic and then send a 401 response to the frontend
+    return response
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            error_handlers=session.InputErrorHandlers(
+                on_try_refresh_token=try_refresh_callback
+            )
+            # highlight-end
+        )
+    ]
+)
+```
+ 
+</TabItem>
+</BackendSDKTabs>
+
+
+### Clear Duplicate Session Cookies
+
+- Thrown when the refresh session API clears session cookies from the `olderCookieDomain` because multiple access tokens were found in the request cookies. See [this issue](https://github.com/supertokens/supertokens-node/issues/826) for more information.
+- The default bahaviour of this is to send a 200 to the frontend.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            //highlight-start
+            errorHandlers: {
+                onClearDuplicateSessionCookies: async (message, request, response, userContext) => {
+                    // TODO: Write your own logic and then send a 200 response to the frontend
+                },
+            }
+            //highlight-end
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"net/http"
+
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				//highlight-start
+				ErrorHandlers: &sessmodels.ErrorHandlers{
+					OnClearDuplicateSessionCookies: func(message string, req *http.Request, res http.ResponseWriter) error {
+						// TODO: Write your own logic and then send a 200 response to the frontend
+						return nil
+					},
+				},
+				//highlight-end
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+from supertokens_python.framework import BaseRequest, BaseResponse
+
+async def on_clear_duplication_session_cookies_callback(req: BaseRequest, err: str, response: BaseResponse):
+    # TODO: Write your own logic and then send a 200 response to the frontend
+    return response
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            error_handlers=session.InputErrorHandlers(
+                on_clear_duplicate_session_cookies=on_clear_duplication_session_cookies_callback
+            )
+            # highlight-end
+        )
+    ]
+)
+```
+ 
 </TabItem>
 </BackendSDKTabs>

--- a/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -52,6 +52,7 @@ SuperTokens.init({
         Session.init({
             // highlight-next-line
             cookieDomain: ".example.com",
+            olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
     ]
 });
@@ -69,12 +70,14 @@ import (
 func main() {
 	// highlight-next-line
 	cookieDomain := ".example.com"
+	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
+				OlderCookieDomain: &olderCookieDomain,
 			}),
 		},
 	})
@@ -95,6 +98,7 @@ init(
         session.init(
             # highlight-start
             cookie_domain='.example.com'
+            older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
     ]
@@ -110,6 +114,10 @@ The above will set the session cookies' domain to `.example.com`, allowing them 
 Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
 
 For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
+:::
+
+:::important
+The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
 ## Step 2) Frontend config

--- a/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -28,9 +28,9 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 - `sessionTokenBackendDomain` in the frontend config must match the `cookieDomain` set in the backend config.
 :::
 
-## Step 1) Backend config
+## Step 1) Set Cookie Domain in the Backend Config
 
-You need to set the `sessionTokenBackendDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -52,6 +52,95 @@ SuperTokens.init({
         Session.init({
             // highlight-next-line
             cookieDomain: ".example.com",
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	// highlight-next-line
+	cookieDomain := ".example.com"
+
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				// highlight-next-line
+				CookieDomain: &cookieDomain,
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            cookie_domain='.example.com'
+            # highlight-end
+        )
+    ]
+)
+```
+
+</TabItem>
+</BackendSDKTabs>
+
+The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
+
+:::note
+Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
+
+For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
+:::
+
+## Step 2) Set Older Cookie Domain in the Backend Config
+
+:::caution
+If `olderCookieDomain` isn't set, users with older sessions will be locked out until the `olderCookieDomain` is set correctly or they clear their cookies.
+:::
+
+To avoid locking out users with existing sessions, set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            // highlight-next-line
+            cookieDomain: ".example.com",
+            // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
     ]
@@ -70,14 +159,15 @@ import (
 func main() {
 	// highlight-next-line
 	cookieDomain := ".example.com"
-	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
+    olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
-				OlderCookieDomain: &olderCookieDomain,
+                // highlight-next-line
+                OlderCookieDomain: &olderCookieDomain
 			}),
 		},
 	})
@@ -108,19 +198,15 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
-
-:::note
-Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
-
-For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
-:::
-
-:::important
+:::info
 The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
-## Step 2) Frontend config
+:::info
+Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+:::
+
+## Step 3) Frontend config
 
 You need to set the same value for `sessionTokenBackendDomain` on the frontend. This will allow the frontend SDK to apply interception and automatic refreshing across all your API calls:
 

--- a/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -114,14 +114,6 @@ For local development, you should not set the `cookieDomain` to an IP address ba
 
 ## Step 2) Set Older Cookie Domain in the Backend Config
 
-:::caution
-- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
-
-- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year.
-
-- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
-:::
-
 To avoid locking out users with existing sessions (they will get a 500 error when try to refresh their session), set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
 
 <BackendSDKTabs>
@@ -202,10 +194,18 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-:::info
-- The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
+:::caution
+- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
+
+- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year (even though the JWT expiry is a few hours).
+
+- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
 
 - Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+:::
+
+:::info
+The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
 ## Step 3) Frontend config

--- a/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -30,7 +30,7 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 
 ## Step 1) Set Cookie Domain in the Backend Config
 
-You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is NOT important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -51,7 +51,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: ".example.com",
+            cookieDomain: "example.com", // or ".example.com" (they both work)
         })
     ]
 });
@@ -68,7 +68,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := ".example.com"
+	cookieDomain := "example.com" // or ".example.com" (they both work)
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
@@ -94,7 +94,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='.example.com'
+            cookie_domain='example.com' # or ".example.com" (they both work)
             # highlight-end
         )
     ]
@@ -104,7 +104,7 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
+The above will set the session cookies' domain to `example.com`, allowing them to be sent to `*.example.com`.
 
 :::note
 Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
@@ -115,10 +115,14 @@ For local development, you should not set the `cookieDomain` to an IP address ba
 ## Step 2) Set Older Cookie Domain in the Backend Config
 
 :::caution
-If `olderCookieDomain` isn't set, users with older sessions will be locked out until the `olderCookieDomain` is set correctly or they clear their cookies.
+- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
+
+- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year.
+
+- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
 :::
 
-To avoid locking out users with existing sessions, set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
+To avoid locking out users with existing sessions (they will get a 500 error when try to refresh their session), set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -139,7 +143,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: ".example.com",
+            cookieDomain: "example.com", // or ".example.com" (they both work)
             // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
@@ -158,16 +162,16 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := ".example.com"
-    olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
+	cookieDomain := "example.com"  // or ".example.com" (they both work)
+	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
-                // highlight-next-line
-                OlderCookieDomain: &olderCookieDomain
+				// highlight-next-line
+				OlderCookieDomain: &olderCookieDomain,
 			}),
 		},
 	})
@@ -187,7 +191,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='.example.com'
+            cookie_domain='example.com'  # or ".example.com" (they both work)
             older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
@@ -199,11 +203,9 @@ init(
 </BackendSDKTabs>
 
 :::info
-The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
-:::
+- The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 
-:::info
-Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+- Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
 :::
 
 ## Step 3) Frontend config
@@ -231,7 +233,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line 
-            sessionTokenBackendDomain: ".example.com" 
+            sessionTokenBackendDomain: "example.com"  // or ".example.com" (they both work)
         })
     ]
 });
@@ -262,7 +264,7 @@ SuperTokens.init({
     },
     recipeList: [
         Session.init({
-            sessionTokenBackendDomain: ".example.com"
+            sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
         }),
     ],
 });
@@ -281,7 +283,7 @@ supertokens.init({
     },
     recipeList: [
         supertokensSession.init({
-            sessionTokenBackendDomain: ".example.com",
+            sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
         })
     ],
 });
@@ -303,7 +305,7 @@ import SuperTokens from 'supertokens-react-native';
 
 SuperTokens.init({
     apiDomain: "...",
-    sessionTokenBackendDomain: ".example.com"
+    sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
 });
 ```
 
@@ -321,7 +323,7 @@ class MainApplication: Application() {
         
         SuperTokens.Builder(this, "...")
             // highlight-next-line
-            .sessionTokenBackendDomain(".example.com")
+            .sessionTokenBackendDomain("example.com") // or ".example.com" (they both work)
             .build()
     }
 }
@@ -342,7 +344,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
             try SuperTokens.initialize(
                 apiDomain: "...",
                 // highlight-next-line
-                sessionTokenBackendDomain: ".example.com"
+                sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
             )
         } catch SuperTokensError.initError(let message) {
             // TODO: Handle initialization error
@@ -366,7 +368,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        sessionTokenBackendDomain: ".example.com",
+        sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
     );
 }
 ```

--- a/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -24,7 +24,7 @@ Sharing sessions across multiple sub domains in SuperTokens can be configured by
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
- - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `.example.com`
+ - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `example.com` or `.example.com`.
 
 
 <PreBuiltOrCustomUISwitcher>
@@ -50,7 +50,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com" // or ".example.com" (they both work)
         })
     ]
 });
@@ -97,7 +97,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-start
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
             // highlight-end 
         }),
     ],
@@ -119,7 +119,7 @@ supertokens.init({
         supertokensSession.init({
             // ...
             // highlight-start
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
             // highlight-end
         })
     ],

--- a/v2/passwordless/nextjs/app-directory/protecting-route.mdx
+++ b/v2/passwordless/nextjs/app-directory/protecting-route.mdx
@@ -239,6 +239,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             * 
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }
@@ -411,6 +413,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             * 
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }

--- a/v2/passwordless/nextjs/app-directory/protecting-route.mdx
+++ b/v2/passwordless/nextjs/app-directory/protecting-route.mdx
@@ -240,7 +240,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -412,7 +412,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 

--- a/v2/passwordless/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/passwordless/nextjs/app-directory/server-components-requests.mdx
@@ -66,6 +66,7 @@ export async function HomePage() {
         if (hasInvalidClaims) {
             return <SessionAuthForNextJS />;
         } else {
+            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
             return <TryRefreshComponent key={Date.now()} />;
         }
     }
@@ -89,6 +90,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
+        // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
         return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         // SessionAuthForNextJS will redirect based on which claim is invalid
@@ -176,6 +178,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             *
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }
@@ -200,6 +204,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
+        // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
         return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         /**

--- a/v2/passwordless/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/passwordless/nextjs/app-directory/server-components-requests.mdx
@@ -66,7 +66,7 @@ export async function HomePage() {
         if (hasInvalidClaims) {
             return <SessionAuthForNextJS />;
         } else {
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -89,7 +89,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
-        return <TryRefreshComponent />
+        return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         // SessionAuthForNextJS will redirect based on which claim is invalid
         return <SessionAuthForNextJS />;
@@ -177,7 +177,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -200,7 +200,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
-        return <TryRefreshComponent />
+        return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         /**
          * This means that one of the session claims is invalid. You should redirect the user to

--- a/v2/session/common-customizations/sessions/error-handling.mdx
+++ b/v2/session/common-customizations/sessions/error-handling.mdx
@@ -38,7 +38,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onUnauthorised: async (message, request, response) => {
+                onUnauthorised: async (message, request, response, userContext) => {
                     // TODO: Write your own logic and then send a 401 response to the frontend
                 },
             }
@@ -132,7 +132,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onInvalidClaim: async (message, request, response) => {
+                onInvalidClaim: async (validatorErrors, request, response, userContext) => {
                     // TODO: Write your own logic and then send a 403 response to the frontend
                 },
             }
@@ -231,7 +231,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onTokenTheftDetected: async (sessionHandle, userId, req, res) => {
+                onTokenTheftDetected: async (sessionHandle, userId, req, res, userContext) => {
                     // TODO: Write your own logic and then send a 401 response to the frontend
                 },
             }
@@ -299,5 +299,193 @@ init(
 )
 ```
 
+</TabItem>
+</BackendSDKTabs>
+
+
+### Try Refresh Token
+
+- Thrown when the access token is expired or invalid. This can also be thrown from the session refresh endpoint if multiple access tokens are present in the request cookies.
+- The default bahaviour of this is to send a 401 to the frontend.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            //highlight-start
+            errorHandlers: {
+                onTryRefreshToken: async (message, request, response, userContext) => {
+                    // TODO: Write your own logic and then send a 401 response to the frontend
+                },
+            }
+            //highlight-end
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"net/http"
+
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				//highlight-start
+				ErrorHandlers: &sessmodels.ErrorHandlers{
+					OnTryRefreshToken: func(message string, req *http.Request, res http.ResponseWriter) error {
+						// TODO: Write your own logic and then send a 401 response to the frontend
+						return nil
+					},
+				},
+				//highlight-end
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+from supertokens_python.framework import BaseRequest, BaseResponse
+
+async def try_refresh_callback(req: BaseRequest, err: str, response: BaseResponse):
+    # TODO: Write your own logic and then send a 401 response to the frontend
+    return response
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            error_handlers=session.InputErrorHandlers(
+                on_try_refresh_token=try_refresh_callback
+            )
+            # highlight-end
+        )
+    ]
+)
+```
+ 
+</TabItem>
+</BackendSDKTabs>
+
+
+### Clear Duplicate Session Cookies
+
+- Thrown when the refresh session API clears session cookies from the `olderCookieDomain` because multiple access tokens were found in the request cookies. See [this issue](https://github.com/supertokens/supertokens-node/issues/826) for more information.
+- The default bahaviour of this is to send a 200 to the frontend.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            //highlight-start
+            errorHandlers: {
+                onClearDuplicateSessionCookies: async (message, request, response, userContext) => {
+                    // TODO: Write your own logic and then send a 200 response to the frontend
+                },
+            }
+            //highlight-end
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"net/http"
+
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				//highlight-start
+				ErrorHandlers: &sessmodels.ErrorHandlers{
+					OnClearDuplicateSessionCookies: func(message string, req *http.Request, res http.ResponseWriter) error {
+						// TODO: Write your own logic and then send a 200 response to the frontend
+						return nil
+					},
+				},
+				//highlight-end
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+from supertokens_python.framework import BaseRequest, BaseResponse
+
+async def on_clear_duplication_session_cookies_callback(req: BaseRequest, err: str, response: BaseResponse):
+    # TODO: Write your own logic and then send a 200 response to the frontend
+    return response
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            error_handlers=session.InputErrorHandlers(
+                on_clear_duplicate_session_cookies=on_clear_duplication_session_cookies_callback
+            )
+            # highlight-end
+        )
+    ]
+)
+```
+ 
 </TabItem>
 </BackendSDKTabs>

--- a/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -52,6 +52,7 @@ SuperTokens.init({
         Session.init({
             // highlight-next-line
             cookieDomain: ".example.com",
+            olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
     ]
 });
@@ -69,12 +70,14 @@ import (
 func main() {
 	// highlight-next-line
 	cookieDomain := ".example.com"
+	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
+				OlderCookieDomain: &olderCookieDomain,
 			}),
 		},
 	})
@@ -95,6 +98,7 @@ init(
         session.init(
             # highlight-start
             cookie_domain='.example.com'
+            older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
     ]
@@ -110,6 +114,10 @@ The above will set the session cookies' domain to `.example.com`, allowing them 
 Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
 
 For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
+:::
+
+:::important
+The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
 ## Step 2) Frontend config

--- a/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -28,9 +28,9 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 - `sessionTokenBackendDomain` in the frontend config must match the `cookieDomain` set in the backend config.
 :::
 
-## Step 1) Backend config
+## Step 1) Set Cookie Domain in the Backend Config
 
-You need to set the `sessionTokenBackendDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -52,6 +52,95 @@ SuperTokens.init({
         Session.init({
             // highlight-next-line
             cookieDomain: ".example.com",
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	// highlight-next-line
+	cookieDomain := ".example.com"
+
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				// highlight-next-line
+				CookieDomain: &cookieDomain,
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            cookie_domain='.example.com'
+            # highlight-end
+        )
+    ]
+)
+```
+
+</TabItem>
+</BackendSDKTabs>
+
+The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
+
+:::note
+Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
+
+For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
+:::
+
+## Step 2) Set Older Cookie Domain in the Backend Config
+
+:::caution
+If `olderCookieDomain` isn't set, users with older sessions will be locked out until the `olderCookieDomain` is set correctly or they clear their cookies.
+:::
+
+To avoid locking out users with existing sessions, set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            // highlight-next-line
+            cookieDomain: ".example.com",
+            // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
     ]
@@ -70,14 +159,15 @@ import (
 func main() {
 	// highlight-next-line
 	cookieDomain := ".example.com"
-	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
+    olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
-				OlderCookieDomain: &olderCookieDomain,
+                // highlight-next-line
+                OlderCookieDomain: &olderCookieDomain
 			}),
 		},
 	})
@@ -108,19 +198,15 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
-
-:::note
-Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
-
-For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
-:::
-
-:::important
+:::info
 The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
-## Step 2) Frontend config
+:::info
+Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+:::
+
+## Step 3) Frontend config
 
 You need to set the same value for `sessionTokenBackendDomain` on the frontend. This will allow the frontend SDK to apply interception and automatic refreshing across all your API calls:
 

--- a/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -114,14 +114,6 @@ For local development, you should not set the `cookieDomain` to an IP address ba
 
 ## Step 2) Set Older Cookie Domain in the Backend Config
 
-:::caution
-- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
-
-- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year.
-
-- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
-:::
-
 To avoid locking out users with existing sessions (they will get a 500 error when try to refresh their session), set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
 
 <BackendSDKTabs>
@@ -202,10 +194,18 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-:::info
-- The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
+:::caution
+- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
+
+- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year (even though the JWT expiry is a few hours).
+
+- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
 
 - Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+:::
+
+:::info
+The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
 ## Step 3) Frontend config

--- a/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -30,7 +30,7 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 
 ## Step 1) Set Cookie Domain in the Backend Config
 
-You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is NOT important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -51,7 +51,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: ".example.com",
+            cookieDomain: "example.com", // or ".example.com" (they both work)
         })
     ]
 });
@@ -68,7 +68,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := ".example.com"
+	cookieDomain := "example.com" // or ".example.com" (they both work)
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
@@ -94,7 +94,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='.example.com'
+            cookie_domain='example.com' # or ".example.com" (they both work)
             # highlight-end
         )
     ]
@@ -104,7 +104,7 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
+The above will set the session cookies' domain to `example.com`, allowing them to be sent to `*.example.com`.
 
 :::note
 Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
@@ -115,10 +115,14 @@ For local development, you should not set the `cookieDomain` to an IP address ba
 ## Step 2) Set Older Cookie Domain in the Backend Config
 
 :::caution
-If `olderCookieDomain` isn't set, users with older sessions will be locked out until the `olderCookieDomain` is set correctly or they clear their cookies.
+- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
+
+- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year.
+
+- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
 :::
 
-To avoid locking out users with existing sessions, set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
+To avoid locking out users with existing sessions (they will get a 500 error when try to refresh their session), set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -139,7 +143,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: ".example.com",
+            cookieDomain: "example.com", // or ".example.com" (they both work)
             // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
@@ -158,16 +162,16 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := ".example.com"
-    olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
+	cookieDomain := "example.com"  // or ".example.com" (they both work)
+	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
-                // highlight-next-line
-                OlderCookieDomain: &olderCookieDomain
+				// highlight-next-line
+				OlderCookieDomain: &olderCookieDomain,
 			}),
 		},
 	})
@@ -187,7 +191,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='.example.com'
+            cookie_domain='example.com'  # or ".example.com" (they both work)
             older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
@@ -199,11 +203,9 @@ init(
 </BackendSDKTabs>
 
 :::info
-The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
-:::
+- The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 
-:::info
-Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+- Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
 :::
 
 ## Step 3) Frontend config
@@ -231,7 +233,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line 
-            sessionTokenBackendDomain: ".example.com" 
+            sessionTokenBackendDomain: "example.com"  // or ".example.com" (they both work)
         })
     ]
 });
@@ -262,7 +264,7 @@ SuperTokens.init({
     },
     recipeList: [
         Session.init({
-            sessionTokenBackendDomain: ".example.com"
+            sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
         }),
     ],
 });
@@ -281,7 +283,7 @@ supertokens.init({
     },
     recipeList: [
         supertokensSession.init({
-            sessionTokenBackendDomain: ".example.com",
+            sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
         })
     ],
 });
@@ -303,7 +305,7 @@ import SuperTokens from 'supertokens-react-native';
 
 SuperTokens.init({
     apiDomain: "...",
-    sessionTokenBackendDomain: ".example.com"
+    sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
 });
 ```
 
@@ -321,7 +323,7 @@ class MainApplication: Application() {
         
         SuperTokens.Builder(this, "...")
             // highlight-next-line
-            .sessionTokenBackendDomain(".example.com")
+            .sessionTokenBackendDomain("example.com") // or ".example.com" (they both work)
             .build()
     }
 }
@@ -342,7 +344,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
             try SuperTokens.initialize(
                 apiDomain: "...",
                 // highlight-next-line
-                sessionTokenBackendDomain: ".example.com"
+                sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
             )
         } catch SuperTokensError.initError(let message) {
             // TODO: Handle initialization error
@@ -366,7 +368,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        sessionTokenBackendDomain: ".example.com",
+        sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
     );
 }
 ```

--- a/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -24,7 +24,7 @@ Sharing sessions across multiple sub domains in SuperTokens can be configured by
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
- - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `.example.com`
+ - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `example.com` or `.example.com`.
 
 
 <PreBuiltOrCustomUISwitcher>
@@ -50,7 +50,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com" // or ".example.com" (they both work)
         })
     ]
 });
@@ -97,7 +97,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-start
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
             // highlight-end 
         }),
     ],
@@ -119,7 +119,7 @@ supertokens.init({
         supertokensSession.init({
             // ...
             // highlight-start
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
             // highlight-end
         })
     ],

--- a/v2/src/plugins/codeTypeChecking/dart_env/README.md
+++ b/v2/src/plugins/codeTypeChecking/dart_env/README.md
@@ -14,3 +14,9 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Update supertokens_flutter dependency:
+Go into this directory and run:
+```bash
+flutter pub add supertokens_flutter
+```

--- a/v2/src/plugins/codeTypeChecking/dart_env/pubspec.lock
+++ b/v2/src/plugins/codeTypeChecking/dart_env/pubspec.lock
@@ -425,10 +425,10 @@ packages:
     dependency: "direct main"
     description:
       name: supertokens_flutter
-      sha256: d03f0223f1c7485690ee7a2c864144ab5bbcc814961fe551d0c50278cad9af87
+      sha256: "7505f9fdc8def40cac15d403c73016df6571c4549dd79fc40696ecbf124fea99"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.5.0"
   term_glyph:
     dependency: transitive
     description:

--- a/v2/src/plugins/codeTypeChecking/dart_env/pubspec.yaml
+++ b/v2/src/plugins/codeTypeChecking/dart_env/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  supertokens_flutter: ^0.3.0
+  supertokens_flutter: ^0.5.0
   google_sign_in: ^6.1.4
   sign_in_with_apple: ^5.0.0
   dio: ^5.3.3

--- a/v2/src/plugins/codeTypeChecking/goEnv/README.md
+++ b/v2/src/plugins/codeTypeChecking/goEnv/README.md
@@ -1,0 +1,5 @@
+## Updating supertokens-golang in dependency
+Go into this directory and run:
+```bash
+go get -u github.com/supertokens/supertokens-golang@<tag>
+```

--- a/v2/src/plugins/codeTypeChecking/goEnv/go.mod
+++ b/v2/src/plugins/codeTypeChecking/goEnv/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-chi/cors v1.2.1
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
-	github.com/supertokens/supertokens-golang v0.17.4
+	github.com/supertokens/supertokens-golang v0.19.0
 )
 
 require (

--- a/v2/src/plugins/codeTypeChecking/goEnv/go.sum
+++ b/v2/src/plugins/codeTypeChecking/goEnv/go.sum
@@ -97,6 +97,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/supertokens/supertokens-golang v0.17.4 h1:G5FngSJpGjlLG/t+xQtVnq0XkMjhAkZivmmEwgZ2gD4=
 github.com/supertokens/supertokens-golang v0.17.4/go.mod h1:/n6zQ9461RscnnWB4Y4bWwzhPivnj8w79j/doqkLOs8=
+github.com/supertokens/supertokens-golang v0.19.0 h1:TlpsPdFCWqsbqdiJo6gsagHpQ362csWSuMlJmTowigc=
+github.com/supertokens/supertokens-golang v0.19.0/go.mod h1:/n6zQ9461RscnnWB4Y4bWwzhPivnj8w79j/doqkLOs8=
 github.com/twilio/twilio-go v0.26.0 h1:wFW4oTe3/LKt6bvByP7eio8JsjtaLHjMQKOUEzQry7U=
 github.com/twilio/twilio-go v0.26.0/go.mod h1:lz62Hopu4vicpQ056H5TJ0JE4AP0rS3sQ35/ejmgOwE=
 github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=

--- a/v2/src/plugins/codeTypeChecking/iosenv/Podfile
+++ b/v2/src/plugins/codeTypeChecking/iosenv/Podfile
@@ -6,7 +6,7 @@ target 'iosenv' do
   use_frameworks!
 
   # Pods for iosenv
-  pod "SuperTokensIOS", "~> 0.2.5"
+  pod "SuperTokensIOS", "~> 0.3.0"
   pod 'xcbeautify'
   pod 'Alamofire'
   pod 'GoogleSignIn'

--- a/v2/src/plugins/codeTypeChecking/iosenv/Podfile.lock
+++ b/v2/src/plugins/codeTypeChecking/iosenv/Podfile.lock
@@ -14,13 +14,13 @@ PODS:
     - AppAuth/Core (~> 1.6)
     - GTMSessionFetcher/Core (< 4.0, >= 1.5)
   - GTMSessionFetcher/Core (3.1.1)
-  - SuperTokensIOS (0.2.6)
+  - SuperTokensIOS (0.3.0)
   - xcbeautify (0.17.0)
 
 DEPENDENCIES:
   - Alamofire
   - GoogleSignIn
-  - SuperTokensIOS (~> 0.2.5)
+  - SuperTokensIOS (~> 0.3.0)
   - xcbeautify
 
 SPEC REPOS:
@@ -39,9 +39,9 @@ SPEC CHECKSUMS:
   GoogleSignIn: b232380cf495a429b8095d3178a8d5855b42e842
   GTMAppAuth: 99fb010047ba3973b7026e45393f51f27ab965ae
   GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72
-  SuperTokensIOS: 04e07f5343136949df8973aaa6905ee7ffa2d749
+  SuperTokensIOS: bcae8b229f538b8d670c1d45a796ba8ab7d1c8bf
   xcbeautify: 6e2f57af5c3a86d490376d5758030a8dcc201c1b
 
-PODFILE CHECKSUM: 8c8b23d19c13c115133d9d41fd507e3c2cbeab6a
+PODFILE CHECKSUM: ddc76d2bf152351716acdaf0eac33f01742ac3ea
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.15.2

--- a/v2/src/plugins/codeTypeChecking/iosenv/Pods/Manifest.lock
+++ b/v2/src/plugins/codeTypeChecking/iosenv/Pods/Manifest.lock
@@ -14,13 +14,13 @@ PODS:
     - AppAuth/Core (~> 1.6)
     - GTMSessionFetcher/Core (< 4.0, >= 1.5)
   - GTMSessionFetcher/Core (3.1.1)
-  - SuperTokensIOS (0.2.6)
+  - SuperTokensIOS (0.3.0)
   - xcbeautify (0.17.0)
 
 DEPENDENCIES:
   - Alamofire
   - GoogleSignIn
-  - SuperTokensIOS (~> 0.2.5)
+  - SuperTokensIOS (~> 0.3.0)
   - xcbeautify
 
 SPEC REPOS:
@@ -39,9 +39,9 @@ SPEC CHECKSUMS:
   GoogleSignIn: b232380cf495a429b8095d3178a8d5855b42e842
   GTMAppAuth: 99fb010047ba3973b7026e45393f51f27ab965ae
   GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72
-  SuperTokensIOS: 04e07f5343136949df8973aaa6905ee7ffa2d749
+  SuperTokensIOS: bcae8b229f538b8d670c1d45a796ba8ab7d1c8bf
   xcbeautify: 6e2f57af5c3a86d490376d5758030a8dcc201c1b
 
-PODFILE CHECKSUM: 8c8b23d19c13c115133d9d41fd507e3c2cbeab6a
+PODFILE CHECKSUM: ddc76d2bf152351716acdaf0eac33f01742ac3ea
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.15.2

--- a/v2/src/plugins/codeTypeChecking/iosenv/Pods/SuperTokensIOS/SuperTokensIOS/Classes/Version.swift
+++ b/v2/src/plugins/codeTypeChecking/iosenv/Pods/SuperTokensIOS/SuperTokensIOS/Classes/Version.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 internal class Version {
-    static let supported_fdi: [String] = ["1.16", "1.17", "1.18"]
-    static let sdkVersion = "0.2.6"
+    static let supported_fdi: [String] = ["1.16", "1.17", "1.18", "1.19"]
+    static let sdkVersion = "0.3.0"
 }

--- a/v2/src/plugins/codeTypeChecking/iosenv/Pods/Target Support Files/SuperTokensIOS/SuperTokensIOS-Info.plist
+++ b/v2/src/plugins/codeTypeChecking/iosenv/Pods/Target Support Files/SuperTokensIOS/SuperTokensIOS-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.2.6</string>
+  <string>0.3.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/v2/src/plugins/codeTypeChecking/iosenv/README.md
+++ b/v2/src/plugins/codeTypeChecking/iosenv/README.md
@@ -1,0 +1,9 @@
+## Updating SuperTokensIOS dependency
+
+1. Update the version of SuperTokensIOS in the Podfile
+
+2. Run `pod install` in the ios directory
+
+3. If the above doesn't work (cause maybe the version wasn't found):
+- Check that the version is actually released
+- Run `pod repo update` and then `pod install` again

--- a/v2/src/plugins/codeTypeChecking/jsEnv/package.json
+++ b/v2/src/plugins/codeTypeChecking/jsEnv/package.json
@@ -55,14 +55,14 @@
     "react-router-dom5": "npm:react-router-dom@^5.3.0",
     "socket.io": "^4.6.1",
     "socketio": "^1.0.0",
-    "supertokens-auth-react": "^0.39.0",
-    "supertokens-node": "^17.0.0",
+    "supertokens-auth-react": "^0.41.0",
+    "supertokens-node": "^17.1.0",
     "supertokens-node7": "npm:supertokens-node@7.3",
-    "supertokens-react-native": "^4.0.0",
-    "supertokens-web-js": "^0.10.0",
-    "supertokens-web-js-script": "github:supertokens/supertokens-web-js#0.10",
-    "supertokens-website": "^19.0.0",
-    "supertokens-website-script": "github:supertokens/supertokens-website#19.0",
+    "supertokens-react-native": "^5.0.0",
+    "supertokens-web-js": "^0.11.0",
+    "supertokens-web-js-script": "github:supertokens/supertokens-web-js#0.11",
+    "supertokens-website": "^20.0.0",
+    "supertokens-website-script": "github:supertokens/supertokens-website#20.0",
     "typescript": "^4.9.5"
   }
 }

--- a/v2/src/plugins/codeTypeChecking/kotlinEnv/README.md
+++ b/v2/src/plugins/codeTypeChecking/kotlinEnv/README.md
@@ -1,0 +1,3 @@
+## Updating supertokens dependency
+
+Update the version of supertokens-android in app/build.gradle

--- a/v2/src/plugins/codeTypeChecking/kotlinEnv/app/build.gradle
+++ b/v2/src/plugins/codeTypeChecking/kotlinEnv/app/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
-    implementation 'com.github.supertokens:supertokens-android:0.3.0'
+    implementation 'com.github.supertokens:supertokens-android:0.4.0'
     implementation 'com.google.android.gms:play-services-auth:20.3.0'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'com.github.franmontiel:PersistentCookieJar:v1.0.1'

--- a/v2/src/plugins/codeTypeChecking/pythonEnv/README.md
+++ b/v2/src/plugins/codeTypeChecking/pythonEnv/README.md
@@ -1,0 +1,9 @@
+## Updating supertokens4 dependency
+
+```bash
+source venv/bin/activate
+pip install supertokens-python==<version>
+pip freeze > requirements.txt
+```
+
+Check that only supertokens-python is updated in the requirements.txt file (unless you expect some dependency of supertokens python to also be updated).

--- a/v2/src/plugins/codeTypeChecking/pythonEnv/requirements.txt
+++ b/v2/src/plugins/codeTypeChecking/pythonEnv/requirements.txt
@@ -72,7 +72,7 @@ six==1.16.0
 sniffio==1.3.0
 sqlparse==0.4.2
 starlette==0.14.2
-supertokens-python==0.18.0
+supertokens-python==0.20.0
 tldextract==3.1.0
 toml==0.10.2
 tomli==2.0.1

--- a/v2/thirdparty/common-customizations/sessions/error-handling.mdx
+++ b/v2/thirdparty/common-customizations/sessions/error-handling.mdx
@@ -38,7 +38,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onUnauthorised: async (message, request, response) => {
+                onUnauthorised: async (message, request, response, userContext) => {
                     // TODO: Write your own logic and then send a 401 response to the frontend
                 },
             }
@@ -132,7 +132,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onInvalidClaim: async (message, request, response) => {
+                onInvalidClaim: async (validatorErrors, request, response, userContext) => {
                     // TODO: Write your own logic and then send a 403 response to the frontend
                 },
             }
@@ -231,7 +231,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onTokenTheftDetected: async (sessionHandle, userId, req, res) => {
+                onTokenTheftDetected: async (sessionHandle, userId, req, res, userContext) => {
                     // TODO: Write your own logic and then send a 401 response to the frontend
                 },
             }
@@ -299,5 +299,193 @@ init(
 )
 ```
 
+</TabItem>
+</BackendSDKTabs>
+
+
+### Try Refresh Token
+
+- Thrown when the access token is expired or invalid. This can also be thrown from the session refresh endpoint if multiple access tokens are present in the request cookies.
+- The default bahaviour of this is to send a 401 to the frontend.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            //highlight-start
+            errorHandlers: {
+                onTryRefreshToken: async (message, request, response, userContext) => {
+                    // TODO: Write your own logic and then send a 401 response to the frontend
+                },
+            }
+            //highlight-end
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"net/http"
+
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				//highlight-start
+				ErrorHandlers: &sessmodels.ErrorHandlers{
+					OnTryRefreshToken: func(message string, req *http.Request, res http.ResponseWriter) error {
+						// TODO: Write your own logic and then send a 401 response to the frontend
+						return nil
+					},
+				},
+				//highlight-end
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+from supertokens_python.framework import BaseRequest, BaseResponse
+
+async def try_refresh_callback(req: BaseRequest, err: str, response: BaseResponse):
+    # TODO: Write your own logic and then send a 401 response to the frontend
+    return response
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            error_handlers=session.InputErrorHandlers(
+                on_try_refresh_token=try_refresh_callback
+            )
+            # highlight-end
+        )
+    ]
+)
+```
+ 
+</TabItem>
+</BackendSDKTabs>
+
+
+### Clear Duplicate Session Cookies
+
+- Thrown when the refresh session API clears session cookies from the `olderCookieDomain` because multiple access tokens were found in the request cookies. See [this issue](https://github.com/supertokens/supertokens-node/issues/826) for more information.
+- The default bahaviour of this is to send a 200 to the frontend.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            //highlight-start
+            errorHandlers: {
+                onClearDuplicateSessionCookies: async (message, request, response, userContext) => {
+                    // TODO: Write your own logic and then send a 200 response to the frontend
+                },
+            }
+            //highlight-end
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"net/http"
+
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				//highlight-start
+				ErrorHandlers: &sessmodels.ErrorHandlers{
+					OnClearDuplicateSessionCookies: func(message string, req *http.Request, res http.ResponseWriter) error {
+						// TODO: Write your own logic and then send a 200 response to the frontend
+						return nil
+					},
+				},
+				//highlight-end
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+from supertokens_python.framework import BaseRequest, BaseResponse
+
+async def on_clear_duplication_session_cookies_callback(req: BaseRequest, err: str, response: BaseResponse):
+    # TODO: Write your own logic and then send a 200 response to the frontend
+    return response
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            error_handlers=session.InputErrorHandlers(
+                on_clear_duplicate_session_cookies=on_clear_duplication_session_cookies_callback
+            )
+            # highlight-end
+        )
+    ]
+)
+```
+ 
 </TabItem>
 </BackendSDKTabs>

--- a/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -52,6 +52,7 @@ SuperTokens.init({
         Session.init({
             // highlight-next-line
             cookieDomain: ".example.com",
+            olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
     ]
 });
@@ -69,12 +70,14 @@ import (
 func main() {
 	// highlight-next-line
 	cookieDomain := ".example.com"
+	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
+				OlderCookieDomain: &olderCookieDomain,
 			}),
 		},
 	})
@@ -95,6 +98,7 @@ init(
         session.init(
             # highlight-start
             cookie_domain='.example.com'
+            older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
     ]
@@ -110,6 +114,10 @@ The above will set the session cookies' domain to `.example.com`, allowing them 
 Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
 
 For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
+:::
+
+:::important
+The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
 ## Step 2) Frontend config

--- a/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -28,9 +28,9 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 - `sessionTokenBackendDomain` in the frontend config must match the `cookieDomain` set in the backend config.
 :::
 
-## Step 1) Backend config
+## Step 1) Set Cookie Domain in the Backend Config
 
-You need to set the `sessionTokenBackendDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -52,6 +52,95 @@ SuperTokens.init({
         Session.init({
             // highlight-next-line
             cookieDomain: ".example.com",
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	// highlight-next-line
+	cookieDomain := ".example.com"
+
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				// highlight-next-line
+				CookieDomain: &cookieDomain,
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            cookie_domain='.example.com'
+            # highlight-end
+        )
+    ]
+)
+```
+
+</TabItem>
+</BackendSDKTabs>
+
+The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
+
+:::note
+Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
+
+For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
+:::
+
+## Step 2) Set Older Cookie Domain in the Backend Config
+
+:::caution
+If `olderCookieDomain` isn't set, users with older sessions will be locked out until the `olderCookieDomain` is set correctly or they clear their cookies.
+:::
+
+To avoid locking out users with existing sessions, set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            // highlight-next-line
+            cookieDomain: ".example.com",
+            // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
     ]
@@ -70,14 +159,15 @@ import (
 func main() {
 	// highlight-next-line
 	cookieDomain := ".example.com"
-	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
+    olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
-				OlderCookieDomain: &olderCookieDomain,
+                // highlight-next-line
+                OlderCookieDomain: &olderCookieDomain
 			}),
 		},
 	})
@@ -108,19 +198,15 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
-
-:::note
-Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
-
-For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
-:::
-
-:::important
+:::info
 The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
-## Step 2) Frontend config
+:::info
+Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+:::
+
+## Step 3) Frontend config
 
 You need to set the same value for `sessionTokenBackendDomain` on the frontend. This will allow the frontend SDK to apply interception and automatic refreshing across all your API calls:
 

--- a/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -114,14 +114,6 @@ For local development, you should not set the `cookieDomain` to an IP address ba
 
 ## Step 2) Set Older Cookie Domain in the Backend Config
 
-:::caution
-- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
-
-- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year.
-
-- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
-:::
-
 To avoid locking out users with existing sessions (they will get a 500 error when try to refresh their session), set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
 
 <BackendSDKTabs>
@@ -202,10 +194,18 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-:::info
-- The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
+:::caution
+- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
+
+- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year (even though the JWT expiry is a few hours).
+
+- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
 
 - Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+:::
+
+:::info
+The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
 ## Step 3) Frontend config

--- a/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -30,7 +30,7 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 
 ## Step 1) Set Cookie Domain in the Backend Config
 
-You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is NOT important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -51,7 +51,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: ".example.com",
+            cookieDomain: "example.com", // or ".example.com" (they both work)
         })
     ]
 });
@@ -68,7 +68,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := ".example.com"
+	cookieDomain := "example.com" // or ".example.com" (they both work)
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
@@ -94,7 +94,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='.example.com'
+            cookie_domain='example.com' # or ".example.com" (they both work)
             # highlight-end
         )
     ]
@@ -104,7 +104,7 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
+The above will set the session cookies' domain to `example.com`, allowing them to be sent to `*.example.com`.
 
 :::note
 Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
@@ -115,10 +115,14 @@ For local development, you should not set the `cookieDomain` to an IP address ba
 ## Step 2) Set Older Cookie Domain in the Backend Config
 
 :::caution
-If `olderCookieDomain` isn't set, users with older sessions will be locked out until the `olderCookieDomain` is set correctly or they clear their cookies.
+- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
+
+- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year.
+
+- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
 :::
 
-To avoid locking out users with existing sessions, set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
+To avoid locking out users with existing sessions (they will get a 500 error when try to refresh their session), set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -139,7 +143,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: ".example.com",
+            cookieDomain: "example.com", // or ".example.com" (they both work)
             // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
@@ -158,16 +162,16 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := ".example.com"
-    olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
+	cookieDomain := "example.com"  // or ".example.com" (they both work)
+	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
-                // highlight-next-line
-                OlderCookieDomain: &olderCookieDomain
+				// highlight-next-line
+				OlderCookieDomain: &olderCookieDomain,
 			}),
 		},
 	})
@@ -187,7 +191,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='.example.com'
+            cookie_domain='example.com'  # or ".example.com" (they both work)
             older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
@@ -199,11 +203,9 @@ init(
 </BackendSDKTabs>
 
 :::info
-The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
-:::
+- The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 
-:::info
-Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+- Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
 :::
 
 ## Step 3) Frontend config
@@ -231,7 +233,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line 
-            sessionTokenBackendDomain: ".example.com" 
+            sessionTokenBackendDomain: "example.com"  // or ".example.com" (they both work)
         })
     ]
 });
@@ -262,7 +264,7 @@ SuperTokens.init({
     },
     recipeList: [
         Session.init({
-            sessionTokenBackendDomain: ".example.com"
+            sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
         }),
     ],
 });
@@ -281,7 +283,7 @@ supertokens.init({
     },
     recipeList: [
         supertokensSession.init({
-            sessionTokenBackendDomain: ".example.com",
+            sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
         })
     ],
 });
@@ -303,7 +305,7 @@ import SuperTokens from 'supertokens-react-native';
 
 SuperTokens.init({
     apiDomain: "...",
-    sessionTokenBackendDomain: ".example.com"
+    sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
 });
 ```
 
@@ -321,7 +323,7 @@ class MainApplication: Application() {
         
         SuperTokens.Builder(this, "...")
             // highlight-next-line
-            .sessionTokenBackendDomain(".example.com")
+            .sessionTokenBackendDomain("example.com") // or ".example.com" (they both work)
             .build()
     }
 }
@@ -342,7 +344,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
             try SuperTokens.initialize(
                 apiDomain: "...",
                 // highlight-next-line
-                sessionTokenBackendDomain: ".example.com"
+                sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
             )
         } catch SuperTokensError.initError(let message) {
             // TODO: Handle initialization error
@@ -366,7 +368,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        sessionTokenBackendDomain: ".example.com",
+        sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
     );
 }
 ```

--- a/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -24,7 +24,7 @@ Sharing sessions across multiple sub domains in SuperTokens can be configured by
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
- - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `.example.com`
+ - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `example.com` or `.example.com`.
 
 
 <PreBuiltOrCustomUISwitcher>
@@ -50,7 +50,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com" // or ".example.com" (they both work)
         })
     ]
 });
@@ -97,7 +97,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-start
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
             // highlight-end 
         }),
     ],
@@ -119,7 +119,7 @@ supertokens.init({
         supertokensSession.init({
             // ...
             // highlight-start
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
             // highlight-end
         })
     ],

--- a/v2/thirdparty/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdparty/nextjs/app-directory/protecting-route.mdx
@@ -239,6 +239,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             * 
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }
@@ -411,6 +413,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             * 
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }

--- a/v2/thirdparty/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdparty/nextjs/app-directory/protecting-route.mdx
@@ -240,7 +240,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -412,7 +412,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 

--- a/v2/thirdparty/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdparty/nextjs/app-directory/server-components-requests.mdx
@@ -66,6 +66,7 @@ export async function HomePage() {
         if (hasInvalidClaims) {
             return <SessionAuthForNextJS />;
         } else {
+            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
             return <TryRefreshComponent key={Date.now()} />;
         }
     }
@@ -89,6 +90,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
+        // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
         return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         // SessionAuthForNextJS will redirect based on which claim is invalid
@@ -176,6 +178,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             *
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }
@@ -200,6 +204,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
+        // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
         return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         /**

--- a/v2/thirdparty/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdparty/nextjs/app-directory/server-components-requests.mdx
@@ -66,7 +66,7 @@ export async function HomePage() {
         if (hasInvalidClaims) {
             return <SessionAuthForNextJS />;
         } else {
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -89,7 +89,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
-        return <TryRefreshComponent />
+        return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         // SessionAuthForNextJS will redirect based on which claim is invalid
         return <SessionAuthForNextJS />;
@@ -177,7 +177,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -200,7 +200,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
-        return <TryRefreshComponent />
+        return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         /**
          * This means that one of the session claims is invalid. You should redirect the user to

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/error-handling.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/error-handling.mdx
@@ -38,7 +38,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onUnauthorised: async (message, request, response) => {
+                onUnauthorised: async (message, request, response, userContext) => {
                     // TODO: Write your own logic and then send a 401 response to the frontend
                 },
             }
@@ -132,7 +132,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onInvalidClaim: async (message, request, response) => {
+                onInvalidClaim: async (validatorErrors, request, response, userContext) => {
                     // TODO: Write your own logic and then send a 403 response to the frontend
                 },
             }
@@ -231,7 +231,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onTokenTheftDetected: async (sessionHandle, userId, req, res) => {
+                onTokenTheftDetected: async (sessionHandle, userId, req, res, userContext) => {
                     // TODO: Write your own logic and then send a 401 response to the frontend
                 },
             }
@@ -299,5 +299,193 @@ init(
 )
 ```
 
+</TabItem>
+</BackendSDKTabs>
+
+
+### Try Refresh Token
+
+- Thrown when the access token is expired or invalid. This can also be thrown from the session refresh endpoint if multiple access tokens are present in the request cookies.
+- The default bahaviour of this is to send a 401 to the frontend.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            //highlight-start
+            errorHandlers: {
+                onTryRefreshToken: async (message, request, response, userContext) => {
+                    // TODO: Write your own logic and then send a 401 response to the frontend
+                },
+            }
+            //highlight-end
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"net/http"
+
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				//highlight-start
+				ErrorHandlers: &sessmodels.ErrorHandlers{
+					OnTryRefreshToken: func(message string, req *http.Request, res http.ResponseWriter) error {
+						// TODO: Write your own logic and then send a 401 response to the frontend
+						return nil
+					},
+				},
+				//highlight-end
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+from supertokens_python.framework import BaseRequest, BaseResponse
+
+async def try_refresh_callback(req: BaseRequest, err: str, response: BaseResponse):
+    # TODO: Write your own logic and then send a 401 response to the frontend
+    return response
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            error_handlers=session.InputErrorHandlers(
+                on_try_refresh_token=try_refresh_callback
+            )
+            # highlight-end
+        )
+    ]
+)
+```
+ 
+</TabItem>
+</BackendSDKTabs>
+
+
+### Clear Duplicate Session Cookies
+
+- Thrown when the refresh session API clears session cookies from the `olderCookieDomain` because multiple access tokens were found in the request cookies. See [this issue](https://github.com/supertokens/supertokens-node/issues/826) for more information.
+- The default bahaviour of this is to send a 200 to the frontend.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            //highlight-start
+            errorHandlers: {
+                onClearDuplicateSessionCookies: async (message, request, response, userContext) => {
+                    // TODO: Write your own logic and then send a 200 response to the frontend
+                },
+            }
+            //highlight-end
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"net/http"
+
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				//highlight-start
+				ErrorHandlers: &sessmodels.ErrorHandlers{
+					OnClearDuplicateSessionCookies: func(message string, req *http.Request, res http.ResponseWriter) error {
+						// TODO: Write your own logic and then send a 200 response to the frontend
+						return nil
+					},
+				},
+				//highlight-end
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+from supertokens_python.framework import BaseRequest, BaseResponse
+
+async def on_clear_duplication_session_cookies_callback(req: BaseRequest, err: str, response: BaseResponse):
+    # TODO: Write your own logic and then send a 200 response to the frontend
+    return response
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            error_handlers=session.InputErrorHandlers(
+                on_clear_duplicate_session_cookies=on_clear_duplication_session_cookies_callback
+            )
+            # highlight-end
+        )
+    ]
+)
+```
+ 
 </TabItem>
 </BackendSDKTabs>

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -52,6 +52,7 @@ SuperTokens.init({
         Session.init({
             // highlight-next-line
             cookieDomain: ".example.com",
+            olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
     ]
 });
@@ -69,12 +70,14 @@ import (
 func main() {
 	// highlight-next-line
 	cookieDomain := ".example.com"
+	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
+				OlderCookieDomain: &olderCookieDomain,
 			}),
 		},
 	})
@@ -95,6 +98,7 @@ init(
         session.init(
             # highlight-start
             cookie_domain='.example.com'
+            older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
     ]
@@ -110,6 +114,10 @@ The above will set the session cookies' domain to `.example.com`, allowing them 
 Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
 
 For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
+:::
+
+:::important
+The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
 ## Step 2) Frontend config

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -28,9 +28,9 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 - `sessionTokenBackendDomain` in the frontend config must match the `cookieDomain` set in the backend config.
 :::
 
-## Step 1) Backend config
+## Step 1) Set Cookie Domain in the Backend Config
 
-You need to set the `sessionTokenBackendDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -52,6 +52,95 @@ SuperTokens.init({
         Session.init({
             // highlight-next-line
             cookieDomain: ".example.com",
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	// highlight-next-line
+	cookieDomain := ".example.com"
+
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				// highlight-next-line
+				CookieDomain: &cookieDomain,
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            cookie_domain='.example.com'
+            # highlight-end
+        )
+    ]
+)
+```
+
+</TabItem>
+</BackendSDKTabs>
+
+The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
+
+:::note
+Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
+
+For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
+:::
+
+## Step 2) Set Older Cookie Domain in the Backend Config
+
+:::caution
+If `olderCookieDomain` isn't set, users with older sessions will be locked out until the `olderCookieDomain` is set correctly or they clear their cookies.
+:::
+
+To avoid locking out users with existing sessions, set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            // highlight-next-line
+            cookieDomain: ".example.com",
+            // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
     ]
@@ -70,14 +159,15 @@ import (
 func main() {
 	// highlight-next-line
 	cookieDomain := ".example.com"
-	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
+    olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
-				OlderCookieDomain: &olderCookieDomain,
+                // highlight-next-line
+                OlderCookieDomain: &olderCookieDomain
 			}),
 		},
 	})
@@ -108,19 +198,15 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
-
-:::note
-Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
-
-For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
-:::
-
-:::important
+:::info
 The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
-## Step 2) Frontend config
+:::info
+Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+:::
+
+## Step 3) Frontend config
 
 You need to set the same value for `sessionTokenBackendDomain` on the frontend. This will allow the frontend SDK to apply interception and automatic refreshing across all your API calls:
 

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -114,14 +114,6 @@ For local development, you should not set the `cookieDomain` to an IP address ba
 
 ## Step 2) Set Older Cookie Domain in the Backend Config
 
-:::caution
-- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
-
-- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year.
-
-- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
-:::
-
 To avoid locking out users with existing sessions (they will get a 500 error when try to refresh their session), set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
 
 <BackendSDKTabs>
@@ -202,10 +194,18 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-:::info
-- The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
+:::caution
+- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
+
+- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year (even though the JWT expiry is a few hours).
+
+- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
 
 - Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+:::
+
+:::info
+The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
 ## Step 3) Frontend config

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -30,7 +30,7 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 
 ## Step 1) Set Cookie Domain in the Backend Config
 
-You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is NOT important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -51,7 +51,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: ".example.com",
+            cookieDomain: "example.com", // or ".example.com" (they both work)
         })
     ]
 });
@@ -68,7 +68,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := ".example.com"
+	cookieDomain := "example.com" // or ".example.com" (they both work)
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
@@ -94,7 +94,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='.example.com'
+            cookie_domain='example.com' # or ".example.com" (they both work)
             # highlight-end
         )
     ]
@@ -104,7 +104,7 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
+The above will set the session cookies' domain to `example.com`, allowing them to be sent to `*.example.com`.
 
 :::note
 Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
@@ -115,10 +115,14 @@ For local development, you should not set the `cookieDomain` to an IP address ba
 ## Step 2) Set Older Cookie Domain in the Backend Config
 
 :::caution
-If `olderCookieDomain` isn't set, users with older sessions will be locked out until the `olderCookieDomain` is set correctly or they clear their cookies.
+- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
+
+- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year.
+
+- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
 :::
 
-To avoid locking out users with existing sessions, set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
+To avoid locking out users with existing sessions (they will get a 500 error when try to refresh their session), set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -139,7 +143,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: ".example.com",
+            cookieDomain: "example.com", // or ".example.com" (they both work)
             // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
@@ -158,16 +162,16 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := ".example.com"
-    olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
+	cookieDomain := "example.com"  // or ".example.com" (they both work)
+	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
-                // highlight-next-line
-                OlderCookieDomain: &olderCookieDomain
+				// highlight-next-line
+				OlderCookieDomain: &olderCookieDomain,
 			}),
 		},
 	})
@@ -187,7 +191,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='.example.com'
+            cookie_domain='example.com'  # or ".example.com" (they both work)
             older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
@@ -199,11 +203,9 @@ init(
 </BackendSDKTabs>
 
 :::info
-The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
-:::
+- The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 
-:::info
-Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+- Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
 :::
 
 ## Step 3) Frontend config
@@ -231,7 +233,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line 
-            sessionTokenBackendDomain: ".example.com" 
+            sessionTokenBackendDomain: "example.com"  // or ".example.com" (they both work)
         })
     ]
 });
@@ -262,7 +264,7 @@ SuperTokens.init({
     },
     recipeList: [
         Session.init({
-            sessionTokenBackendDomain: ".example.com"
+            sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
         }),
     ],
 });
@@ -281,7 +283,7 @@ supertokens.init({
     },
     recipeList: [
         supertokensSession.init({
-            sessionTokenBackendDomain: ".example.com",
+            sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
         })
     ],
 });
@@ -303,7 +305,7 @@ import SuperTokens from 'supertokens-react-native';
 
 SuperTokens.init({
     apiDomain: "...",
-    sessionTokenBackendDomain: ".example.com"
+    sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
 });
 ```
 
@@ -321,7 +323,7 @@ class MainApplication: Application() {
         
         SuperTokens.Builder(this, "...")
             // highlight-next-line
-            .sessionTokenBackendDomain(".example.com")
+            .sessionTokenBackendDomain("example.com") // or ".example.com" (they both work)
             .build()
     }
 }
@@ -342,7 +344,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
             try SuperTokens.initialize(
                 apiDomain: "...",
                 // highlight-next-line
-                sessionTokenBackendDomain: ".example.com"
+                sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
             )
         } catch SuperTokensError.initError(let message) {
             // TODO: Handle initialization error
@@ -366,7 +368,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        sessionTokenBackendDomain: ".example.com",
+        sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
     );
 }
 ```

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -24,7 +24,7 @@ Sharing sessions across multiple sub domains in SuperTokens can be configured by
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
- - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `.example.com`
+ - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `example.com` or `.example.com`.
 
 
 <PreBuiltOrCustomUISwitcher>
@@ -50,7 +50,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com" // or ".example.com" (they both work)
         })
     ]
 });
@@ -97,7 +97,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-start
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
             // highlight-end 
         }),
     ],
@@ -119,7 +119,7 @@ supertokens.init({
         supertokensSession.init({
             // ...
             // highlight-start
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
             // highlight-end
         })
     ],

--- a/v2/thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx
@@ -240,6 +240,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             * 
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }
@@ -412,6 +414,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             * 
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }

--- a/v2/thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx
@@ -241,7 +241,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -413,7 +413,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 

--- a/v2/thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx
@@ -67,6 +67,7 @@ export async function HomePage() {
         if (hasInvalidClaims) {
             return <SessionAuthForNextJS />;
         } else {
+            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
             return <TryRefreshComponent key={Date.now()} />;
         }
     }
@@ -90,6 +91,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
+        // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
         return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         // SessionAuthForNextJS will redirect based on which claim is invalid
@@ -177,6 +179,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             *
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }
@@ -201,6 +205,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
+        // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
         return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         /**

--- a/v2/thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx
@@ -67,7 +67,7 @@ export async function HomePage() {
         if (hasInvalidClaims) {
             return <SessionAuthForNextJS />;
         } else {
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -90,7 +90,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
-        return <TryRefreshComponent />
+        return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         // SessionAuthForNextJS will redirect based on which claim is invalid
         return <SessionAuthForNextJS />;
@@ -178,7 +178,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -201,7 +201,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
-        return <TryRefreshComponent />
+        return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         /**
          * This means that one of the session claims is invalid. You should redirect the user to

--- a/v2/thirdpartypasswordless/common-customizations/sessions/error-handling.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/error-handling.mdx
@@ -38,7 +38,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onUnauthorised: async (message, request, response) => {
+                onUnauthorised: async (message, request, response, userContext) => {
                     // TODO: Write your own logic and then send a 401 response to the frontend
                 },
             }
@@ -132,7 +132,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onInvalidClaim: async (message, request, response) => {
+                onInvalidClaim: async (validatorErrors, request, response, userContext) => {
                     // TODO: Write your own logic and then send a 403 response to the frontend
                 },
             }
@@ -231,7 +231,7 @@ SuperTokens.init({
         Session.init({
             //highlight-start
             errorHandlers: {
-                onTokenTheftDetected: async (sessionHandle, userId, req, res) => {
+                onTokenTheftDetected: async (sessionHandle, userId, req, res, userContext) => {
                     // TODO: Write your own logic and then send a 401 response to the frontend
                 },
             }
@@ -299,5 +299,193 @@ init(
 )
 ```
 
+</TabItem>
+</BackendSDKTabs>
+
+
+### Try Refresh Token
+
+- Thrown when the access token is expired or invalid. This can also be thrown from the session refresh endpoint if multiple access tokens are present in the request cookies.
+- The default bahaviour of this is to send a 401 to the frontend.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            //highlight-start
+            errorHandlers: {
+                onTryRefreshToken: async (message, request, response, userContext) => {
+                    // TODO: Write your own logic and then send a 401 response to the frontend
+                },
+            }
+            //highlight-end
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"net/http"
+
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				//highlight-start
+				ErrorHandlers: &sessmodels.ErrorHandlers{
+					OnTryRefreshToken: func(message string, req *http.Request, res http.ResponseWriter) error {
+						// TODO: Write your own logic and then send a 401 response to the frontend
+						return nil
+					},
+				},
+				//highlight-end
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+from supertokens_python.framework import BaseRequest, BaseResponse
+
+async def try_refresh_callback(req: BaseRequest, err: str, response: BaseResponse):
+    # TODO: Write your own logic and then send a 401 response to the frontend
+    return response
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            error_handlers=session.InputErrorHandlers(
+                on_try_refresh_token=try_refresh_callback
+            )
+            # highlight-end
+        )
+    ]
+)
+```
+ 
+</TabItem>
+</BackendSDKTabs>
+
+
+### Clear Duplicate Session Cookies
+
+- Thrown when the refresh session API clears session cookies from the `olderCookieDomain` because multiple access tokens were found in the request cookies. See [this issue](https://github.com/supertokens/supertokens-node/issues/826) for more information.
+- The default bahaviour of this is to send a 200 to the frontend.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            //highlight-start
+            errorHandlers: {
+                onClearDuplicateSessionCookies: async (message, request, response, userContext) => {
+                    // TODO: Write your own logic and then send a 200 response to the frontend
+                },
+            }
+            //highlight-end
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"net/http"
+
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				//highlight-start
+				ErrorHandlers: &sessmodels.ErrorHandlers{
+					OnClearDuplicateSessionCookies: func(message string, req *http.Request, res http.ResponseWriter) error {
+						// TODO: Write your own logic and then send a 200 response to the frontend
+						return nil
+					},
+				},
+				//highlight-end
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+from supertokens_python.framework import BaseRequest, BaseResponse
+
+async def on_clear_duplication_session_cookies_callback(req: BaseRequest, err: str, response: BaseResponse):
+    # TODO: Write your own logic and then send a 200 response to the frontend
+    return response
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            error_handlers=session.InputErrorHandlers(
+                on_clear_duplicate_session_cookies=on_clear_duplication_session_cookies_callback
+            )
+            # highlight-end
+        )
+    ]
+)
+```
+ 
 </TabItem>
 </BackendSDKTabs>

--- a/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -52,6 +52,7 @@ SuperTokens.init({
         Session.init({
             // highlight-next-line
             cookieDomain: ".example.com",
+            olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
     ]
 });
@@ -69,12 +70,14 @@ import (
 func main() {
 	// highlight-next-line
 	cookieDomain := ".example.com"
+	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
+				OlderCookieDomain: &olderCookieDomain,
 			}),
 		},
 	})
@@ -95,6 +98,7 @@ init(
         session.init(
             # highlight-start
             cookie_domain='.example.com'
+            older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
     ]
@@ -110,6 +114,10 @@ The above will set the session cookies' domain to `.example.com`, allowing them 
 Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
 
 For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
+:::
+
+:::important
+The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
 ## Step 2) Frontend config

--- a/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -28,9 +28,9 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 - `sessionTokenBackendDomain` in the frontend config must match the `cookieDomain` set in the backend config.
 :::
 
-## Step 1) Backend config
+## Step 1) Set Cookie Domain in the Backend Config
 
-You need to set the `sessionTokenBackendDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -52,6 +52,95 @@ SuperTokens.init({
         Session.init({
             // highlight-next-line
             cookieDomain: ".example.com",
+        })
+    ]
+});
+```
+</TabItem>
+<TabItem value="go">
+
+```go
+import (
+	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
+	"github.com/supertokens/supertokens-golang/supertokens"
+)
+
+func main() {
+	// highlight-next-line
+	cookieDomain := ".example.com"
+
+	supertokens.Init(supertokens.TypeInput{
+		RecipeList: []supertokens.Recipe{
+			session.Init(&sessmodels.TypeInput{
+				// highlight-next-line
+				CookieDomain: &cookieDomain,
+			}),
+		},
+	})
+}
+```
+</TabItem>
+<TabItem value="python">
+
+```python
+from supertokens_python import init, InputAppInfo
+from supertokens_python.recipe import session
+
+
+init(
+    app_info=InputAppInfo(api_domain="...", app_name="...", website_domain="..."),
+    framework='...', # type: ignore
+    recipe_list=[
+        session.init(
+            # highlight-start
+            cookie_domain='.example.com'
+            # highlight-end
+        )
+    ]
+)
+```
+
+</TabItem>
+</BackendSDKTabs>
+
+The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
+
+:::note
+Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
+
+For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
+:::
+
+## Step 2) Set Older Cookie Domain in the Backend Config
+
+:::caution
+If `olderCookieDomain` isn't set, users with older sessions will be locked out until the `olderCookieDomain` is set correctly or they clear their cookies.
+:::
+
+To avoid locking out users with existing sessions, set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
+
+<BackendSDKTabs>
+<TabItem value="nodejs">
+
+```tsx
+import SuperTokens from "supertokens-node";
+import Session from "supertokens-node/recipe/session";
+
+SuperTokens.init({
+    supertokens: {
+        connectionURI: "...",
+    },
+    appInfo: {
+        apiDomain: "...",
+        appName: "...",
+        websiteDomain: "..."
+    },
+    recipeList: [
+        Session.init({
+            // highlight-next-line
+            cookieDomain: ".example.com",
+            // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
     ]
@@ -70,14 +159,15 @@ import (
 func main() {
 	// highlight-next-line
 	cookieDomain := ".example.com"
-	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
+    olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
-				OlderCookieDomain: &olderCookieDomain,
+                // highlight-next-line
+                OlderCookieDomain: &olderCookieDomain
 			}),
 		},
 	})
@@ -108,19 +198,15 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
-
-:::note
-Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
-
-For local development, you should not set the `cookieDomain` to an IP address based domain, or `.localhost` - browsers will reject these cookies. Instead, you should [alias `localhost` to a named domain and use that](https://superuser.com/questions/152146/how-to-alias-a-hostname-on-mac-osx). 
-:::
-
-:::important
+:::info
 The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
-## Step 2) Frontend config
+:::info
+Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+:::
+
+## Step 3) Frontend config
 
 You need to set the same value for `sessionTokenBackendDomain` on the frontend. This will allow the frontend SDK to apply interception and automatic refreshing across all your API calls:
 

--- a/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -114,14 +114,6 @@ For local development, you should not set the `cookieDomain` to an IP address ba
 
 ## Step 2) Set Older Cookie Domain in the Backend Config
 
-:::caution
-- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
-
-- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year.
-
-- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
-:::
-
 To avoid locking out users with existing sessions (they will get a 500 error when try to refresh their session), set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
 
 <BackendSDKTabs>
@@ -202,10 +194,18 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-:::info
-- The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
+:::caution
+- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
+
+- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year (even though the JWT expiry is a few hours).
+
+- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
 
 - Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+:::
+
+:::info
+The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 :::
 
 ## Step 3) Frontend config

--- a/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -30,7 +30,7 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 
 ## Step 1) Set Cookie Domain in the Backend Config
 
-You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is NOT important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -51,7 +51,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: ".example.com",
+            cookieDomain: "example.com", // or ".example.com" (they both work)
         })
     ]
 });
@@ -68,7 +68,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := ".example.com"
+	cookieDomain := "example.com" // or ".example.com" (they both work)
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
@@ -94,7 +94,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='.example.com'
+            cookie_domain='example.com' # or ".example.com" (they both work)
             # highlight-end
         )
     ]
@@ -104,7 +104,7 @@ init(
 </TabItem>
 </BackendSDKTabs>
 
-The above will set the session cookies' domain to `.example.com`, allowing them to be sent to `*.example.com`.
+The above will set the session cookies' domain to `example.com`, allowing them to be sent to `*.example.com`.
 
 :::note
 Whilst the `cookieDomain` can start with a leading `.`, the value of the `apiDomain` in `appInfo` must point to an exact API domain only. This should be the API in which you want to expose all the auth related endpoints (for example `/auth/signin`).
@@ -115,10 +115,14 @@ For local development, you should not set the `cookieDomain` to an IP address ba
 ## Step 2) Set Older Cookie Domain in the Backend Config
 
 :::caution
-If `olderCookieDomain` isn't set, users with older sessions will be locked out until the `olderCookieDomain` is set correctly or they clear their cookies.
+- If `olderCookieDomain` isn't set, users with older sessions will get a 500 error from the session refresh endpoint, effectively locking them out. This will continue until `olderCookieDomain` is set correctly or they clear their cookies.
+
+- The value set for `olderCookieDomain` must be kept for 1 year because the cookie lifetime of the access token on the frontend is 1 year.
+
+- If you have changed the `cookieDomain` more than once within one year, to prevent a stuck state, switch to [header based auth](https://supertokens.com/docs/session/common-customizations/sessions/token-transfer-method#backend-configuration-optional) for all your clients. The important thing here is that you have to set the backend config to header even though that doc says it's optional. This is so that all clients are forced to use header based auth.
 :::
 
-To avoid locking out users with existing sessions, set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
+To avoid locking out users with existing sessions (they will get a 500 error when try to refresh their session), set `olderCookieDomain` to match your previous `cookieDomain`. If your `cookieDomain` was not set, you can use an empty string. However, if you don't have any existing sessions, you can skip this step entirely.
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -139,7 +143,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: ".example.com",
+            cookieDomain: "example.com", // or ".example.com" (they both work)
             // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
@@ -158,16 +162,16 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := ".example.com"
-    olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
+	cookieDomain := "example.com"  // or ".example.com" (they both work)
+	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
 			session.Init(&sessmodels.TypeInput{
 				// highlight-next-line
 				CookieDomain: &cookieDomain,
-                // highlight-next-line
-                OlderCookieDomain: &olderCookieDomain
+				// highlight-next-line
+				OlderCookieDomain: &olderCookieDomain,
 			}),
 		},
 	})
@@ -187,7 +191,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='.example.com'
+            cookie_domain='example.com'  # or ".example.com" (they both work)
             older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
@@ -199,11 +203,9 @@ init(
 </BackendSDKTabs>
 
 :::info
-The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
-:::
+- The `olderCookieDomain` value should be set to prevent clients from having multiple session cookies from different domains. This can happen when cookies from a previous domain are still valid and sent with requests. For instance, if your previous `cookieDomain` was `api.example.com` and the new one is `.example.com`, both sets of cookies would be sent to the apiDomain `api.example.com`, leading to an inconsistent state. This can cause issues until the older cookies are cleared. Setting `olderCookieDomain` in the configuration ensures that the SuperTokens SDK can automatically remove these older cookies.
 
-:::info
-Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
+- Changing the `cookieDomain` can cause a temporary spike in requests, even if the `olderCookieDomain` is set correctly. This happens because older sessions, with older cookie domain, require additional refresh calls to clear their old cookies and set new ones. This spike is a one-time event and should not recur after the update.
 :::
 
 ## Step 3) Frontend config
@@ -231,7 +233,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line 
-            sessionTokenBackendDomain: ".example.com" 
+            sessionTokenBackendDomain: "example.com"  // or ".example.com" (they both work)
         })
     ]
 });
@@ -262,7 +264,7 @@ SuperTokens.init({
     },
     recipeList: [
         Session.init({
-            sessionTokenBackendDomain: ".example.com"
+            sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
         }),
     ],
 });
@@ -281,7 +283,7 @@ supertokens.init({
     },
     recipeList: [
         supertokensSession.init({
-            sessionTokenBackendDomain: ".example.com",
+            sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
         })
     ],
 });
@@ -303,7 +305,7 @@ import SuperTokens from 'supertokens-react-native';
 
 SuperTokens.init({
     apiDomain: "...",
-    sessionTokenBackendDomain: ".example.com"
+    sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
 });
 ```
 
@@ -321,7 +323,7 @@ class MainApplication: Application() {
         
         SuperTokens.Builder(this, "...")
             // highlight-next-line
-            .sessionTokenBackendDomain(".example.com")
+            .sessionTokenBackendDomain("example.com") // or ".example.com" (they both work)
             .build()
     }
 }
@@ -342,7 +344,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
             try SuperTokens.initialize(
                 apiDomain: "...",
                 // highlight-next-line
-                sessionTokenBackendDomain: ".example.com"
+                sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
             )
         } catch SuperTokensError.initError(let message) {
             // TODO: Handle initialization error
@@ -366,7 +368,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        sessionTokenBackendDomain: ".example.com",
+        sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
     );
 }
 ```

--- a/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -24,7 +24,7 @@ Sharing sessions across multiple sub domains in SuperTokens can be configured by
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
- - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `.example.com`
+ - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `example.com` or `.example.com`.
 
 
 <PreBuiltOrCustomUISwitcher>
@@ -50,7 +50,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com" // or ".example.com" (they both work)
         })
     ]
 });
@@ -97,7 +97,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-start
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
             // highlight-end 
         }),
     ],
@@ -119,7 +119,7 @@ supertokens.init({
         supertokensSession.init({
             // ...
             // highlight-start
-            sessionTokenFrontendDomain: ".example.com"
+            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
             // highlight-end
         })
     ],

--- a/v2/thirdpartypasswordless/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdpartypasswordless/nextjs/app-directory/protecting-route.mdx
@@ -239,6 +239,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             * 
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }
@@ -411,6 +413,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             * 
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }

--- a/v2/thirdpartypasswordless/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdpartypasswordless/nextjs/app-directory/protecting-route.mdx
@@ -240,7 +240,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -412,7 +412,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 

--- a/v2/thirdpartypasswordless/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdpartypasswordless/nextjs/app-directory/server-components-requests.mdx
@@ -66,6 +66,7 @@ export async function HomePage() {
         if (hasInvalidClaims) {
             return <SessionAuthForNextJS />;
         } else {
+            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
             return <TryRefreshComponent key={Date.now()} />;
         }
     }
@@ -89,6 +90,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
+        // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
         return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         // SessionAuthForNextJS will redirect based on which claim is invalid
@@ -176,6 +178,8 @@ export async function HomePage() {
             /**
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
+             *
+             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
              */
             return <TryRefreshComponent key={Date.now()} />;
         }
@@ -200,6 +204,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
+        // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
         return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         /**

--- a/v2/thirdpartypasswordless/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdpartypasswordless/nextjs/app-directory/server-components-requests.mdx
@@ -66,7 +66,7 @@ export async function HomePage() {
         if (hasInvalidClaims) {
             return <SessionAuthForNextJS />;
         } else {
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -89,7 +89,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
-        return <TryRefreshComponent />
+        return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         // SessionAuthForNextJS will redirect based on which claim is invalid
         return <SessionAuthForNextJS />;
@@ -177,7 +177,7 @@ export async function HomePage() {
              * This means that the session does not exist but we have session tokens for the user. In this case
              * the `TryRefreshComponent` will try to refresh the session.
              */
-            return <TryRefreshComponent />;
+            return <TryRefreshComponent key={Date.now()} />;
         }
     }
 
@@ -200,7 +200,7 @@ export async function HomePage() {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
         // The TryRefreshComponent will try to refresh the session
-        return <TryRefreshComponent />
+        return <TryRefreshComponent key={Date.now()} />
     } else if (userInfoResponse.status === 403) {
         /**
          * This means that one of the session claims is invalid. You should redirect the user to


### PR DESCRIPTION
## Summary of change
This PR updates the docs for `olderCookieDomain` config option in backend SDKs.

## Related issues

- https://github.com/supertokens/supertokens-node/pull/813

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
