### PR TITLE
fix: Remove getSession usage from SSR

### DIFF
--- a/v2/emailpassword/nextjs/app-directory/protecting-route.mdx
+++ b/v2/emailpassword/nextjs/app-directory/protecting-route.mdx
@@ -173,47 +173,87 @@ export const TryRefreshComponent = () => {
 We then create a server component that can check if the session exists and return any session information we may need:
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let SessionAuthForNextJS: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
 // @ts-ignore
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -223,27 +263,12 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This will make sure that the user is redirected based on their session claims. For example they
-           * will be redirected to the email verification screen if needed.
-           * 
-           * We pass in no children in this case to prevent hydration issues and still be able to redirect the
-           * user.
-           */
-            return <SessionAuthForNextJS />;
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             * 
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     /**
@@ -253,7 +278,7 @@ export async function HomePage() {
     return (
         <SessionAuthForNextJS>
             <div>
-                Your user id is: {session.getUserId()}
+                Your user id is: {accessTokenPayload.sub}
             </div>
         </SessionAuthForNextJS>
     );
@@ -352,45 +377,85 @@ export const TryRefreshComponent = () => {
 Lets modify the Home page server component we created earlier:
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -400,37 +465,23 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This means that one of the session claims is invalid. You should redirect the user to
-           * the appropriate page depending on which claim is invalid.
-           */
-          return <div>Invalid Session Claims</div>
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             * 
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     return (
         <div>
-            Your user id is: {session.getUserId()}
+            Your user id is: {accessTokenPayload.sub}
         </div>
     );
 }
 ```
 
 The `TryRefreshComponent` is a client component that checks if a session exists and tries to refresh the session if it is expired.
-
-`hasInvalidClaims` indicates that one or more of the session claims failed their validation. In this case you should check which session claim failed and redirect the user accordingly. For example to check for the email verification claim you can refer to [this page](../../common-customizations/email-verification/protecting-routes.mdx#protecting-frontend-routes--cust).
 
 And then we can modify the `/app/page.tsx` file to use our server component
 

--- a/v2/emailpassword/nextjs/app-directory/protecting-route.mdx
+++ b/v2/emailpassword/nextjs/app-directory/protecting-route.mdx
@@ -8,11 +8,13 @@ hide_title: true
 <!-- ./thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 4. Checking for sessions in frontend routes
 
 Protecting a website route means that it cannot be accessed unless a user is signed in. If a non signed in user tries to access it, they will be redirected to the login page.
 
+<CoreInjector showTenantId={false}>
 <PreBuiltOrCustomUISwitcher>
 
 <PreBuiltUIContent>
@@ -187,7 +189,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -220,9 +222,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -389,7 +392,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -422,9 +425,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -509,3 +513,4 @@ For custom UI SuperTokens provides no login UI, the code above will redirect the
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+</CoreInjector>

--- a/v2/emailpassword/nextjs/app-directory/protecting-route.mdx
+++ b/v2/emailpassword/nextjs/app-directory/protecting-route.mdx
@@ -185,8 +185,6 @@ import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
@@ -388,8 +386,6 @@ import { TryRefreshComponent } from "./tryRefreshClientComponent";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/emailpassword/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/emailpassword/nextjs/app-directory/server-components-requests.mdx
@@ -18,9 +18,7 @@ Lets modify the Home page we made in a [previous step](../protecting-route.mdx) 
 <PreBuiltUIContent>
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 declare let SessionAuthForNextJS: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
@@ -28,64 +26,112 @@ import { redirect } from "next/navigation";
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
 // @ts-ignore
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
 
-    if (!session) {
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
+            /**
+             * This means that the user is not logged in. If you want to display some other UI in this
+             * case, you can do so here.
+             */
             return redirect("/auth");
         }
 
-        if (hasInvalidClaims) {
-            return <SessionAuthForNextJS />;
-        } else {
-            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        /**
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
+         */
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     // highlight-start
     const userInfoResponse = await fetch('http://localhost:3000/api/user', {
       headers: {
         /**
-         * We read the access token from the session and use that as a Bearer token when
+         * We read the access token from the cookies and use that as a Bearer token when
          * making network requests.
          */
-        Authorization: 'Bearer ' + session.getAccessToken(),
+        Authorization: 'Bearer ' + getAccessToken(),
       },
     });
 
     let message = "";
 
     if (userInfoResponse.status === 200) {
-        message = `Your user id is: ${session.getUserId()}`
+        message = `Your user id is: ${accessTokenPayload.sub}`
     } else if (userInfoResponse.status === 500) {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
@@ -110,52 +156,91 @@ export async function HomePage() {
 }
 ```
 
-We use `session` returned by `getSSRSession` to get the access token of the user. We can then send the access token as a header to the API. When the API calls `withSession` it will try to read the access token from the headers and if a session exists it will return the information. You can use the `session` object to fetch other information such as `session.getUserId()`.
+We read the access token of the user from cookies.  We can then send the access token as a header to the API. When the API calls `withSession` it will try to read the access token from the headers and if a session exists it will return the session information.
 
 </PreBuiltUIContent>
 
 <CustomUIContent>
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
-import { TryRefreshComponent } from "./tryRefreshClientComponent";
+import { TryRefreshComponent } from "./tryRefreshClientComponent";import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -165,41 +250,29 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This means that one of the session claims is invalid. You should redirect the user to
-           * the appropriate page depending on which claim is invalid.
-           */
-          return <div>Invalid Session Claims</div>
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             *
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     // highlight-start
     const userInfoResponse = await fetch('http://localhost:3000/api/user', {
       headers: {
         /**
-         * We read the access token from the session and use that as a Bearer token when
+         * We read the access token from the cookies and use that as a Bearer token when
          * making network requests.
          */
-        Authorization: 'Bearer ' + session.getAccessToken(),
+        Authorization: 'Bearer ' + getAccessToken(),
       },
     });
 
     let message = "";
 
     if (userInfoResponse.status === 200) {
-        message = `Your user id is: ${session.getUserId()}`
+        message = `Your user id is: ${accessTokenPayload.sub}`
     } else if (userInfoResponse.status === 500) {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {

--- a/v2/emailpassword/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/emailpassword/nextjs/app-directory/server-components-requests.mdx
@@ -8,11 +8,13 @@ hide_title: true
 <!-- ./thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 6. Making requests from Server Components
 
 Lets modify the Home page we made in a [previous step](../protecting-route.mdx) to make a call to this API
 
+<CoreInjector showTenantId={false}>
 <PreBuiltOrCustomUISwitcher>
 
 <PreBuiltUIContent>
@@ -33,7 +35,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -65,10 +67,11 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 
 /**
  * A helper function to retrieve session details on the server side.
- *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * 
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -174,7 +177,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -207,9 +210,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -305,3 +309,4 @@ APIs that require sessions will return status:
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+</CoreInjector>

--- a/v2/emailpassword/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/emailpassword/nextjs/app-directory/server-components-requests.mdx
@@ -31,8 +31,6 @@ import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
@@ -173,8 +171,6 @@ import { redirect } from "next/navigation";
 import { TryRefreshComponent } from "./tryRefreshClientComponent";import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/emailpassword/nextjs/session-verification/in-ssr.mdx
+++ b/v2/emailpassword/nextjs/session-verification/in-ssr.mdx
@@ -9,6 +9,7 @@ show_ui_switcher: true
 <!-- ./thirdpartyemailpassword/nextjs/session-verification/in-ssr.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 5b. Session verification in getServerSideProps
 
@@ -24,6 +25,7 @@ For this guide, we will assume that we want to pass the logged in user's ID as a
 If using `getInitialProps`, the method described below applies as well. The only difference is the way the props are returned (see comments in the code).
 :::
 
+<CoreInjector showTenantId={false}>
 
 ```tsx
 import jwksClient from "jwks-rsa";
@@ -34,7 +36,7 @@ import { GetServerSidePropsContext } from 'next';
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-  jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+  jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
   async fetcher(jwksUri) {
     return fetch(jwksUri).then((res) => res.json());
   },
@@ -123,6 +125,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     // or return { userId: accessTokenPayload.sub } in case of getInitialProps
 }
 ```
+</CoreInjector>
 
 :::caution
 Don't use getSession or verifySession here. They might update the session tokens, and since our request interceptors don't run server-side, the updated token won't be propagated to the client side.

--- a/v2/emailpassword/nextjs/session-verification/in-ssr.mdx
+++ b/v2/emailpassword/nextjs/session-verification/in-ssr.mdx
@@ -32,8 +32,6 @@ import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { GetServerSidePropsContext } from 'next';
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
   jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/emailpassword/nextjs/session-verification/in-ssr.mdx
+++ b/v2/emailpassword/nextjs/session-verification/in-ssr.mdx
@@ -18,7 +18,7 @@ This is applicable for when verifying a session in `getServerSideProps` or `getI
 
 For this guide, we will assume that we want to pass the logged in user's ID as a prop to a protected route. An easier method to achieve this would be to [directly get the user ID from the frontend](../../common-customizations/get-user-info#on-the-frontend), but for this example, we will pass it from the server side.
 
-## 1) We use `getSession` in `getServerSideProps`
+## 1) We parse the `accessToken` JWT in `getServerSideProps`
 
 :::important
 If using `getInitialProps`, the method described below applies as well. The only difference is the way the props are returned (see comments in the code).
@@ -26,58 +26,106 @@ If using `getInitialProps`, the method described below applies as well. The only
 
 
 ```tsx
-import Session from 'supertokens-node/recipe/session'
-import supertokensNode from 'supertokens-node'
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
+import { GetServerSidePropsContext } from 'next';
 // @ts-ignore
-import { backendConfig } from '../config/backendConfig'
+import { appInfo } from "../config/appInfo";
 
-export async function getServerSideProps(context: any) {
+const client = jwksClient({
+  jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+  async fetcher(jwksUri) {
+    return fetch(jwksUri).then((res) => res.json());
+  },
+});
 
-    // this runs on the backend, so we must call init on supertokens-node SDK
-    supertokensNode.init(backendConfig())
+function getAccessToken(context: GetServerSidePropsContext ): string | undefined {
+  return context.req.cookies["sAccessToken"];
+}
 
-    // this will contain the session object post verification
-    let session
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+  client.getSigningKey(header.kid, (err, key) => {
+      if (err) {
+          callback(err);
+      } else {
+          const signingKey = key?.getPublicKey();
+          callback(null, signingKey);
+      }
+  });
+}
 
-    try {
-        // getSession will do session verification for us
-        session = await Session.getSession(context.req, context.res, {
-        overrideGlobalClaimValidators: () => {
-          // this makes it so that no custom session claims are checked
-          return []
-        }})
-    } catch (err: any) {
-        if (err.type === Session.Error.TRY_REFRESH_TOKEN) {
+async function verifyToken(token: string): Promise<JwtPayload> {
+  return new Promise((resolve, reject) => {
+      JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+          if (err) {
+              reject(err);
+          } else {
+              resolve(decoded as JwtPayload);
+          }
+      });
+  });
+}
 
-            // in this case, the session is still valid, only the access token has expired.
-            // The refresh token is not sent to this route as it's tied to the /api/auth/session/refresh API paths.
-            // So we must send a "signal" to the frontend which will then call the 
-            // refresh API and reload the page.
+/**
+* A helper function to retrieve session details on the server side.
+*
+* NOTE: This function does not use the getSession or verifySession functions from the supertokens-node SDK
+* because they can update the access token. These updated tokens would not be
+* propagated to the client side, as request interceptors do not run on the server side.
+*/
+async function getSSRSessionHelper(context: GetServerSidePropsContext): Promise<{
+  accessTokenPayload: JwtPayload | undefined;
+  hasToken: boolean;
+  error: Error | undefined;
+}> {
+  const accessToken = getAccessToken(context);
+  const hasToken = !!accessToken;
+  try {
+      if (accessToken) {
+          const decoded = await verifyToken(accessToken);
+          return { accessTokenPayload: decoded, hasToken, error: undefined };
+      }
+      return { accessTokenPayload: undefined, hasToken, error: undefined };
+  } catch (error) {
+      if (error instanceof JsonWebToken.TokenExpiredError) {
+          return { accessTokenPayload: undefined, hasToken, error: undefined };
+      }
+      return { accessTokenPayload: undefined, hasToken, error: error as Error };
+  }
+}
 
-            return { props: { fromSupertokens: 'needs-refresh' } }
-            // or return {fromSupertokens: 'needs-refresh'} in case of getInitialProps
-        } else if (err.type === Session.Error.UNAUTHORISED) {
-            // in this case, there is no session, or it has been revoked on the backend.
-            // either way, sending this response will make the frontend try and refresh
-            // which will fail and redirect the user to the login screen.
-            return { props: { fromSupertokens: 'needs-refresh' } }
-        }
-        
-        throw err
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+    const { accessTokenPayload, error } = await getSSRSessionHelper(context);
+
+    if (error) {
+      throw error;
     }
 
-    // session verification is successful and we can pass
-    // the user's ID to the frontend.
+    if (accessTokenPayload === undefined) {
+      // This occurs if the token has expired or doesn't exist.
+      // Either way, sending this response prompts the frontend to attempt a session refresh.
+      // 
+      // Case 1: Token doesn't exist
+      // - The refresh will fail, and the user will be redirected to the login page.
+      // 
+      // Case 2: Token has expired
+      // - The client will call the refresh API and update the session tokens.
+    
+      return { props: { fromSupertokens: 'needs-refresh' } }
+      // or return {fromSupertokens: 'needs-refresh'} in case of getInitialProps
+    }
 
     return {
-        props: { userId: session!.getUserId() },
+        props: { userId: accessTokenPayload.sub }
     }
-    // or return {userId: session.getUserId()} in case of getInitialProps
+
+    // or return { userId: accessTokenPayload.sub } in case of getInitialProps
 }
 ```
 
 :::caution
-Do not use the `verifySession` function here. The reason is that this will send a reply to the client in case of `TRY_REFRESH_TOKEN`, and here, we want to catch that error and send a custom reply.
+Don't use getSession or verifySession here. They might update the session tokens, and since our request interceptors don't run server-side, the updated token won't be propagated to the client side.
 :::
 
 ## 2) Doing manual refresh on the frontend
@@ -196,7 +244,7 @@ On success, `getServerSideProps` returns
 {
     // Refer to Step 1)
     // @ts-ignore
-    props: { userId: session.getUserId() }
+    props: { userId: accessTokenPayload.sub }
 }
 ```
 

--- a/v2/passwordless/nextjs/app-directory/protecting-route.mdx
+++ b/v2/passwordless/nextjs/app-directory/protecting-route.mdx
@@ -173,47 +173,87 @@ export const TryRefreshComponent = () => {
 We then create a server component that can check if the session exists and return any session information we may need:
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let SessionAuthForNextJS: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
 // @ts-ignore
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -223,27 +263,12 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This will make sure that the user is redirected based on their session claims. For example they
-           * will be redirected to the email verification screen if needed.
-           * 
-           * We pass in no children in this case to prevent hydration issues and still be able to redirect the
-           * user.
-           */
-            return <SessionAuthForNextJS />;
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             * 
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     /**
@@ -253,7 +278,7 @@ export async function HomePage() {
     return (
         <SessionAuthForNextJS>
             <div>
-                Your user id is: {session.getUserId()}
+                Your user id is: {accessTokenPayload.sub}
             </div>
         </SessionAuthForNextJS>
     );
@@ -352,45 +377,85 @@ export const TryRefreshComponent = () => {
 Lets modify the Home page server component we created earlier:
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -400,37 +465,23 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This means that one of the session claims is invalid. You should redirect the user to
-           * the appropriate page depending on which claim is invalid.
-           */
-          return <div>Invalid Session Claims</div>
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             * 
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     return (
         <div>
-            Your user id is: {session.getUserId()}
+            Your user id is: {accessTokenPayload.sub}
         </div>
     );
 }
 ```
 
 The `TryRefreshComponent` is a client component that checks if a session exists and tries to refresh the session if it is expired.
-
-`hasInvalidClaims` indicates that one or more of the session claims failed their validation. In this case you should check which session claim failed and redirect the user accordingly. For example to check for the email verification claim you can refer to [this page](../../common-customizations/email-verification/protecting-routes.mdx#protecting-frontend-routes--cust).
 
 And then we can modify the `/app/page.tsx` file to use our server component
 

--- a/v2/passwordless/nextjs/app-directory/protecting-route.mdx
+++ b/v2/passwordless/nextjs/app-directory/protecting-route.mdx
@@ -8,11 +8,13 @@ hide_title: true
 <!-- ./thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 4. Checking for sessions in frontend routes
 
 Protecting a website route means that it cannot be accessed unless a user is signed in. If a non signed in user tries to access it, they will be redirected to the login page.
 
+<CoreInjector showTenantId={false}>
 <PreBuiltOrCustomUISwitcher>
 
 <PreBuiltUIContent>
@@ -187,7 +189,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -220,9 +222,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -389,7 +392,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -422,9 +425,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -509,3 +513,4 @@ For custom UI SuperTokens provides no login UI, the code above will redirect the
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+</CoreInjector>

--- a/v2/passwordless/nextjs/app-directory/protecting-route.mdx
+++ b/v2/passwordless/nextjs/app-directory/protecting-route.mdx
@@ -185,8 +185,6 @@ import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
@@ -388,8 +386,6 @@ import { TryRefreshComponent } from "./tryRefreshClientComponent";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/passwordless/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/passwordless/nextjs/app-directory/server-components-requests.mdx
@@ -18,9 +18,7 @@ Lets modify the Home page we made in a [previous step](../protecting-route.mdx) 
 <PreBuiltUIContent>
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 declare let SessionAuthForNextJS: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
@@ -28,64 +26,112 @@ import { redirect } from "next/navigation";
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
 // @ts-ignore
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
 
-    if (!session) {
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
+            /**
+             * This means that the user is not logged in. If you want to display some other UI in this
+             * case, you can do so here.
+             */
             return redirect("/auth");
         }
 
-        if (hasInvalidClaims) {
-            return <SessionAuthForNextJS />;
-        } else {
-            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        /**
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
+         */
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     // highlight-start
     const userInfoResponse = await fetch('http://localhost:3000/api/user', {
       headers: {
         /**
-         * We read the access token from the session and use that as a Bearer token when
+         * We read the access token from the cookies and use that as a Bearer token when
          * making network requests.
          */
-        Authorization: 'Bearer ' + session.getAccessToken(),
+        Authorization: 'Bearer ' + getAccessToken(),
       },
     });
 
     let message = "";
 
     if (userInfoResponse.status === 200) {
-        message = `Your user id is: ${session.getUserId()}`
+        message = `Your user id is: ${accessTokenPayload.sub}`
     } else if (userInfoResponse.status === 500) {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
@@ -110,52 +156,91 @@ export async function HomePage() {
 }
 ```
 
-We use `session` returned by `getSSRSession` to get the access token of the user. We can then send the access token as a header to the API. When the API calls `withSession` it will try to read the access token from the headers and if a session exists it will return the information. You can use the `session` object to fetch other information such as `session.getUserId()`.
+We read the access token of the user from cookies.  We can then send the access token as a header to the API. When the API calls `withSession` it will try to read the access token from the headers and if a session exists it will return the session information.
 
 </PreBuiltUIContent>
 
 <CustomUIContent>
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
-import { TryRefreshComponent } from "./tryRefreshClientComponent";
+import { TryRefreshComponent } from "./tryRefreshClientComponent";import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -165,41 +250,29 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This means that one of the session claims is invalid. You should redirect the user to
-           * the appropriate page depending on which claim is invalid.
-           */
-          return <div>Invalid Session Claims</div>
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             *
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     // highlight-start
     const userInfoResponse = await fetch('http://localhost:3000/api/user', {
       headers: {
         /**
-         * We read the access token from the session and use that as a Bearer token when
+         * We read the access token from the cookies and use that as a Bearer token when
          * making network requests.
          */
-        Authorization: 'Bearer ' + session.getAccessToken(),
+        Authorization: 'Bearer ' + getAccessToken(),
       },
     });
 
     let message = "";
 
     if (userInfoResponse.status === 200) {
-        message = `Your user id is: ${session.getUserId()}`
+        message = `Your user id is: ${accessTokenPayload.sub}`
     } else if (userInfoResponse.status === 500) {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {

--- a/v2/passwordless/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/passwordless/nextjs/app-directory/server-components-requests.mdx
@@ -8,11 +8,13 @@ hide_title: true
 <!-- ./thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 6. Making requests from Server Components
 
 Lets modify the Home page we made in a [previous step](../protecting-route.mdx) to make a call to this API
 
+<CoreInjector showTenantId={false}>
 <PreBuiltOrCustomUISwitcher>
 
 <PreBuiltUIContent>
@@ -33,7 +35,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -65,10 +67,11 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 
 /**
  * A helper function to retrieve session details on the server side.
- *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * 
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -174,7 +177,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -207,9 +210,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -305,3 +309,4 @@ APIs that require sessions will return status:
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+</CoreInjector>

--- a/v2/passwordless/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/passwordless/nextjs/app-directory/server-components-requests.mdx
@@ -31,8 +31,6 @@ import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
@@ -173,8 +171,6 @@ import { redirect } from "next/navigation";
 import { TryRefreshComponent } from "./tryRefreshClientComponent";import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/passwordless/nextjs/session-verification/in-ssr.mdx
+++ b/v2/passwordless/nextjs/session-verification/in-ssr.mdx
@@ -9,6 +9,7 @@ show_ui_switcher: true
 <!-- ./thirdpartyemailpassword/nextjs/session-verification/in-ssr.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 5b. Session verification in getServerSideProps
 
@@ -24,6 +25,7 @@ For this guide, we will assume that we want to pass the logged in user's ID as a
 If using `getInitialProps`, the method described below applies as well. The only difference is the way the props are returned (see comments in the code).
 :::
 
+<CoreInjector showTenantId={false}>
 
 ```tsx
 import jwksClient from "jwks-rsa";
@@ -34,7 +36,7 @@ import { GetServerSidePropsContext } from 'next';
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-  jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+  jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
   async fetcher(jwksUri) {
     return fetch(jwksUri).then((res) => res.json());
   },
@@ -123,6 +125,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     // or return { userId: accessTokenPayload.sub } in case of getInitialProps
 }
 ```
+</CoreInjector>
 
 :::caution
 Don't use getSession or verifySession here. They might update the session tokens, and since our request interceptors don't run server-side, the updated token won't be propagated to the client side.

--- a/v2/passwordless/nextjs/session-verification/in-ssr.mdx
+++ b/v2/passwordless/nextjs/session-verification/in-ssr.mdx
@@ -32,8 +32,6 @@ import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { GetServerSidePropsContext } from 'next';
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
   jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/passwordless/nextjs/session-verification/in-ssr.mdx
+++ b/v2/passwordless/nextjs/session-verification/in-ssr.mdx
@@ -18,7 +18,7 @@ This is applicable for when verifying a session in `getServerSideProps` or `getI
 
 For this guide, we will assume that we want to pass the logged in user's ID as a prop to a protected route. An easier method to achieve this would be to [directly get the user ID from the frontend](../../common-customizations/get-user-info#on-the-frontend), but for this example, we will pass it from the server side.
 
-## 1) We use `getSession` in `getServerSideProps`
+## 1) We parse the `accessToken` JWT in `getServerSideProps`
 
 :::important
 If using `getInitialProps`, the method described below applies as well. The only difference is the way the props are returned (see comments in the code).
@@ -26,58 +26,106 @@ If using `getInitialProps`, the method described below applies as well. The only
 
 
 ```tsx
-import Session from 'supertokens-node/recipe/session'
-import supertokensNode from 'supertokens-node'
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
+import { GetServerSidePropsContext } from 'next';
 // @ts-ignore
-import { backendConfig } from '../config/backendConfig'
+import { appInfo } from "../config/appInfo";
 
-export async function getServerSideProps(context: any) {
+const client = jwksClient({
+  jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+  async fetcher(jwksUri) {
+    return fetch(jwksUri).then((res) => res.json());
+  },
+});
 
-    // this runs on the backend, so we must call init on supertokens-node SDK
-    supertokensNode.init(backendConfig())
+function getAccessToken(context: GetServerSidePropsContext ): string | undefined {
+  return context.req.cookies["sAccessToken"];
+}
 
-    // this will contain the session object post verification
-    let session
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+  client.getSigningKey(header.kid, (err, key) => {
+      if (err) {
+          callback(err);
+      } else {
+          const signingKey = key?.getPublicKey();
+          callback(null, signingKey);
+      }
+  });
+}
 
-    try {
-        // getSession will do session verification for us
-        session = await Session.getSession(context.req, context.res, {
-        overrideGlobalClaimValidators: () => {
-          // this makes it so that no custom session claims are checked
-          return []
-        }})
-    } catch (err: any) {
-        if (err.type === Session.Error.TRY_REFRESH_TOKEN) {
+async function verifyToken(token: string): Promise<JwtPayload> {
+  return new Promise((resolve, reject) => {
+      JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+          if (err) {
+              reject(err);
+          } else {
+              resolve(decoded as JwtPayload);
+          }
+      });
+  });
+}
 
-            // in this case, the session is still valid, only the access token has expired.
-            // The refresh token is not sent to this route as it's tied to the /api/auth/session/refresh API paths.
-            // So we must send a "signal" to the frontend which will then call the 
-            // refresh API and reload the page.
+/**
+* A helper function to retrieve session details on the server side.
+*
+* NOTE: This function does not use the getSession or verifySession functions from the supertokens-node SDK
+* because they can update the access token. These updated tokens would not be
+* propagated to the client side, as request interceptors do not run on the server side.
+*/
+async function getSSRSessionHelper(context: GetServerSidePropsContext): Promise<{
+  accessTokenPayload: JwtPayload | undefined;
+  hasToken: boolean;
+  error: Error | undefined;
+}> {
+  const accessToken = getAccessToken(context);
+  const hasToken = !!accessToken;
+  try {
+      if (accessToken) {
+          const decoded = await verifyToken(accessToken);
+          return { accessTokenPayload: decoded, hasToken, error: undefined };
+      }
+      return { accessTokenPayload: undefined, hasToken, error: undefined };
+  } catch (error) {
+      if (error instanceof JsonWebToken.TokenExpiredError) {
+          return { accessTokenPayload: undefined, hasToken, error: undefined };
+      }
+      return { accessTokenPayload: undefined, hasToken, error: error as Error };
+  }
+}
 
-            return { props: { fromSupertokens: 'needs-refresh' } }
-            // or return {fromSupertokens: 'needs-refresh'} in case of getInitialProps
-        } else if (err.type === Session.Error.UNAUTHORISED) {
-            // in this case, there is no session, or it has been revoked on the backend.
-            // either way, sending this response will make the frontend try and refresh
-            // which will fail and redirect the user to the login screen.
-            return { props: { fromSupertokens: 'needs-refresh' } }
-        }
-        
-        throw err
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+    const { accessTokenPayload, error } = await getSSRSessionHelper(context);
+
+    if (error) {
+      throw error;
     }
 
-    // session verification is successful and we can pass
-    // the user's ID to the frontend.
+    if (accessTokenPayload === undefined) {
+      // This occurs if the token has expired or doesn't exist.
+      // Either way, sending this response prompts the frontend to attempt a session refresh.
+      // 
+      // Case 1: Token doesn't exist
+      // - The refresh will fail, and the user will be redirected to the login page.
+      // 
+      // Case 2: Token has expired
+      // - The client will call the refresh API and update the session tokens.
+    
+      return { props: { fromSupertokens: 'needs-refresh' } }
+      // or return {fromSupertokens: 'needs-refresh'} in case of getInitialProps
+    }
 
     return {
-        props: { userId: session!.getUserId() },
+        props: { userId: accessTokenPayload.sub }
     }
-    // or return {userId: session.getUserId()} in case of getInitialProps
+
+    // or return { userId: accessTokenPayload.sub } in case of getInitialProps
 }
 ```
 
 :::caution
-Do not use the `verifySession` function here. The reason is that this will send a reply to the client in case of `TRY_REFRESH_TOKEN`, and here, we want to catch that error and send a custom reply.
+Don't use getSession or verifySession here. They might update the session tokens, and since our request interceptors don't run server-side, the updated token won't be propagated to the client side.
 :::
 
 ## 2) Doing manual refresh on the frontend
@@ -196,7 +244,7 @@ On success, `getServerSideProps` returns
 {
     // Refer to Step 1)
     // @ts-ignore
-    props: { userId: session.getUserId() }
+    props: { userId: accessTokenPayload.sub }
 }
 ```
 

--- a/v2/thirdparty/common-customizations/account-linking/automatic-account-linking.mdx
+++ b/v2/thirdparty/common-customizations/account-linking/automatic-account-linking.mdx
@@ -254,7 +254,7 @@ The following is a list of support status codes that the end user might see duri
 
 
 ### ERR_CODE_003
-This used to be an error code, which is no longer valid and can be ignored.
+This used to be an error code which is no longer valid and can be ignored.
 
 ### ERR_CODE_004
 - This can happen during the thirdparty recipe's signinup API (during sign in):

--- a/v2/thirdparty/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdparty/nextjs/app-directory/protecting-route.mdx
@@ -173,47 +173,87 @@ export const TryRefreshComponent = () => {
 We then create a server component that can check if the session exists and return any session information we may need:
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let SessionAuthForNextJS: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
 // @ts-ignore
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -223,27 +263,12 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This will make sure that the user is redirected based on their session claims. For example they
-           * will be redirected to the email verification screen if needed.
-           * 
-           * We pass in no children in this case to prevent hydration issues and still be able to redirect the
-           * user.
-           */
-            return <SessionAuthForNextJS />;
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             * 
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     /**
@@ -253,7 +278,7 @@ export async function HomePage() {
     return (
         <SessionAuthForNextJS>
             <div>
-                Your user id is: {session.getUserId()}
+                Your user id is: {accessTokenPayload.sub}
             </div>
         </SessionAuthForNextJS>
     );
@@ -352,45 +377,85 @@ export const TryRefreshComponent = () => {
 Lets modify the Home page server component we created earlier:
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -400,37 +465,23 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This means that one of the session claims is invalid. You should redirect the user to
-           * the appropriate page depending on which claim is invalid.
-           */
-          return <div>Invalid Session Claims</div>
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             * 
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     return (
         <div>
-            Your user id is: {session.getUserId()}
+            Your user id is: {accessTokenPayload.sub}
         </div>
     );
 }
 ```
 
 The `TryRefreshComponent` is a client component that checks if a session exists and tries to refresh the session if it is expired.
-
-`hasInvalidClaims` indicates that one or more of the session claims failed their validation. In this case you should check which session claim failed and redirect the user accordingly. For example to check for the email verification claim you can refer to [this page](../../common-customizations/email-verification/protecting-routes.mdx#protecting-frontend-routes--cust).
 
 And then we can modify the `/app/page.tsx` file to use our server component
 

--- a/v2/thirdparty/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdparty/nextjs/app-directory/protecting-route.mdx
@@ -8,11 +8,13 @@ hide_title: true
 <!-- ./thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 4. Checking for sessions in frontend routes
 
 Protecting a website route means that it cannot be accessed unless a user is signed in. If a non signed in user tries to access it, they will be redirected to the login page.
 
+<CoreInjector showTenantId={false}>
 <PreBuiltOrCustomUISwitcher>
 
 <PreBuiltUIContent>
@@ -187,7 +189,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -220,9 +222,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -389,7 +392,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -422,9 +425,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -509,3 +513,4 @@ For custom UI SuperTokens provides no login UI, the code above will redirect the
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+</CoreInjector>

--- a/v2/thirdparty/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdparty/nextjs/app-directory/protecting-route.mdx
@@ -185,8 +185,6 @@ import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
@@ -388,8 +386,6 @@ import { TryRefreshComponent } from "./tryRefreshClientComponent";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/thirdparty/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdparty/nextjs/app-directory/server-components-requests.mdx
@@ -18,9 +18,7 @@ Lets modify the Home page we made in a [previous step](../protecting-route.mdx) 
 <PreBuiltUIContent>
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 declare let SessionAuthForNextJS: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
@@ -28,64 +26,112 @@ import { redirect } from "next/navigation";
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
 // @ts-ignore
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
 
-    if (!session) {
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
+            /**
+             * This means that the user is not logged in. If you want to display some other UI in this
+             * case, you can do so here.
+             */
             return redirect("/auth");
         }
 
-        if (hasInvalidClaims) {
-            return <SessionAuthForNextJS />;
-        } else {
-            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        /**
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
+         */
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     // highlight-start
     const userInfoResponse = await fetch('http://localhost:3000/api/user', {
       headers: {
         /**
-         * We read the access token from the session and use that as a Bearer token when
+         * We read the access token from the cookies and use that as a Bearer token when
          * making network requests.
          */
-        Authorization: 'Bearer ' + session.getAccessToken(),
+        Authorization: 'Bearer ' + getAccessToken(),
       },
     });
 
     let message = "";
 
     if (userInfoResponse.status === 200) {
-        message = `Your user id is: ${session.getUserId()}`
+        message = `Your user id is: ${accessTokenPayload.sub}`
     } else if (userInfoResponse.status === 500) {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
@@ -110,52 +156,91 @@ export async function HomePage() {
 }
 ```
 
-We use `session` returned by `getSSRSession` to get the access token of the user. We can then send the access token as a header to the API. When the API calls `withSession` it will try to read the access token from the headers and if a session exists it will return the information. You can use the `session` object to fetch other information such as `session.getUserId()`.
+We read the access token of the user from cookies.  We can then send the access token as a header to the API. When the API calls `withSession` it will try to read the access token from the headers and if a session exists it will return the session information.
 
 </PreBuiltUIContent>
 
 <CustomUIContent>
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
-import { TryRefreshComponent } from "./tryRefreshClientComponent";
+import { TryRefreshComponent } from "./tryRefreshClientComponent";import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -165,41 +250,29 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This means that one of the session claims is invalid. You should redirect the user to
-           * the appropriate page depending on which claim is invalid.
-           */
-          return <div>Invalid Session Claims</div>
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             *
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     // highlight-start
     const userInfoResponse = await fetch('http://localhost:3000/api/user', {
       headers: {
         /**
-         * We read the access token from the session and use that as a Bearer token when
+         * We read the access token from the cookies and use that as a Bearer token when
          * making network requests.
          */
-        Authorization: 'Bearer ' + session.getAccessToken(),
+        Authorization: 'Bearer ' + getAccessToken(),
       },
     });
 
     let message = "";
 
     if (userInfoResponse.status === 200) {
-        message = `Your user id is: ${session.getUserId()}`
+        message = `Your user id is: ${accessTokenPayload.sub}`
     } else if (userInfoResponse.status === 500) {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {

--- a/v2/thirdparty/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdparty/nextjs/app-directory/server-components-requests.mdx
@@ -8,11 +8,13 @@ hide_title: true
 <!-- ./thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 6. Making requests from Server Components
 
 Lets modify the Home page we made in a [previous step](../protecting-route.mdx) to make a call to this API
 
+<CoreInjector showTenantId={false}>
 <PreBuiltOrCustomUISwitcher>
 
 <PreBuiltUIContent>
@@ -33,7 +35,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -65,10 +67,11 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 
 /**
  * A helper function to retrieve session details on the server side.
- *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * 
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -174,7 +177,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -207,9 +210,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -305,3 +309,4 @@ APIs that require sessions will return status:
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+</CoreInjector>

--- a/v2/thirdparty/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdparty/nextjs/app-directory/server-components-requests.mdx
@@ -31,8 +31,6 @@ import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
@@ -173,8 +171,6 @@ import { redirect } from "next/navigation";
 import { TryRefreshComponent } from "./tryRefreshClientComponent";import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/thirdparty/nextjs/session-verification/in-ssr.mdx
+++ b/v2/thirdparty/nextjs/session-verification/in-ssr.mdx
@@ -9,6 +9,7 @@ show_ui_switcher: true
 <!-- ./thirdpartyemailpassword/nextjs/session-verification/in-ssr.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 5b. Session verification in getServerSideProps
 
@@ -24,6 +25,7 @@ For this guide, we will assume that we want to pass the logged in user's ID as a
 If using `getInitialProps`, the method described below applies as well. The only difference is the way the props are returned (see comments in the code).
 :::
 
+<CoreInjector showTenantId={false}>
 
 ```tsx
 import jwksClient from "jwks-rsa";
@@ -34,7 +36,7 @@ import { GetServerSidePropsContext } from 'next';
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-  jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+  jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
   async fetcher(jwksUri) {
     return fetch(jwksUri).then((res) => res.json());
   },
@@ -123,6 +125,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     // or return { userId: accessTokenPayload.sub } in case of getInitialProps
 }
 ```
+</CoreInjector>
 
 :::caution
 Don't use getSession or verifySession here. They might update the session tokens, and since our request interceptors don't run server-side, the updated token won't be propagated to the client side.

--- a/v2/thirdparty/nextjs/session-verification/in-ssr.mdx
+++ b/v2/thirdparty/nextjs/session-verification/in-ssr.mdx
@@ -32,8 +32,6 @@ import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { GetServerSidePropsContext } from 'next';
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
   jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/thirdparty/nextjs/session-verification/in-ssr.mdx
+++ b/v2/thirdparty/nextjs/session-verification/in-ssr.mdx
@@ -18,7 +18,7 @@ This is applicable for when verifying a session in `getServerSideProps` or `getI
 
 For this guide, we will assume that we want to pass the logged in user's ID as a prop to a protected route. An easier method to achieve this would be to [directly get the user ID from the frontend](../../common-customizations/get-user-info#on-the-frontend), but for this example, we will pass it from the server side.
 
-## 1) We use `getSession` in `getServerSideProps`
+## 1) We parse the `accessToken` JWT in `getServerSideProps`
 
 :::important
 If using `getInitialProps`, the method described below applies as well. The only difference is the way the props are returned (see comments in the code).
@@ -26,58 +26,106 @@ If using `getInitialProps`, the method described below applies as well. The only
 
 
 ```tsx
-import Session from 'supertokens-node/recipe/session'
-import supertokensNode from 'supertokens-node'
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
+import { GetServerSidePropsContext } from 'next';
 // @ts-ignore
-import { backendConfig } from '../config/backendConfig'
+import { appInfo } from "../config/appInfo";
 
-export async function getServerSideProps(context: any) {
+const client = jwksClient({
+  jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+  async fetcher(jwksUri) {
+    return fetch(jwksUri).then((res) => res.json());
+  },
+});
 
-    // this runs on the backend, so we must call init on supertokens-node SDK
-    supertokensNode.init(backendConfig())
+function getAccessToken(context: GetServerSidePropsContext ): string | undefined {
+  return context.req.cookies["sAccessToken"];
+}
 
-    // this will contain the session object post verification
-    let session
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+  client.getSigningKey(header.kid, (err, key) => {
+      if (err) {
+          callback(err);
+      } else {
+          const signingKey = key?.getPublicKey();
+          callback(null, signingKey);
+      }
+  });
+}
 
-    try {
-        // getSession will do session verification for us
-        session = await Session.getSession(context.req, context.res, {
-        overrideGlobalClaimValidators: () => {
-          // this makes it so that no custom session claims are checked
-          return []
-        }})
-    } catch (err: any) {
-        if (err.type === Session.Error.TRY_REFRESH_TOKEN) {
+async function verifyToken(token: string): Promise<JwtPayload> {
+  return new Promise((resolve, reject) => {
+      JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+          if (err) {
+              reject(err);
+          } else {
+              resolve(decoded as JwtPayload);
+          }
+      });
+  });
+}
 
-            // in this case, the session is still valid, only the access token has expired.
-            // The refresh token is not sent to this route as it's tied to the /api/auth/session/refresh API paths.
-            // So we must send a "signal" to the frontend which will then call the 
-            // refresh API and reload the page.
+/**
+* A helper function to retrieve session details on the server side.
+*
+* NOTE: This function does not use the getSession or verifySession functions from the supertokens-node SDK
+* because they can update the access token. These updated tokens would not be
+* propagated to the client side, as request interceptors do not run on the server side.
+*/
+async function getSSRSessionHelper(context: GetServerSidePropsContext): Promise<{
+  accessTokenPayload: JwtPayload | undefined;
+  hasToken: boolean;
+  error: Error | undefined;
+}> {
+  const accessToken = getAccessToken(context);
+  const hasToken = !!accessToken;
+  try {
+      if (accessToken) {
+          const decoded = await verifyToken(accessToken);
+          return { accessTokenPayload: decoded, hasToken, error: undefined };
+      }
+      return { accessTokenPayload: undefined, hasToken, error: undefined };
+  } catch (error) {
+      if (error instanceof JsonWebToken.TokenExpiredError) {
+          return { accessTokenPayload: undefined, hasToken, error: undefined };
+      }
+      return { accessTokenPayload: undefined, hasToken, error: error as Error };
+  }
+}
 
-            return { props: { fromSupertokens: 'needs-refresh' } }
-            // or return {fromSupertokens: 'needs-refresh'} in case of getInitialProps
-        } else if (err.type === Session.Error.UNAUTHORISED) {
-            // in this case, there is no session, or it has been revoked on the backend.
-            // either way, sending this response will make the frontend try and refresh
-            // which will fail and redirect the user to the login screen.
-            return { props: { fromSupertokens: 'needs-refresh' } }
-        }
-        
-        throw err
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+    const { accessTokenPayload, error } = await getSSRSessionHelper(context);
+
+    if (error) {
+      throw error;
     }
 
-    // session verification is successful and we can pass
-    // the user's ID to the frontend.
+    if (accessTokenPayload === undefined) {
+      // This occurs if the token has expired or doesn't exist.
+      // Either way, sending this response prompts the frontend to attempt a session refresh.
+      // 
+      // Case 1: Token doesn't exist
+      // - The refresh will fail, and the user will be redirected to the login page.
+      // 
+      // Case 2: Token has expired
+      // - The client will call the refresh API and update the session tokens.
+    
+      return { props: { fromSupertokens: 'needs-refresh' } }
+      // or return {fromSupertokens: 'needs-refresh'} in case of getInitialProps
+    }
 
     return {
-        props: { userId: session!.getUserId() },
+        props: { userId: accessTokenPayload.sub }
     }
-    // or return {userId: session.getUserId()} in case of getInitialProps
+
+    // or return { userId: accessTokenPayload.sub } in case of getInitialProps
 }
 ```
 
 :::caution
-Do not use the `verifySession` function here. The reason is that this will send a reply to the client in case of `TRY_REFRESH_TOKEN`, and here, we want to catch that error and send a custom reply.
+Don't use getSession or verifySession here. They might update the session tokens, and since our request interceptors don't run server-side, the updated token won't be propagated to the client side.
 :::
 
 ## 2) Doing manual refresh on the frontend
@@ -196,7 +244,7 @@ On success, `getServerSideProps` returns
 {
     // Refer to Step 1)
     // @ts-ignore
-    props: { userId: session.getUserId() }
+    props: { userId: accessTokenPayload.sub }
 }
 ```
 

--- a/v2/thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx
@@ -174,47 +174,87 @@ export const TryRefreshComponent = () => {
 We then create a server component that can check if the session exists and return any session information we may need:
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let SessionAuthForNextJS: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
 // @ts-ignore
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -224,27 +264,12 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This will make sure that the user is redirected based on their session claims. For example they
-           * will be redirected to the email verification screen if needed.
-           * 
-           * We pass in no children in this case to prevent hydration issues and still be able to redirect the
-           * user.
-           */
-            return <SessionAuthForNextJS />;
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             * 
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     /**
@@ -254,7 +279,7 @@ export async function HomePage() {
     return (
         <SessionAuthForNextJS>
             <div>
-                Your user id is: {session.getUserId()}
+                Your user id is: {accessTokenPayload.sub}
             </div>
         </SessionAuthForNextJS>
     );
@@ -353,45 +378,85 @@ export const TryRefreshComponent = () => {
 Lets modify the Home page server component we created earlier:
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -401,37 +466,23 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This means that one of the session claims is invalid. You should redirect the user to
-           * the appropriate page depending on which claim is invalid.
-           */
-          return <div>Invalid Session Claims</div>
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             * 
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     return (
         <div>
-            Your user id is: {session.getUserId()}
+            Your user id is: {accessTokenPayload.sub}
         </div>
     );
 }
 ```
 
 The `TryRefreshComponent` is a client component that checks if a session exists and tries to refresh the session if it is expired.
-
-`hasInvalidClaims` indicates that one or more of the session claims failed their validation. In this case you should check which session claim failed and redirect the user accordingly. For example to check for the email verification claim you can refer to [this page](../../common-customizations/email-verification/protecting-routes.mdx#protecting-frontend-routes--cust).
 
 And then we can modify the `/app/page.tsx` file to use our server component
 

--- a/v2/thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx
@@ -9,11 +9,13 @@ show_ui_switcher: true
 <!-- ./thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 4. Checking for sessions in frontend routes
 
 Protecting a website route means that it cannot be accessed unless a user is signed in. If a non signed in user tries to access it, they will be redirected to the login page.
 
+<CoreInjector showTenantId={false}>
 <PreBuiltOrCustomUISwitcher>
 
 <PreBuiltUIContent>
@@ -188,7 +190,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -221,9 +223,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -390,7 +393,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -423,9 +426,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -510,3 +514,4 @@ For custom UI SuperTokens provides no login UI, the code above will redirect the
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+</CoreInjector>

--- a/v2/thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx
@@ -186,8 +186,6 @@ import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
@@ -389,8 +387,6 @@ import { TryRefreshComponent } from "./tryRefreshClientComponent";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx
@@ -19,9 +19,7 @@ Lets modify the Home page we made in a [previous step](../protecting-route.mdx) 
 <PreBuiltUIContent>
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 declare let SessionAuthForNextJS: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
@@ -29,64 +27,112 @@ import { redirect } from "next/navigation";
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
 // @ts-ignore
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
 
-    if (!session) {
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
+            /**
+             * This means that the user is not logged in. If you want to display some other UI in this
+             * case, you can do so here.
+             */
             return redirect("/auth");
         }
 
-        if (hasInvalidClaims) {
-            return <SessionAuthForNextJS />;
-        } else {
-            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        /**
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
+         */
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     // highlight-start
     const userInfoResponse = await fetch('http://localhost:3000/api/user', {
       headers: {
         /**
-         * We read the access token from the session and use that as a Bearer token when
+         * We read the access token from the cookies and use that as a Bearer token when
          * making network requests.
          */
-        Authorization: 'Bearer ' + session.getAccessToken(),
+        Authorization: 'Bearer ' + getAccessToken(),
       },
     });
 
     let message = "";
 
     if (userInfoResponse.status === 200) {
-        message = `Your user id is: ${session.getUserId()}`
+        message = `Your user id is: ${accessTokenPayload.sub}`
     } else if (userInfoResponse.status === 500) {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
@@ -111,52 +157,91 @@ export async function HomePage() {
 }
 ```
 
-We use `session` returned by `getSSRSession` to get the access token of the user. We can then send the access token as a header to the API. When the API calls `withSession` it will try to read the access token from the headers and if a session exists it will return the information. You can use the `session` object to fetch other information such as `session.getUserId()`.
+We read the access token of the user from cookies.  We can then send the access token as a header to the API. When the API calls `withSession` it will try to read the access token from the headers and if a session exists it will return the session information.
 
 </PreBuiltUIContent>
 
 <CustomUIContent>
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
-import { TryRefreshComponent } from "./tryRefreshClientComponent";
+import { TryRefreshComponent } from "./tryRefreshClientComponent";import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -166,41 +251,29 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This means that one of the session claims is invalid. You should redirect the user to
-           * the appropriate page depending on which claim is invalid.
-           */
-          return <div>Invalid Session Claims</div>
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             *
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     // highlight-start
     const userInfoResponse = await fetch('http://localhost:3000/api/user', {
       headers: {
         /**
-         * We read the access token from the session and use that as a Bearer token when
+         * We read the access token from the cookies and use that as a Bearer token when
          * making network requests.
          */
-        Authorization: 'Bearer ' + session.getAccessToken(),
+        Authorization: 'Bearer ' + getAccessToken(),
       },
     });
 
     let message = "";
 
     if (userInfoResponse.status === 200) {
-        message = `Your user id is: ${session.getUserId()}`
+        message = `Your user id is: ${accessTokenPayload.sub}`
     } else if (userInfoResponse.status === 500) {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {

--- a/v2/thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx
@@ -32,8 +32,6 @@ import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
@@ -174,8 +172,6 @@ import { redirect } from "next/navigation";
 import { TryRefreshComponent } from "./tryRefreshClientComponent";import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx
@@ -9,11 +9,13 @@ show_ui_switcher: true
 <!-- ./thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 6. Making requests from Server Components
 
 Lets modify the Home page we made in a [previous step](../protecting-route.mdx) to make a call to this API
 
+<CoreInjector showTenantId={false}>
 <PreBuiltOrCustomUISwitcher>
 
 <PreBuiltUIContent>
@@ -34,7 +36,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -66,10 +68,11 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 
 /**
  * A helper function to retrieve session details on the server side.
- *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * 
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -175,7 +178,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -208,9 +211,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -306,3 +310,4 @@ APIs that require sessions will return status:
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+</CoreInjector>

--- a/v2/thirdpartyemailpassword/nextjs/session-verification/in-ssr.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/session-verification/in-ssr.mdx
@@ -9,6 +9,7 @@ show_ui_switcher: true
 <!-- ./thirdpartyemailpassword/nextjs/session-verification/in-ssr.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 5b. Session verification in getServerSideProps
 
@@ -24,6 +25,7 @@ For this guide, we will assume that we want to pass the logged in user's ID as a
 If using `getInitialProps`, the method described below applies as well. The only difference is the way the props are returned (see comments in the code).
 :::
 
+<CoreInjector showTenantId={false}>
 
 ```tsx
 import jwksClient from "jwks-rsa";
@@ -34,7 +36,7 @@ import { GetServerSidePropsContext } from 'next';
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-  jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+  jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
   async fetcher(jwksUri) {
     return fetch(jwksUri).then((res) => res.json());
   },
@@ -123,6 +125,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     // or return { userId: accessTokenPayload.sub } in case of getInitialProps
 }
 ```
+</CoreInjector>
 
 :::caution
 Don't use getSession or verifySession here. They might update the session tokens, and since our request interceptors don't run server-side, the updated token won't be propagated to the client side.

--- a/v2/thirdpartyemailpassword/nextjs/session-verification/in-ssr.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/session-verification/in-ssr.mdx
@@ -32,8 +32,6 @@ import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { GetServerSidePropsContext } from 'next';
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
   jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/thirdpartyemailpassword/nextjs/session-verification/in-ssr.mdx
+++ b/v2/thirdpartyemailpassword/nextjs/session-verification/in-ssr.mdx
@@ -18,7 +18,7 @@ This is applicable for when verifying a session in `getServerSideProps` or `getI
 
 For this guide, we will assume that we want to pass the logged in user's ID as a prop to a protected route. An easier method to achieve this would be to [directly get the user ID from the frontend](../../common-customizations/get-user-info#on-the-frontend), but for this example, we will pass it from the server side.
 
-## 1) We use `getSession` in `getServerSideProps`
+## 1) We parse the `accessToken` JWT in `getServerSideProps`
 
 :::important
 If using `getInitialProps`, the method described below applies as well. The only difference is the way the props are returned (see comments in the code).
@@ -26,58 +26,106 @@ If using `getInitialProps`, the method described below applies as well. The only
 
 
 ```tsx
-import Session from 'supertokens-node/recipe/session'
-import supertokensNode from 'supertokens-node'
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
+import { GetServerSidePropsContext } from 'next';
 // @ts-ignore
-import { backendConfig } from '../config/backendConfig'
+import { appInfo } from "../config/appInfo";
 
-export async function getServerSideProps(context: any) {
+const client = jwksClient({
+  jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+  async fetcher(jwksUri) {
+    return fetch(jwksUri).then((res) => res.json());
+  },
+});
 
-    // this runs on the backend, so we must call init on supertokens-node SDK
-    supertokensNode.init(backendConfig())
+function getAccessToken(context: GetServerSidePropsContext ): string | undefined {
+  return context.req.cookies["sAccessToken"];
+}
 
-    // this will contain the session object post verification
-    let session
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+  client.getSigningKey(header.kid, (err, key) => {
+      if (err) {
+          callback(err);
+      } else {
+          const signingKey = key?.getPublicKey();
+          callback(null, signingKey);
+      }
+  });
+}
 
-    try {
-        // getSession will do session verification for us
-        session = await Session.getSession(context.req, context.res, {
-        overrideGlobalClaimValidators: () => {
-          // this makes it so that no custom session claims are checked
-          return []
-        }})
-    } catch (err: any) {
-        if (err.type === Session.Error.TRY_REFRESH_TOKEN) {
+async function verifyToken(token: string): Promise<JwtPayload> {
+  return new Promise((resolve, reject) => {
+      JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+          if (err) {
+              reject(err);
+          } else {
+              resolve(decoded as JwtPayload);
+          }
+      });
+  });
+}
 
-            // in this case, the session is still valid, only the access token has expired.
-            // The refresh token is not sent to this route as it's tied to the /api/auth/session/refresh API paths.
-            // So we must send a "signal" to the frontend which will then call the 
-            // refresh API and reload the page.
+/**
+* A helper function to retrieve session details on the server side.
+*
+* NOTE: This function does not use the getSession or verifySession functions from the supertokens-node SDK
+* because they can update the access token. These updated tokens would not be
+* propagated to the client side, as request interceptors do not run on the server side.
+*/
+async function getSSRSessionHelper(context: GetServerSidePropsContext): Promise<{
+  accessTokenPayload: JwtPayload | undefined;
+  hasToken: boolean;
+  error: Error | undefined;
+}> {
+  const accessToken = getAccessToken(context);
+  const hasToken = !!accessToken;
+  try {
+      if (accessToken) {
+          const decoded = await verifyToken(accessToken);
+          return { accessTokenPayload: decoded, hasToken, error: undefined };
+      }
+      return { accessTokenPayload: undefined, hasToken, error: undefined };
+  } catch (error) {
+      if (error instanceof JsonWebToken.TokenExpiredError) {
+          return { accessTokenPayload: undefined, hasToken, error: undefined };
+      }
+      return { accessTokenPayload: undefined, hasToken, error: error as Error };
+  }
+}
 
-            return { props: { fromSupertokens: 'needs-refresh' } }
-            // or return {fromSupertokens: 'needs-refresh'} in case of getInitialProps
-        } else if (err.type === Session.Error.UNAUTHORISED) {
-            // in this case, there is no session, or it has been revoked on the backend.
-            // either way, sending this response will make the frontend try and refresh
-            // which will fail and redirect the user to the login screen.
-            return { props: { fromSupertokens: 'needs-refresh' } }
-        }
-        
-        throw err
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+    const { accessTokenPayload, error } = await getSSRSessionHelper(context);
+
+    if (error) {
+      throw error;
     }
 
-    // session verification is successful and we can pass
-    // the user's ID to the frontend.
+    if (accessTokenPayload === undefined) {
+      // This occurs if the token has expired or doesn't exist.
+      // Either way, sending this response prompts the frontend to attempt a session refresh.
+      // 
+      // Case 1: Token doesn't exist
+      // - The refresh will fail, and the user will be redirected to the login page.
+      // 
+      // Case 2: Token has expired
+      // - The client will call the refresh API and update the session tokens.
+    
+      return { props: { fromSupertokens: 'needs-refresh' } }
+      // or return {fromSupertokens: 'needs-refresh'} in case of getInitialProps
+    }
 
     return {
-        props: { userId: session!.getUserId() },
+        props: { userId: accessTokenPayload.sub }
     }
-    // or return {userId: session.getUserId()} in case of getInitialProps
+
+    // or return { userId: accessTokenPayload.sub } in case of getInitialProps
 }
 ```
 
 :::caution
-Do not use the `verifySession` function here. The reason is that this will send a reply to the client in case of `TRY_REFRESH_TOKEN`, and here, we want to catch that error and send a custom reply.
+Don't use getSession or verifySession here. They might update the session tokens, and since our request interceptors don't run server-side, the updated token won't be propagated to the client side.
 :::
 
 ## 2) Doing manual refresh on the frontend
@@ -196,7 +244,7 @@ On success, `getServerSideProps` returns
 {
     // Refer to Step 1)
     // @ts-ignore
-    props: { userId: session.getUserId() }
+    props: { userId: accessTokenPayload.sub }
 }
 ```
 

--- a/v2/thirdpartypasswordless/common-customizations/account-linking/automatic-account-linking.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/account-linking/automatic-account-linking.mdx
@@ -254,7 +254,7 @@ The following is a list of support status codes that the end user might see duri
 
 
 ### ERR_CODE_003
-This used to be an error code, which is no longer valid and can be ignored.
+This used to be an error code which is no longer valid and can be ignored.
 
 ### ERR_CODE_004
 - This can happen during the thirdparty recipe's signinup API (during sign in):

--- a/v2/thirdpartypasswordless/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdpartypasswordless/nextjs/app-directory/protecting-route.mdx
@@ -173,47 +173,87 @@ export const TryRefreshComponent = () => {
 We then create a server component that can check if the session exists and return any session information we may need:
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let SessionAuthForNextJS: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
 // @ts-ignore
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -223,27 +263,12 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This will make sure that the user is redirected based on their session claims. For example they
-           * will be redirected to the email verification screen if needed.
-           * 
-           * We pass in no children in this case to prevent hydration issues and still be able to redirect the
-           * user.
-           */
-            return <SessionAuthForNextJS />;
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             * 
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     /**
@@ -253,7 +278,7 @@ export async function HomePage() {
     return (
         <SessionAuthForNextJS>
             <div>
-                Your user id is: {session.getUserId()}
+                Your user id is: {accessTokenPayload.sub}
             </div>
         </SessionAuthForNextJS>
     );
@@ -352,45 +377,85 @@ export const TryRefreshComponent = () => {
 Lets modify the Home page server component we created earlier:
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -400,37 +465,23 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This means that one of the session claims is invalid. You should redirect the user to
-           * the appropriate page depending on which claim is invalid.
-           */
-          return <div>Invalid Session Claims</div>
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             * 
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     return (
         <div>
-            Your user id is: {session.getUserId()}
+            Your user id is: {accessTokenPayload.sub}
         </div>
     );
 }
 ```
 
 The `TryRefreshComponent` is a client component that checks if a session exists and tries to refresh the session if it is expired.
-
-`hasInvalidClaims` indicates that one or more of the session claims failed their validation. In this case you should check which session claim failed and redirect the user accordingly. For example to check for the email verification claim you can refer to [this page](../../common-customizations/email-verification/protecting-routes.mdx#protecting-frontend-routes--cust).
 
 And then we can modify the `/app/page.tsx` file to use our server component
 

--- a/v2/thirdpartypasswordless/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdpartypasswordless/nextjs/app-directory/protecting-route.mdx
@@ -8,11 +8,13 @@ hide_title: true
 <!-- ./thirdpartyemailpassword/nextjs/app-directory/protecting-route.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 4. Checking for sessions in frontend routes
 
 Protecting a website route means that it cannot be accessed unless a user is signed in. If a non signed in user tries to access it, they will be redirected to the login page.
 
+<CoreInjector showTenantId={false}>
 <PreBuiltOrCustomUISwitcher>
 
 <PreBuiltUIContent>
@@ -187,7 +189,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -220,9 +222,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -389,7 +392,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -422,9 +425,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -509,3 +513,4 @@ For custom UI SuperTokens provides no login UI, the code above will redirect the
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+</CoreInjector>

--- a/v2/thirdpartypasswordless/nextjs/app-directory/protecting-route.mdx
+++ b/v2/thirdpartypasswordless/nextjs/app-directory/protecting-route.mdx
@@ -185,8 +185,6 @@ import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
@@ -388,8 +386,6 @@ import { TryRefreshComponent } from "./tryRefreshClientComponent";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/thirdpartypasswordless/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdpartypasswordless/nextjs/app-directory/server-components-requests.mdx
@@ -18,9 +18,7 @@ Lets modify the Home page we made in a [previous step](../protecting-route.mdx) 
 <PreBuiltUIContent>
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 declare let SessionAuthForNextJS: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
@@ -28,64 +26,112 @@ import { redirect } from "next/navigation";
 import { TryRefreshComponent } from "./tryRefreshClientComponent";
 // @ts-ignore
 import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
 
-    if (!session) {
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
+            /**
+             * This means that the user is not logged in. If you want to display some other UI in this
+             * case, you can do so here.
+             */
             return redirect("/auth");
         }
 
-        if (hasInvalidClaims) {
-            return <SessionAuthForNextJS />;
-        } else {
-            // To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        /**
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
+         */
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     // highlight-start
     const userInfoResponse = await fetch('http://localhost:3000/api/user', {
       headers: {
         /**
-         * We read the access token from the session and use that as a Bearer token when
+         * We read the access token from the cookies and use that as a Bearer token when
          * making network requests.
          */
-        Authorization: 'Bearer ' + session.getAccessToken(),
+        Authorization: 'Bearer ' + getAccessToken(),
       },
     });
 
     let message = "";
 
     if (userInfoResponse.status === 200) {
-        message = `Your user id is: ${session.getUserId()}`
+        message = `Your user id is: ${accessTokenPayload.sub}`
     } else if (userInfoResponse.status === 500) {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {
@@ -110,52 +156,91 @@ export async function HomePage() {
 }
 ```
 
-We use `session` returned by `getSSRSession` to get the access token of the user. We can then send the access token as a header to the API. When the API calls `withSession` it will try to read the access token from the headers and if a session exists it will return the information. You can use the `session` object to fetch other information such as `session.getUserId()`.
+We read the access token of the user from cookies.  We can then send the access token as a header to the API. When the API calls `withSession` it will try to read the access token from the headers and if a session exists it will return the session information.
 
 </PreBuiltUIContent>
 
 <CustomUIContent>
 
 ```tsx title="app/components/home.tsx"
-import { getSSRSession } from "supertokens-node/nextjs";
-import { SessionContainer } from "supertokens-node/recipe/session";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 declare let TryRefreshComponent: any; // typecheck-only, removed from output
 import { redirect } from "next/navigation";
 // @ts-ignore
-import { TryRefreshComponent } from "./tryRefreshClientComponent";
+import { TryRefreshComponent } from "./tryRefreshClientComponent";import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 // @ts-ignore
-import { ensureSuperTokensInit } from "../config/backend";
+import { appInfo } from "../config/appInfo";
 
-ensureSuperTokensInit();
+const client = jwksClient({
+    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+});
 
-async function getSSRSessionHelper(): Promise<{ session: SessionContainer | undefined; hasToken: boolean; hasInvalidClaims: boolean, error: Error | undefined }> {
-    let session: SessionContainer | undefined;
-    let hasToken = false;
-    let hasInvalidClaims = false;
-    let error: Error | undefined = undefined;
-    
+function getAccessToken(): string | undefined {
+    return cookies().get("sAccessToken")?.value;
+}
+
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+        } else {
+            const signingKey = key?.getPublicKey();
+            callback(null, signingKey);
+        }
+    });
+}
+
+async function verifyToken(token: string): Promise<JwtPayload> {
+    return new Promise((resolve, reject) => {
+        JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(decoded as JwtPayload);
+            }
+        });
+    });
+}
+
+/**
+ * A helper function to retrieve session details on the server side.
+ *
+ * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
+ * because getSession can update the access token. These updated tokens would not be
+ * propagated to the client side, as request interceptors do not run on the server side.
+ */
+async function getSSRSessionHelper(): Promise<{
+    accessTokenPayload: JwtPayload | undefined;
+    hasToken: boolean;
+    error: Error | undefined;
+}> {
+    const accessToken = getAccessToken();
+    const hasToken = !!accessToken;
     try {
-        ({ session, hasToken, hasInvalidClaims } = await getSSRSession(cookies().getAll(), headers()));
-    } catch (err: any) {
-        error = err;
+        if (accessToken) {
+            const decoded = await verifyToken(accessToken);
+            return { accessTokenPayload: decoded, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: undefined };
+    } catch (error) {
+        if (error instanceof JsonWebToken.TokenExpiredError) {
+            return { accessTokenPayload: undefined, hasToken, error: undefined };
+        }
+        return { accessTokenPayload: undefined, hasToken, error: error as Error };
     }
-    return { session, hasToken, hasInvalidClaims, error };
 }
 
 export async function HomePage() {
-    const { session, hasToken, hasInvalidClaims, error } = await getSSRSessionHelper();
+    const { accessTokenPayload, hasToken, error } = await getSSRSessionHelper();
 
     if (error) {
-        return (
-            <div>
-                Something went wrong while trying to get the session. Error - {error.message}
-            </div>
-        )
+        return <div>Something went wrong while trying to get the session. Error - {error.message}</div>;
     }
-    
-    // `session` will be undefined if it does not exist or has expired
-    if (!session) {
+
+    // `accessTokenPayload` will be undefined if it the session does not exist or has expired
+    if (accessTokenPayload === undefined) {
         if (!hasToken) {
             /**
              * This means that the user is not logged in. If you want to display some other UI in this
@@ -165,41 +250,29 @@ export async function HomePage() {
         }
 
         /**
-         * `hasInvalidClaims` indicates that session claims did not pass validation. For example if email
-         * verification is required but the user's email has not been verified.
+         * This means that the session does not exist but we have session tokens for the user. In this case
+         * the `TryRefreshComponent` will try to refresh the session.
+         *
+         * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
          */
-        if (hasInvalidClaims) {
-          /**
-           * This means that one of the session claims is invalid. You should redirect the user to
-           * the appropriate page depending on which claim is invalid.
-           */
-          return <div>Invalid Session Claims</div>
-        } else {
-            /**
-             * This means that the session does not exist but we have session tokens for the user. In this case
-             * the `TryRefreshComponent` will try to refresh the session.
-             *
-             * To learn about why the 'key' attribute is required refer to: https://github.com/supertokens/supertokens-node/issues/826#issuecomment-2092144048
-             */
-            return <TryRefreshComponent key={Date.now()} />;
-        }
+        return <TryRefreshComponent key={Date.now()} />;
     }
 
     // highlight-start
     const userInfoResponse = await fetch('http://localhost:3000/api/user', {
       headers: {
         /**
-         * We read the access token from the session and use that as a Bearer token when
+         * We read the access token from the cookies and use that as a Bearer token when
          * making network requests.
          */
-        Authorization: 'Bearer ' + session.getAccessToken(),
+        Authorization: 'Bearer ' + getAccessToken(),
       },
     });
 
     let message = "";
 
     if (userInfoResponse.status === 200) {
-        message = `Your user id is: ${session.getUserId()}`
+        message = `Your user id is: ${accessTokenPayload.sub}`
     } else if (userInfoResponse.status === 500) {
         message = "Something went wrong"
     } else if (userInfoResponse.status === 401) {

--- a/v2/thirdpartypasswordless/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdpartypasswordless/nextjs/app-directory/server-components-requests.mdx
@@ -8,11 +8,13 @@ hide_title: true
 <!-- ./thirdpartyemailpassword/nextjs/app-directory/server-components-requests.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 6. Making requests from Server Components
 
 Lets modify the Home page we made in a [previous step](../protecting-route.mdx) to make a call to this API
 
+<CoreInjector showTenantId={false}>
 <PreBuiltOrCustomUISwitcher>
 
 <PreBuiltUIContent>
@@ -33,7 +35,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -65,10 +67,11 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 
 /**
  * A helper function to retrieve session details on the server side.
- *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * 
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -174,7 +177,7 @@ import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-    jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+    jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
 });
 
 function getAccessToken(): string | undefined {
@@ -207,9 +210,10 @@ async function verifyToken(token: string): Promise<JwtPayload> {
 /**
  * A helper function to retrieve session details on the server side.
  *
- * NOTE: This function does not use the getSSRSession function from the supertokens-node SDK
- * because getSession can update the access token. These updated tokens would not be
- * propagated to the client side, as request interceptors do not run on the server side.
+ * NOTE: This function does not use the getSession / verifySession function from the supertokens-node SDK
+ * because those functions may update the access token. These updated tokens would not be
+ * propagated to the client side properly, as request interceptors do not run on the server side.
+ * So instead, we use regular JWT verification library
  */
 async function getSSRSessionHelper(): Promise<{
     accessTokenPayload: JwtPayload | undefined;
@@ -305,3 +309,4 @@ APIs that require sessions will return status:
 </CustomUIContent>
 
 </PreBuiltOrCustomUISwitcher>
+</CoreInjector>

--- a/v2/thirdpartypasswordless/nextjs/app-directory/server-components-requests.mdx
+++ b/v2/thirdpartypasswordless/nextjs/app-directory/server-components-requests.mdx
@@ -31,8 +31,6 @@ import { SessionAuthForNextJS } from "./sessionAuthForNextJS";
 import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
@@ -173,8 +171,6 @@ import { redirect } from "next/navigation";
 import { TryRefreshComponent } from "./tryRefreshClientComponent";import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
     jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/thirdpartypasswordless/nextjs/session-verification/in-ssr.mdx
+++ b/v2/thirdpartypasswordless/nextjs/session-verification/in-ssr.mdx
@@ -9,6 +9,7 @@ show_ui_switcher: true
 <!-- ./thirdpartyemailpassword/nextjs/session-verification/in-ssr.mdx -->
 
 import {PreBuiltOrCustomUISwitcher, PreBuiltUIContent, CustomUIContent} from "/src/components/preBuiltOrCustomUISwitcher"
+import CoreInjector from "/src/components/coreInjector"
 
 # 5b. Session verification in getServerSideProps
 
@@ -24,6 +25,7 @@ For this guide, we will assume that we want to pass the logged in user's ID as a
 If using `getInitialProps`, the method described below applies as well. The only difference is the way the props are returned (see comments in the code).
 :::
 
+<CoreInjector showTenantId={false}>
 
 ```tsx
 import jwksClient from "jwks-rsa";
@@ -34,7 +36,7 @@ import { GetServerSidePropsContext } from 'next';
 import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
-  jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+  jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",
   async fetcher(jwksUri) {
     return fetch(jwksUri).then((res) => res.json());
   },
@@ -123,6 +125,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     // or return { userId: accessTokenPayload.sub } in case of getInitialProps
 }
 ```
+</CoreInjector>
 
 :::caution
 Don't use getSession or verifySession here. They might update the session tokens, and since our request interceptors don't run server-side, the updated token won't be propagated to the client side.

--- a/v2/thirdpartypasswordless/nextjs/session-verification/in-ssr.mdx
+++ b/v2/thirdpartypasswordless/nextjs/session-verification/in-ssr.mdx
@@ -32,8 +32,6 @@ import jwksClient from "jwks-rsa";
 import JsonWebToken from "jsonwebtoken";
 import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
 import { GetServerSidePropsContext } from 'next';
-// @ts-ignore
-import { appInfo } from "../config/appInfo";
 
 const client = jwksClient({
   jwksUri: "^{coreInjector_uri_without_quotes}/.well-known/jwks.json",

--- a/v2/thirdpartypasswordless/nextjs/session-verification/in-ssr.mdx
+++ b/v2/thirdpartypasswordless/nextjs/session-verification/in-ssr.mdx
@@ -18,7 +18,7 @@ This is applicable for when verifying a session in `getServerSideProps` or `getI
 
 For this guide, we will assume that we want to pass the logged in user's ID as a prop to a protected route. An easier method to achieve this would be to [directly get the user ID from the frontend](../../common-customizations/get-user-info#on-the-frontend), but for this example, we will pass it from the server side.
 
-## 1) We use `getSession` in `getServerSideProps`
+## 1) We parse the `accessToken` JWT in `getServerSideProps`
 
 :::important
 If using `getInitialProps`, the method described below applies as well. The only difference is the way the props are returned (see comments in the code).
@@ -26,58 +26,106 @@ If using `getInitialProps`, the method described below applies as well. The only
 
 
 ```tsx
-import Session from 'supertokens-node/recipe/session'
-import supertokensNode from 'supertokens-node'
+import jwksClient from "jwks-rsa";
+import JsonWebToken from "jsonwebtoken";
+import type { JwtHeader, JwtPayload, SigningKeyCallback } from "jsonwebtoken";
+import { GetServerSidePropsContext } from 'next';
 // @ts-ignore
-import { backendConfig } from '../config/backendConfig'
+import { appInfo } from "../config/appInfo";
 
-export async function getServerSideProps(context: any) {
+const client = jwksClient({
+  jwksUri: `${appInfo.apiDomain}${appInfo.apiBasePath}/jwt/jwks.json`,
+  async fetcher(jwksUri) {
+    return fetch(jwksUri).then((res) => res.json());
+  },
+});
 
-    // this runs on the backend, so we must call init on supertokens-node SDK
-    supertokensNode.init(backendConfig())
+function getAccessToken(context: GetServerSidePropsContext ): string | undefined {
+  return context.req.cookies["sAccessToken"];
+}
 
-    // this will contain the session object post verification
-    let session
+function getPublicKey(header: JwtHeader, callback: SigningKeyCallback) {
+  client.getSigningKey(header.kid, (err, key) => {
+      if (err) {
+          callback(err);
+      } else {
+          const signingKey = key?.getPublicKey();
+          callback(null, signingKey);
+      }
+  });
+}
 
-    try {
-        // getSession will do session verification for us
-        session = await Session.getSession(context.req, context.res, {
-        overrideGlobalClaimValidators: () => {
-          // this makes it so that no custom session claims are checked
-          return []
-        }})
-    } catch (err: any) {
-        if (err.type === Session.Error.TRY_REFRESH_TOKEN) {
+async function verifyToken(token: string): Promise<JwtPayload> {
+  return new Promise((resolve, reject) => {
+      JsonWebToken.verify(token, getPublicKey, {}, (err, decoded) => {
+          if (err) {
+              reject(err);
+          } else {
+              resolve(decoded as JwtPayload);
+          }
+      });
+  });
+}
 
-            // in this case, the session is still valid, only the access token has expired.
-            // The refresh token is not sent to this route as it's tied to the /api/auth/session/refresh API paths.
-            // So we must send a "signal" to the frontend which will then call the 
-            // refresh API and reload the page.
+/**
+* A helper function to retrieve session details on the server side.
+*
+* NOTE: This function does not use the getSession or verifySession functions from the supertokens-node SDK
+* because they can update the access token. These updated tokens would not be
+* propagated to the client side, as request interceptors do not run on the server side.
+*/
+async function getSSRSessionHelper(context: GetServerSidePropsContext): Promise<{
+  accessTokenPayload: JwtPayload | undefined;
+  hasToken: boolean;
+  error: Error | undefined;
+}> {
+  const accessToken = getAccessToken(context);
+  const hasToken = !!accessToken;
+  try {
+      if (accessToken) {
+          const decoded = await verifyToken(accessToken);
+          return { accessTokenPayload: decoded, hasToken, error: undefined };
+      }
+      return { accessTokenPayload: undefined, hasToken, error: undefined };
+  } catch (error) {
+      if (error instanceof JsonWebToken.TokenExpiredError) {
+          return { accessTokenPayload: undefined, hasToken, error: undefined };
+      }
+      return { accessTokenPayload: undefined, hasToken, error: error as Error };
+  }
+}
 
-            return { props: { fromSupertokens: 'needs-refresh' } }
-            // or return {fromSupertokens: 'needs-refresh'} in case of getInitialProps
-        } else if (err.type === Session.Error.UNAUTHORISED) {
-            // in this case, there is no session, or it has been revoked on the backend.
-            // either way, sending this response will make the frontend try and refresh
-            // which will fail and redirect the user to the login screen.
-            return { props: { fromSupertokens: 'needs-refresh' } }
-        }
-        
-        throw err
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+    const { accessTokenPayload, error } = await getSSRSessionHelper(context);
+
+    if (error) {
+      throw error;
     }
 
-    // session verification is successful and we can pass
-    // the user's ID to the frontend.
+    if (accessTokenPayload === undefined) {
+      // This occurs if the token has expired or doesn't exist.
+      // Either way, sending this response prompts the frontend to attempt a session refresh.
+      // 
+      // Case 1: Token doesn't exist
+      // - The refresh will fail, and the user will be redirected to the login page.
+      // 
+      // Case 2: Token has expired
+      // - The client will call the refresh API and update the session tokens.
+    
+      return { props: { fromSupertokens: 'needs-refresh' } }
+      // or return {fromSupertokens: 'needs-refresh'} in case of getInitialProps
+    }
 
     return {
-        props: { userId: session!.getUserId() },
+        props: { userId: accessTokenPayload.sub }
     }
-    // or return {userId: session.getUserId()} in case of getInitialProps
+
+    // or return { userId: accessTokenPayload.sub } in case of getInitialProps
 }
 ```
 
 :::caution
-Do not use the `verifySession` function here. The reason is that this will send a reply to the client in case of `TRY_REFRESH_TOKEN`, and here, we want to catch that error and send a custom reply.
+Don't use getSession or verifySession here. They might update the session tokens, and since our request interceptors don't run server-side, the updated token won't be propagated to the client side.
 :::
 
 ## 2) Doing manual refresh on the frontend
@@ -196,7 +244,7 @@ On success, `getServerSideProps` returns
 {
     // Refer to Step 1)
     // @ts-ignore
-    props: { userId: session.getUserId() }
+    props: { userId: accessTokenPayload.sub }
 }
 ```
 


### PR DESCRIPTION
## Summary of change
This PR removes getSession usage from SSR. 

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?