### PR TITLE
Added a self hosting option for AWS

### DIFF
--- a/v2/community/supertokens-core/self-hosted/self-hosted-with-aws.mdx
+++ b/v2/community/supertokens-core/self-hosted/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/emailpassword/custom-ui/init/core/self-hosted-with-aws.mdx
+++ b/v2/emailpassword/custom-ui/init/core/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/emailpassword/pre-built-ui/setup/core/self-hosted-with-aws.mdx
+++ b/v2/emailpassword/pre-built-ui/setup/core/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/emailpassword/quick-setup/core/self-hosted-with-aws.mdx
+++ b/v2/emailpassword/quick-setup/core/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/emailpassword/sidebars.js
+++ b/v2/emailpassword/sidebars.js
@@ -33,6 +33,7 @@ module.exports = {
                       items: [
                         "pre-built-ui/setup/core/with-docker",
                         "pre-built-ui/setup/core/without-docker",
+                        "pre-built-ui/setup/core/self-hosted-with-aws",
                         {
                           type: 'category',
                           label: 'Database Setup',
@@ -99,6 +100,7 @@ module.exports = {
                       items: [
                         "custom-ui/init/core/with-docker",
                         "custom-ui/init/core/without-docker",
+                        "custom-ui/init/core/self-hosted-with-aws",
                         {
                           type: 'category',
                           label: 'Database Setup',

--- a/v2/emailpassword/sidebars.js
+++ b/v2/emailpassword/sidebars.js
@@ -33,7 +33,7 @@ module.exports = {
                       items: [
                         "pre-built-ui/setup/core/with-docker",
                         "pre-built-ui/setup/core/without-docker",
-                        "pre-built-ui/setup/core/self-hosted-with-aws",
+                        "pre-built-ui/setup/core/aws-setup-with-stacksnap",
                         {
                           type: 'category',
                           label: 'Database Setup',
@@ -100,7 +100,7 @@ module.exports = {
                       items: [
                         "custom-ui/init/core/with-docker",
                         "custom-ui/init/core/without-docker",
-                        "custom-ui/init/core/self-hosted-with-aws",
+                        "custom-ui/init/core/aws-setup-with-stacksnap",
                         {
                           type: 'category',
                           label: 'Database Setup',

--- a/v2/passwordless/custom-ui/init/core/self-hosted-with-aws.mdx
+++ b/v2/passwordless/custom-ui/init/core/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/passwordless/pre-built-ui/setup/core/self-hosted-with-aws.mdx
+++ b/v2/passwordless/pre-built-ui/setup/core/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/passwordless/sidebars.js
+++ b/v2/passwordless/sidebars.js
@@ -33,7 +33,7 @@ module.exports = {
                       items: [
                         "pre-built-ui/setup/core/with-docker",
                         "pre-built-ui/setup/core/without-docker",
-                        "pre-built-ui/setup/core/self-hosted-with-aws",
+                        "pre-built-ui/setup/core/aws-setup-with-stacksnap",
                         {
                           type: 'category',
                           label: 'Database Setup',
@@ -99,7 +99,7 @@ module.exports = {
                       items: [
                         "custom-ui/init/core/with-docker",
                         "custom-ui/init/core/without-docker",
-                        "custom-ui/init/core/self-hosted-with-aws",
+                        "custom-ui/init/core/aws-setup-with-stacksnap",
                         {
                           type: 'category',
                           label: 'Database Setup',

--- a/v2/passwordless/sidebars.js
+++ b/v2/passwordless/sidebars.js
@@ -33,6 +33,7 @@ module.exports = {
                       items: [
                         "pre-built-ui/setup/core/with-docker",
                         "pre-built-ui/setup/core/without-docker",
+                        "pre-built-ui/setup/core/self-hosted-with-aws",
                         {
                           type: 'category',
                           label: 'Database Setup',
@@ -98,6 +99,7 @@ module.exports = {
                       items: [
                         "custom-ui/init/core/with-docker",
                         "custom-ui/init/core/without-docker",
+                        "custom-ui/init/core/self-hosted-with-aws",
                         {
                           type: 'category',
                           label: 'Database Setup',

--- a/v2/session/quick-setup/core/self-hosted-with-aws.mdx
+++ b/v2/session/quick-setup/core/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/session/sidebars.js
+++ b/v2/session/sidebars.js
@@ -25,6 +25,7 @@ module.exports = {
                   items: [
                     "quick-setup/core/with-docker",
                     "quick-setup/core/without-docker",
+                    "quick-setup/core/self-hosted-with-aws",
                     {
                       type: 'category',
                       label: 'Database Setup',

--- a/v2/session/sidebars.js
+++ b/v2/session/sidebars.js
@@ -25,7 +25,7 @@ module.exports = {
                   items: [
                     "quick-setup/core/with-docker",
                     "quick-setup/core/without-docker",
-                    "quick-setup/core/self-hosted-with-aws",
+                    "quick-setup/core/aws-setup-with-stacksnap",
                     {
                       type: 'category',
                       label: 'Database Setup',

--- a/v2/thirdparty/custom-ui/init/core/self-hosted-with-aws.mdx
+++ b/v2/thirdparty/custom-ui/init/core/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/thirdparty/pre-built-ui/setup/core/self-hosted-with-aws.mdx
+++ b/v2/thirdparty/pre-built-ui/setup/core/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/thirdparty/sidebars.js
+++ b/v2/thirdparty/sidebars.js
@@ -33,7 +33,7 @@ module.exports = {
                       items: [
                         "pre-built-ui/setup/core/with-docker",
                         "pre-built-ui/setup/core/without-docker",
-                        "pre-built-ui/setup/core/self-hosted-with-aws",
+                        "pre-built-ui/setup/core/aws-setup-with-stacksnap",
                         {
                           type: 'category',
                           label: 'Database Setup',
@@ -99,7 +99,7 @@ module.exports = {
                       items: [
                         "custom-ui/init/core/with-docker",
                         "custom-ui/init/core/without-docker",
-                        "custom-ui/init/core/self-hosted-with-aws",
+                        "custom-ui/init/core/aws-setup-with-stacksnap",
                         {
                           type: 'category',
                           label: 'Database Setup',

--- a/v2/thirdparty/sidebars.js
+++ b/v2/thirdparty/sidebars.js
@@ -33,6 +33,7 @@ module.exports = {
                       items: [
                         "pre-built-ui/setup/core/with-docker",
                         "pre-built-ui/setup/core/without-docker",
+                        "pre-built-ui/setup/core/self-hosted-with-aws",
                         {
                           type: 'category',
                           label: 'Database Setup',
@@ -98,6 +99,7 @@ module.exports = {
                       items: [
                         "custom-ui/init/core/with-docker",
                         "custom-ui/init/core/without-docker",
+                        "custom-ui/init/core/self-hosted-with-aws",
                         {
                           type: 'category',
                           label: 'Database Setup',

--- a/v2/thirdpartyemailpassword/custom-ui/init/core/self-hosted-with-aws.mdx
+++ b/v2/thirdpartyemailpassword/custom-ui/init/core/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/thirdpartyemailpassword/pre-built-ui/setup/core/self-hosted-with-aws.mdx
+++ b/v2/thirdpartyemailpassword/pre-built-ui/setup/core/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/thirdpartyemailpassword/sidebars.js
+++ b/v2/thirdpartyemailpassword/sidebars.js
@@ -33,7 +33,7 @@ module.exports = {
                       items: [
                         "pre-built-ui/setup/core/with-docker",
                         "pre-built-ui/setup/core/without-docker",
-                        "pre-built-ui/setup/core/self-hosted-with-aws",
+                        "pre-built-ui/setup/core/aws-setup-with-stacksnap",
                         {
                           type: 'category',
                           label: 'Database Setup',
@@ -101,7 +101,7 @@ module.exports = {
                       items: [
                         "custom-ui/init/core/with-docker",
                         "custom-ui/init/core/without-docker",
-                        "custom-ui/init/core/self-hosted-with-aws",
+                        "custom-ui/init/core/aws-setup-with-stacksnap",
                         {
                           type: 'category',
                           label: 'Database Setup',

--- a/v2/thirdpartyemailpassword/sidebars.js
+++ b/v2/thirdpartyemailpassword/sidebars.js
@@ -33,6 +33,7 @@ module.exports = {
                       items: [
                         "pre-built-ui/setup/core/with-docker",
                         "pre-built-ui/setup/core/without-docker",
+                        "pre-built-ui/setup/core/self-hosted-with-aws",
                         {
                           type: 'category',
                           label: 'Database Setup',
@@ -100,6 +101,7 @@ module.exports = {
                       items: [
                         "custom-ui/init/core/with-docker",
                         "custom-ui/init/core/without-docker",
+                        "custom-ui/init/core/self-hosted-with-aws",
                         {
                           type: 'category',
                           label: 'Database Setup',

--- a/v2/thirdpartypasswordless/custom-ui/init/core/self-hosted-with-aws.mdx
+++ b/v2/thirdpartypasswordless/custom-ui/init/core/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/thirdpartypasswordless/pre-built-ui/setup/core/self-hosted-with-aws.mdx
+++ b/v2/thirdpartypasswordless/pre-built-ui/setup/core/self-hosted-with-aws.mdx
@@ -1,0 +1,20 @@
+---  
+id: aws-setup-with-stacksnap  
+title: AWS Setup with Stacksnap  
+hide_title: true  
+---
+
+import BackendSDKTabs from "/src/components/tabs/BackendSDKTabs";  
+import TabItem from '@theme/TabItem';
+
+# AWS Setup with Stacksnap
+
+Stacksnap is a community supported AWS installer with unofficial SuperTokens support. You can use it to quickly deploy a solid starter deployment of SuperTokens on AWS.
+
+## Deploying SuperTokens on AWS using Stacksnap ✨
+
+- Visit the [SuperTokens Stacksnap page](https://klo.dev/stacksnap/apps/supertokens/)
+- Click on the "Deploy to AWS" button
+
+The 1-click installer automatically sets up an ECS task running SuperTokens, a Postgres DB on RDS for data storage, and an HTTPS url load balanced with a CloudFront distribution.
+

--- a/v2/thirdpartypasswordless/sidebars.js
+++ b/v2/thirdpartypasswordless/sidebars.js
@@ -33,6 +33,7 @@ module.exports = {
                       items: [
                         "pre-built-ui/setup/core/with-docker",
                         "pre-built-ui/setup/core/without-docker",
+                        "pre-built-ui/setup/core/self-hosted-with-aws",
                         {
                           type: 'category',
                           label: 'Database Setup',
@@ -99,6 +100,7 @@ module.exports = {
                       items: [
                         "custom-ui/init/core/with-docker",
                         "custom-ui/init/core/without-docker",
+                        "custom-ui/init/core/self-hosted-with-aws",
                         {
                           type: 'category',
                           label: 'Database Setup',

--- a/v2/thirdpartypasswordless/sidebars.js
+++ b/v2/thirdpartypasswordless/sidebars.js
@@ -33,7 +33,7 @@ module.exports = {
                       items: [
                         "pre-built-ui/setup/core/with-docker",
                         "pre-built-ui/setup/core/without-docker",
-                        "pre-built-ui/setup/core/self-hosted-with-aws",
+                        "pre-built-ui/setup/core/aws-setup-with-stacksnap",
                         {
                           type: 'category',
                           label: 'Database Setup',
@@ -100,7 +100,7 @@ module.exports = {
                       items: [
                         "custom-ui/init/core/with-docker",
                         "custom-ui/init/core/without-docker",
-                        "custom-ui/init/core/self-hosted-with-aws",
+                        "custom-ui/init/core/aws-setup-with-stacksnap",
                         {
                           type: 'category',
                           label: 'Database Setup',


### PR DESCRIPTION
## Summary of change
We're fans of Supertokens and added support to install it on AWS using stacksnap 

## Related issues
- N/A


## Checklist
- [X] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [X] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [X] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?