### PR TITLE
fix: Update NestJS AuthGuard to use getSession

### DIFF
--- a/v2/emailpassword/nestjs/guide.mdx
+++ b/v2/emailpassword/nestjs/guide.mdx
@@ -290,9 +290,6 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
 
     const resp = ctx.getResponse<Response>();
-    if (resp.headersSent) {
-      return;
-    }
 
     this.handler(
       exception,

--- a/v2/emailpassword/nestjs/guide.mdx
+++ b/v2/emailpassword/nestjs/guide.mdx
@@ -106,7 +106,7 @@ export class AuthModule implements NestModule {
 }
 ```
 
-In the provided code sample, we convert this to a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can configure parts of the SuperTokens setup within the App module. This approach allows for centralized configuration, which can be particularly beneficial when managing settings such as using distinct connection URIs for different environments, such as testing or production.
+In the provided code sample, we convert `AuthModule` to a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can configure parts of the SuperTokens setup within the App module. This approach allows for centralized configuration, which can be particularly beneficial when managing settings such as using distinct connection URIs for different environments, such as testing or production.
 
 :::info
 The middleware is registered using the `configure` method in the `AuthModule` class.
@@ -308,6 +308,9 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
 
 We need to add this filter as a global exception filter. You can do this in `main.ts`, right after the updated CORS settings.
 
+<AppInfoForm
+    askForWebsiteDomain={true}>
+
 ```ts title="./src/main.ts"
 import { NestFactory } from '@nestjs/core';
 // @ts-ignore
@@ -320,7 +323,7 @@ import { SupertokensExceptionFilter } from './auth/auth.filter';
 async function bootstrap() {
   const app = await NestFactory.create(AuthModule);
   app.enableCors({
-    origin: ['http://localhost:3001'], // TODO: URL of the website domain
+    origin: ['^{form_websiteDomain}'],
     allowedHeaders: ['content-type', ...supertokens.getAllCORSHeaders()],
     credentials: true,
   });
@@ -334,6 +337,7 @@ async function bootstrap() {
 
 bootstrap();
 ```
+</AppInfoForm>
 
 ## Add a session verification guard
 
@@ -343,40 +347,25 @@ In the newly created `auth.guard.ts` file, implement session verification:
 
 ```ts title="./src/auth/auth.guard.ts"
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
-import { Error as STError } from "supertokens-node";
-
-import { verifySession } from 'supertokens-node/recipe/session/framework/express';
-import { VerifySessionOptions } from 'supertokens-node/recipe/session';
+import { getSession, VerifySessionOptions } from 'supertokens-node/recipe/session';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private readonly verifyOptions?: VerifySessionOptions) {}
+  constructor(private readonly getSessionOptions?: VerifySessionOptions) {}
 
-  async canActivate(context: ExecutionContext): Promise<boolean> {
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
     const ctx = context.switchToHttp();
 
-    let err = undefined;
+    const req = ctx.getRequest();
     const resp = ctx.getResponse();
-    // You can create an optional version of this by passing {sessionRequired: false} to verifySession
-    await verifySession(this.verifyOptions)(
-      ctx.getRequest(),
-      resp,
-      (res: any) => {
-        err = res;
-      },
-    );
 
-    if (resp.headersSent) {
-      throw new STError({
-        message: "RESPONSE_SENT",
-        type: "RESPONSE_SENT",
-      });
-    }
+    // If the session doesn't exist and {sessionRequired: true} is passed to the AuthGuard constructor (default is true),
+    // getSession will throw an error, that will be handled by the exception filter, returning a 401 response.
 
-    if (err) {
-      throw err;
-    }
-
+    // To avoid an error when the session doesn't exist, pass {sessionRequired: false} to the AuthGuard constructor.
+    // In this case, req.session will be undefined if the session doesn't exist.
+    const session = await getSession(req, resp, this.getSessionOptions);
+    req.session = session;
     return true;
   }
 }
@@ -414,11 +403,16 @@ import { Session } from './auth/session/session.decorator';
 @Controller()
 export class AppController {
   // ...
-  @Get('test')
+  @Get('/sessioninfo')
   @UseGuards(new AuthGuard())
-  async getTest(@Session() session: SessionContainer): Promise<string> {
-    // TODO: magic
-    return "magic";
+  getSessionInfo(
+    @Session() session: SessionContainer,
+  ): Record<string, unknown> {
+    return {
+      sessionHandle: session.getHandle(),
+      userId: session.getUserId(),
+      accessTokenPayload: session.getAccessTokenPayload(),
+    };
   }
 }
 ```

--- a/v2/emailpassword/nestjs/guide.mdx
+++ b/v2/emailpassword/nestjs/guide.mdx
@@ -400,7 +400,8 @@ import { Session } from './auth/session/session.decorator';
 @Controller()
 export class AppController {
   // ...
-  @Get('/sessioninfo')
+  // Test endpoint for session verification; not part of the Supertokens setup.
+  @Get('/test')
   @UseGuards(new AuthGuard())
   getSessionInfo(
     @Session() session: SessionContainer,

--- a/v2/passwordless/nestjs/guide.mdx
+++ b/v2/passwordless/nestjs/guide.mdx
@@ -309,9 +309,6 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
 
     const resp = ctx.getResponse<Response>();
-    if (resp.headersSent) {
-      return;
-    }
 
     this.handler(
       exception,

--- a/v2/passwordless/nestjs/guide.mdx
+++ b/v2/passwordless/nestjs/guide.mdx
@@ -106,7 +106,7 @@ export class AuthModule implements NestModule {
 }
 ```
 
-In the provided code sample, we convert this to a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can configure parts of the SuperTokens setup within the App module. This approach allows for centralized configuration, which can be particularly beneficial when managing settings such as using distinct connection URIs for different environments, such as testing or production.
+In the provided code sample, we convert `AuthModule` to a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can configure parts of the SuperTokens setup within the App module. This approach allows for centralized configuration, which can be particularly beneficial when managing settings such as using distinct connection URIs for different environments, such as testing or production.
 
 :::info
 The middleware is registered using the `configure` method in the `AuthModule` class.
@@ -327,6 +327,9 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
 
 We need to add this filter as a global exception filter. You can do this in `main.ts`, right after the updated CORS settings.
 
+<AppInfoForm
+    askForWebsiteDomain={true}>
+
 ```ts title="./src/main.ts"
 import { NestFactory } from '@nestjs/core';
 // @ts-ignore
@@ -339,7 +342,7 @@ import { SupertokensExceptionFilter } from './auth/auth.filter';
 async function bootstrap() {
   const app = await NestFactory.create(AuthModule);
   app.enableCors({
-    origin: ['http://localhost:3001'], // TODO: URL of the website domain
+    origin: ['^{form_websiteDomain}'],
     allowedHeaders: ['content-type', ...supertokens.getAllCORSHeaders()],
     credentials: true,
   });
@@ -353,6 +356,7 @@ async function bootstrap() {
 
 bootstrap();
 ```
+</AppInfoForm>
 
 ## Add a session verification guard
 
@@ -362,40 +366,25 @@ In the newly created `auth.guard.ts` file, implement session verification:
 
 ```ts title="./src/auth/auth.guard.ts"
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
-import { Error as STError } from "supertokens-node";
-
-import { verifySession } from 'supertokens-node/recipe/session/framework/express';
-import { VerifySessionOptions } from 'supertokens-node/recipe/session';
+import { getSession, VerifySessionOptions } from 'supertokens-node/recipe/session';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private readonly verifyOptions?: VerifySessionOptions) {}
+  constructor(private readonly getSessionOptions?: VerifySessionOptions) {}
 
-  async canActivate(context: ExecutionContext): Promise<boolean> {
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
     const ctx = context.switchToHttp();
 
-    let err = undefined;
+    const req = ctx.getRequest();
     const resp = ctx.getResponse();
-    // You can create an optional version of this by passing {sessionRequired: false} to verifySession
-    await verifySession(this.verifyOptions)(
-      ctx.getRequest(),
-      resp,
-      (res: any) => {
-        err = res;
-      },
-    );
 
-    if (resp.headersSent) {
-      throw new STError({
-        message: "RESPONSE_SENT",
-        type: "RESPONSE_SENT",
-      });
-    }
+    // If the session doesn't exist and {sessionRequired: true} is passed to the AuthGuard constructor (default is true),
+    // getSession will throw an error, that will be handled by the exception filter, returning a 401 response.
 
-    if (err) {
-      throw err;
-    }
-
+    // To avoid an error when the session doesn't exist, pass {sessionRequired: false} to the AuthGuard constructor.
+    // In this case, req.session will be undefined if the session doesn't exist.
+    const session = await getSession(req, resp, this.getSessionOptions);
+    req.session = session;
     return true;
   }
 }
@@ -433,11 +422,16 @@ import { Session } from './auth/session/session.decorator';
 @Controller()
 export class AppController {
   // ...
-  @Get('test')
+  @Get('/sessioninfo')
   @UseGuards(new AuthGuard())
-  async getTest(@Session() session: SessionContainer): Promise<string> {
-    // TODO: magic
-    return "magic";
+  getSessionInfo(
+    @Session() session: SessionContainer,
+  ): Record<string, unknown> {
+    return {
+      sessionHandle: session.getHandle(),
+      userId: session.getUserId(),
+      accessTokenPayload: session.getAccessTokenPayload(),
+    };
   }
 }
 ```

--- a/v2/passwordless/nestjs/guide.mdx
+++ b/v2/passwordless/nestjs/guide.mdx
@@ -419,7 +419,8 @@ import { Session } from './auth/session/session.decorator';
 @Controller()
 export class AppController {
   // ...
-  @Get('/sessioninfo')
+  // Test endpoint for session verification; not part of the Supertokens setup.
+  @Get('/test')
   @UseGuards(new AuthGuard())
   getSessionInfo(
     @Session() session: SessionContainer,

--- a/v2/thirdparty/nestjs/guide.mdx
+++ b/v2/thirdparty/nestjs/guide.mdx
@@ -367,9 +367,6 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
 
     const resp = ctx.getResponse<Response>();
-    if (resp.headersSent) {
-      return;
-    }
 
     this.handler(
       exception,

--- a/v2/thirdparty/nestjs/guide.mdx
+++ b/v2/thirdparty/nestjs/guide.mdx
@@ -104,7 +104,7 @@ export class AuthModule implements NestModule {
 }
 ```
 
-In the provided code sample, we convert this to a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can configure parts of the SuperTokens setup within the App module. This approach allows for centralized configuration, which can be particularly beneficial when managing settings such as using distinct connection URIs for different environments, such as testing or production.
+In the provided code sample, we convert `AuthModule` to a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can configure parts of the SuperTokens setup within the App module. This approach allows for centralized configuration, which can be particularly beneficial when managing settings such as using distinct connection URIs for different environments, such as testing or production.
 
 :::info
 The middleware is registered using the `configure` method in the `AuthModule` class.
@@ -385,6 +385,9 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
 
 We need to add this filter as a global exception filter. You can do this in `main.ts`, right after the updated CORS settings.
 
+<AppInfoForm
+    askForWebsiteDomain={true}>
+
 ```ts title="./src/main.ts"
 import { NestFactory } from '@nestjs/core';
 // @ts-ignore
@@ -397,7 +400,7 @@ import { SupertokensExceptionFilter } from './auth/auth.filter';
 async function bootstrap() {
   const app = await NestFactory.create(AuthModule);
   app.enableCors({
-    origin: ['http://localhost:3001'], // TODO: URL of the website domain
+    origin: ['^{form_websiteDomain}'],
     allowedHeaders: ['content-type', ...supertokens.getAllCORSHeaders()],
     credentials: true,
   });
@@ -411,6 +414,7 @@ async function bootstrap() {
 
 bootstrap();
 ```
+</AppInfoForm>
 
 ## Add a session verification guard
 
@@ -420,40 +424,25 @@ In the newly created `auth.guard.ts` file, implement session verification:
 
 ```ts title="./src/auth/auth.guard.ts"
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
-import { Error as STError } from "supertokens-node";
-
-import { verifySession } from 'supertokens-node/recipe/session/framework/express';
-import { VerifySessionOptions } from 'supertokens-node/recipe/session';
+import { getSession, VerifySessionOptions } from 'supertokens-node/recipe/session';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private readonly verifyOptions?: VerifySessionOptions) {}
+  constructor(private readonly getSessionOptions?: VerifySessionOptions) {}
 
-  async canActivate(context: ExecutionContext): Promise<boolean> {
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
     const ctx = context.switchToHttp();
 
-    let err = undefined;
+    const req = ctx.getRequest();
     const resp = ctx.getResponse();
-    // You can create an optional version of this by passing {sessionRequired: false} to verifySession
-    await verifySession(this.verifyOptions)(
-      ctx.getRequest(),
-      resp,
-      (res: any) => {
-        err = res;
-      },
-    );
 
-    if (resp.headersSent) {
-      throw new STError({
-        message: "RESPONSE_SENT",
-        type: "RESPONSE_SENT",
-      });
-    }
+    // If the session doesn't exist and {sessionRequired: true} is passed to the AuthGuard constructor (default is true),
+    // getSession will throw an error, that will be handled by the exception filter, returning a 401 response.
 
-    if (err) {
-      throw err;
-    }
-
+    // To avoid an error when the session doesn't exist, pass {sessionRequired: false} to the AuthGuard constructor.
+    // In this case, req.session will be undefined if the session doesn't exist.
+    const session = await getSession(req, resp, this.getSessionOptions);
+    req.session = session;
     return true;
   }
 }
@@ -491,11 +480,16 @@ import { Session } from './auth/session/session.decorator';
 @Controller()
 export class AppController {
   // ...
-  @Get('test')
+  @Get('/sessioninfo')
   @UseGuards(new AuthGuard())
-  async getTest(@Session() session: SessionContainer): Promise<string> {
-    // TODO: magic
-    return "magic";
+  getSessionInfo(
+    @Session() session: SessionContainer,
+  ): Record<string, unknown> {
+    return {
+      sessionHandle: session.getHandle(),
+      userId: session.getUserId(),
+      accessTokenPayload: session.getAccessTokenPayload(),
+    };
   }
 }
 ```

--- a/v2/thirdparty/nestjs/guide.mdx
+++ b/v2/thirdparty/nestjs/guide.mdx
@@ -477,7 +477,8 @@ import { Session } from './auth/session/session.decorator';
 @Controller()
 export class AppController {
   // ...
-  @Get('/sessioninfo')
+  // Test endpoint for session verification; not part of the Supertokens setup.
+  @Get('/test')
   @UseGuards(new AuthGuard())
   getSessionInfo(
     @Session() session: SessionContainer,

--- a/v2/thirdpartyemailpassword/nestjs/guide.mdx
+++ b/v2/thirdpartyemailpassword/nestjs/guide.mdx
@@ -479,7 +479,8 @@ import { Session } from './auth/session/session.decorator';
 @Controller()
 export class AppController {
   // ...
-  @Get('/sessioninfo')
+  // Test endpoint for session verification; not part of the Supertokens setup.
+  @Get('/test')
   @UseGuards(new AuthGuard())
   getSessionInfo(
     @Session() session: SessionContainer,

--- a/v2/thirdpartyemailpassword/nestjs/guide.mdx
+++ b/v2/thirdpartyemailpassword/nestjs/guide.mdx
@@ -369,9 +369,6 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
 
     const resp = ctx.getResponse<Response>();
-    if (resp.headersSent) {
-      return;
-    }
 
     this.handler(
       exception,

--- a/v2/thirdpartyemailpassword/nestjs/guide.mdx
+++ b/v2/thirdpartyemailpassword/nestjs/guide.mdx
@@ -104,7 +104,7 @@ export class AuthModule implements NestModule {
 }
 ```
 
-In the provided code sample, we convert this to a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can configure parts of the SuperTokens setup within the App module. This approach allows for centralized configuration, which can be particularly beneficial when managing settings such as using distinct connection URIs for different environments, such as testing or production.
+In the provided code sample, we convert `AuthModule` to a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can configure parts of the SuperTokens setup within the App module. This approach allows for centralized configuration, which can be particularly beneficial when managing settings such as using distinct connection URIs for different environments, such as testing or production.
 
 :::info
 The middleware is registered using the `configure` method in the `AuthModule` class.
@@ -387,6 +387,9 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
 
 We need to add this filter as a global exception filter. You can do this in `main.ts`, right after the updated CORS settings.
 
+<AppInfoForm
+    askForWebsiteDomain={true}>
+
 ```ts title="./src/main.ts"
 import { NestFactory } from '@nestjs/core';
 // @ts-ignore
@@ -399,7 +402,7 @@ import { SupertokensExceptionFilter } from './auth/auth.filter';
 async function bootstrap() {
   const app = await NestFactory.create(AuthModule);
   app.enableCors({
-    origin: ['http://localhost:3001'], // TODO: URL of the website domain
+    origin: ['^{form_websiteDomain}'],
     allowedHeaders: ['content-type', ...supertokens.getAllCORSHeaders()],
     credentials: true,
   });
@@ -413,6 +416,7 @@ async function bootstrap() {
 
 bootstrap();
 ```
+</AppInfoForm>
 
 ## Add a session verification guard
 
@@ -422,40 +426,25 @@ In the newly created `auth.guard.ts` file, implement session verification:
 
 ```ts title="./src/auth/auth.guard.ts"
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
-import { Error as STError } from "supertokens-node";
-
-import { verifySession } from 'supertokens-node/recipe/session/framework/express';
-import { VerifySessionOptions } from 'supertokens-node/recipe/session';
+import { getSession, VerifySessionOptions } from 'supertokens-node/recipe/session';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private readonly verifyOptions?: VerifySessionOptions) {}
+  constructor(private readonly getSessionOptions?: VerifySessionOptions) {}
 
-  async canActivate(context: ExecutionContext): Promise<boolean> {
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
     const ctx = context.switchToHttp();
 
-    let err = undefined;
+    const req = ctx.getRequest();
     const resp = ctx.getResponse();
-    // You can create an optional version of this by passing {sessionRequired: false} to verifySession
-    await verifySession(this.verifyOptions)(
-      ctx.getRequest(),
-      resp,
-      (res: any) => {
-        err = res;
-      },
-    );
 
-    if (resp.headersSent) {
-      throw new STError({
-        message: "RESPONSE_SENT",
-        type: "RESPONSE_SENT",
-      });
-    }
+    // If the session doesn't exist and {sessionRequired: true} is passed to the AuthGuard constructor (default is true),
+    // getSession will throw an error, that will be handled by the exception filter, returning a 401 response.
 
-    if (err) {
-      throw err;
-    }
-
+    // To avoid an error when the session doesn't exist, pass {sessionRequired: false} to the AuthGuard constructor.
+    // In this case, req.session will be undefined if the session doesn't exist.
+    const session = await getSession(req, resp, this.getSessionOptions);
+    req.session = session;
     return true;
   }
 }
@@ -493,11 +482,16 @@ import { Session } from './auth/session/session.decorator';
 @Controller()
 export class AppController {
   // ...
-  @Get('test')
+  @Get('/sessioninfo')
   @UseGuards(new AuthGuard())
-  async getTest(@Session() session: SessionContainer): Promise<string> {
-    // TODO: magic
-    return "magic";
+  getSessionInfo(
+    @Session() session: SessionContainer,
+  ): Record<string, unknown> {
+    return {
+      sessionHandle: session.getHandle(),
+      userId: session.getUserId(),
+      accessTokenPayload: session.getAccessTokenPayload(),
+    };
   }
 }
 ```

--- a/v2/thirdpartypasswordless/nestjs/guide.mdx
+++ b/v2/thirdpartypasswordless/nestjs/guide.mdx
@@ -106,7 +106,7 @@ export class AuthModule implements NestModule {
 }
 ```
 
-In the provided code sample, we convert this to a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can configure parts of the SuperTokens setup within the App module. This approach allows for centralized configuration, which can be particularly beneficial when managing settings such as using distinct connection URIs for different environments, such as testing or production.
+In the provided code sample, we convert `AuthModule` to a [dynamic module](https://docs.nestjs.com/modules#dynamic-modules) so we can configure parts of the SuperTokens setup within the App module. This approach allows for centralized configuration, which can be particularly beneficial when managing settings such as using distinct connection URIs for different environments, such as testing or production.
 
 :::info
 The middleware is registered using the `configure` method in the `AuthModule` class.
@@ -402,6 +402,9 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
 
 We need to add this filter as a global exception filter. You can do this in `main.ts`, right after the updated CORS settings.
 
+<AppInfoForm
+    askForWebsiteDomain={true}>
+
 ```ts title="./src/main.ts"
 import { NestFactory } from '@nestjs/core';
 // @ts-ignore
@@ -414,7 +417,7 @@ import { SupertokensExceptionFilter } from './auth/auth.filter';
 async function bootstrap() {
   const app = await NestFactory.create(AuthModule);
   app.enableCors({
-    origin: ['http://localhost:3001'], // TODO: URL of the website domain
+    origin: ['^{form_websiteDomain}'],
     allowedHeaders: ['content-type', ...supertokens.getAllCORSHeaders()],
     credentials: true,
   });
@@ -428,6 +431,7 @@ async function bootstrap() {
 
 bootstrap();
 ```
+</AppInfoForm>
 
 ## Add a session verification guard
 
@@ -437,40 +441,25 @@ In the newly created `auth.guard.ts` file, implement session verification:
 
 ```ts title="./src/auth/auth.guard.ts"
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
-import { Error as STError } from "supertokens-node";
-
-import { verifySession } from 'supertokens-node/recipe/session/framework/express';
-import { VerifySessionOptions } from 'supertokens-node/recipe/session';
+import { getSession, VerifySessionOptions } from 'supertokens-node/recipe/session';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private readonly verifyOptions?: VerifySessionOptions) {}
+  constructor(private readonly getSessionOptions?: VerifySessionOptions) {}
 
-  async canActivate(context: ExecutionContext): Promise<boolean> {
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
     const ctx = context.switchToHttp();
 
-    let err = undefined;
+    const req = ctx.getRequest();
     const resp = ctx.getResponse();
-    // You can create an optional version of this by passing {sessionRequired: false} to verifySession
-    await verifySession(this.verifyOptions)(
-      ctx.getRequest(),
-      resp,
-      (res: any) => {
-        err = res;
-      },
-    );
 
-    if (resp.headersSent) {
-      throw new STError({
-        message: "RESPONSE_SENT",
-        type: "RESPONSE_SENT",
-      });
-    }
+    // If the session doesn't exist and {sessionRequired: true} is passed to the AuthGuard constructor (default is true),
+    // getSession will throw an error, that will be handled by the exception filter, returning a 401 response.
 
-    if (err) {
-      throw err;
-    }
-
+    // To avoid an error when the session doesn't exist, pass {sessionRequired: false} to the AuthGuard constructor.
+    // In this case, req.session will be undefined if the session doesn't exist.
+    const session = await getSession(req, resp, this.getSessionOptions);
+    req.session = session;
     return true;
   }
 }
@@ -508,11 +497,16 @@ import { Session } from './auth/session/session.decorator';
 @Controller()
 export class AppController {
   // ...
-  @Get('test')
+  @Get('/sessioninfo')
   @UseGuards(new AuthGuard())
-  async getTest(@Session() session: SessionContainer): Promise<string> {
-    // TODO: magic
-    return "magic";
+  getSessionInfo(
+    @Session() session: SessionContainer,
+  ): Record<string, unknown> {
+    return {
+      sessionHandle: session.getHandle(),
+      userId: session.getUserId(),
+      accessTokenPayload: session.getAccessTokenPayload(),
+    };
   }
 }
 ```

--- a/v2/thirdpartypasswordless/nestjs/guide.mdx
+++ b/v2/thirdpartypasswordless/nestjs/guide.mdx
@@ -384,9 +384,6 @@ export class SupertokensExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
 
     const resp = ctx.getResponse<Response>();
-    if (resp.headersSent) {
-      return;
-    }
 
     this.handler(
       exception,

--- a/v2/thirdpartypasswordless/nestjs/guide.mdx
+++ b/v2/thirdpartypasswordless/nestjs/guide.mdx
@@ -494,7 +494,8 @@ import { Session } from './auth/session/session.decorator';
 @Controller()
 export class AppController {
   // ...
-  @Get('/sessioninfo')
+  // Test endpoint for session verification; not part of the Supertokens setup.
+  @Get('/test')
   @UseGuards(new AuthGuard())
   getSessionInfo(
     @Session() session: SessionContainer,


### PR DESCRIPTION
## Summary of change
This PR updates the NestJS AuthGuard to use `getSession` instead of `verifySession`.

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
