### PR TITLE
fix: Add a leading dot while setting the cookie domain

### DIFF
--- a/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/emailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -30,7 +30,7 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 
 ## Step 1) Set Cookie Domain in the Backend Config (only applicable for cookie based auth)
 
-You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is NOT important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -51,7 +51,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: "example.com", // or ".example.com" (they both work)
+            cookieDomain: ".example.com",
         })
     ]
 });
@@ -68,7 +68,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := "example.com" // or ".example.com" (they both work)
+	cookieDomain := ".example.com"
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
@@ -94,7 +94,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='example.com' # or ".example.com" (they both work)
+            cookie_domain='.example.com'
             # highlight-end
         )
     ]
@@ -135,7 +135,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: "example.com", // or ".example.com" (they both work)
+            cookieDomain: ".example.com",
             // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
@@ -154,7 +154,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := "example.com"  // or ".example.com" (they both work)
+	cookieDomain := ".example.com"
 	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
@@ -183,7 +183,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='example.com',  # or ".example.com" (they both work)
+            cookie_domain='.example.com',
             older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
@@ -233,7 +233,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line 
-            sessionTokenBackendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com"
         })
     ]
 });
@@ -264,7 +264,7 @@ SuperTokens.init({
     },
     recipeList: [
         Session.init({
-            sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com"
         }),
     ],
 });
@@ -283,7 +283,7 @@ supertokens.init({
     },
     recipeList: [
         supertokensSession.init({
-            sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com",
         })
     ],
 });
@@ -305,7 +305,7 @@ import SuperTokens from 'supertokens-react-native';
 
 SuperTokens.init({
     apiDomain: "...",
-    sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+    sessionTokenBackendDomain: ".example.com"
 });
 ```
 
@@ -323,7 +323,7 @@ class MainApplication: Application() {
         
         SuperTokens.Builder(this, "...")
             // highlight-next-line
-            .sessionTokenBackendDomain("example.com") // or ".example.com" (they both work)
+            .sessionTokenBackendDomain(".example.com")
             .build()
     }
 }
@@ -344,7 +344,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
             try SuperTokens.initialize(
                 apiDomain: "...",
                 // highlight-next-line
-                sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+                sessionTokenBackendDomain: ".example.com"
             )
         } catch SuperTokensError.initError(let message) {
             // TODO: Handle initialization error
@@ -368,7 +368,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
+        sessionTokenBackendDomain: ".example.com",
     );
 }
 ```

--- a/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/emailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -24,7 +24,7 @@ Sharing sessions across multiple sub domains in SuperTokens can be configured by
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
- - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `example.com` or `.example.com`.
+ - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `.example.com`.
 
 
 <PreBuiltOrCustomUISwitcher>
@@ -50,7 +50,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionTokenFrontendDomain: "example.com" // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
         })
     ]
 });
@@ -97,7 +97,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-start
-            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
             // highlight-end 
         }),
     ],
@@ -119,7 +119,7 @@ supertokens.init({
         supertokensSession.init({
             // ...
             // highlight-start
-            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
             // highlight-end
         })
     ],

--- a/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/passwordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -30,7 +30,7 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 
 ## Step 1) Set Cookie Domain in the Backend Config (only applicable for cookie based auth)
 
-You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is NOT important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -51,7 +51,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: "example.com", // or ".example.com" (they both work)
+            cookieDomain: ".example.com",
         })
     ]
 });
@@ -68,7 +68,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := "example.com" // or ".example.com" (they both work)
+	cookieDomain := ".example.com"
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
@@ -94,7 +94,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='example.com' # or ".example.com" (they both work)
+            cookie_domain='.example.com'
             # highlight-end
         )
     ]
@@ -135,7 +135,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: "example.com", // or ".example.com" (they both work)
+            cookieDomain: ".example.com",
             // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
@@ -154,7 +154,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := "example.com"  // or ".example.com" (they both work)
+	cookieDomain := ".example.com"
 	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
@@ -183,7 +183,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='example.com',  # or ".example.com" (they both work)
+            cookie_domain='.example.com',
             older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
@@ -233,7 +233,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line 
-            sessionTokenBackendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com"
         })
     ]
 });
@@ -264,7 +264,7 @@ SuperTokens.init({
     },
     recipeList: [
         Session.init({
-            sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com"
         }),
     ],
 });
@@ -283,7 +283,7 @@ supertokens.init({
     },
     recipeList: [
         supertokensSession.init({
-            sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com",
         })
     ],
 });
@@ -305,7 +305,7 @@ import SuperTokens from 'supertokens-react-native';
 
 SuperTokens.init({
     apiDomain: "...",
-    sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+    sessionTokenBackendDomain: ".example.com"
 });
 ```
 
@@ -323,7 +323,7 @@ class MainApplication: Application() {
         
         SuperTokens.Builder(this, "...")
             // highlight-next-line
-            .sessionTokenBackendDomain("example.com") // or ".example.com" (they both work)
+            .sessionTokenBackendDomain(".example.com")
             .build()
     }
 }
@@ -344,7 +344,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
             try SuperTokens.initialize(
                 apiDomain: "...",
                 // highlight-next-line
-                sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+                sessionTokenBackendDomain: ".example.com"
             )
         } catch SuperTokensError.initError(let message) {
             // TODO: Handle initialization error
@@ -368,7 +368,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
+        sessionTokenBackendDomain: ".example.com",
     );
 }
 ```

--- a/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/passwordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -24,7 +24,7 @@ Sharing sessions across multiple sub domains in SuperTokens can be configured by
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
- - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `example.com` or `.example.com`.
+ - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `.example.com`.
 
 
 <PreBuiltOrCustomUISwitcher>
@@ -50,7 +50,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionTokenFrontendDomain: "example.com" // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
         })
     ]
 });
@@ -97,7 +97,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-start
-            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
             // highlight-end 
         }),
     ],
@@ -119,7 +119,7 @@ supertokens.init({
         supertokensSession.init({
             // ...
             // highlight-start
-            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
             // highlight-end
         })
     ],

--- a/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/session/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -30,7 +30,7 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 
 ## Step 1) Set Cookie Domain in the Backend Config (only applicable for cookie based auth)
 
-You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is NOT important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -51,7 +51,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: "example.com", // or ".example.com" (they both work)
+            cookieDomain: ".example.com",
         })
     ]
 });
@@ -68,7 +68,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := "example.com" // or ".example.com" (they both work)
+	cookieDomain := ".example.com"
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
@@ -94,7 +94,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='example.com' # or ".example.com" (they both work)
+            cookie_domain='.example.com'
             # highlight-end
         )
     ]
@@ -135,7 +135,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: "example.com", // or ".example.com" (they both work)
+            cookieDomain: ".example.com",
             // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
@@ -154,7 +154,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := "example.com"  // or ".example.com" (they both work)
+	cookieDomain := ".example.com"
 	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
@@ -183,7 +183,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='example.com',  # or ".example.com" (they both work)
+            cookie_domain='.example.com',
             older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
@@ -233,7 +233,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line 
-            sessionTokenBackendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com"
         })
     ]
 });
@@ -264,7 +264,7 @@ SuperTokens.init({
     },
     recipeList: [
         Session.init({
-            sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com"
         }),
     ],
 });
@@ -283,7 +283,7 @@ supertokens.init({
     },
     recipeList: [
         supertokensSession.init({
-            sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com",
         })
     ],
 });
@@ -305,7 +305,7 @@ import SuperTokens from 'supertokens-react-native';
 
 SuperTokens.init({
     apiDomain: "...",
-    sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+    sessionTokenBackendDomain: ".example.com"
 });
 ```
 
@@ -323,7 +323,7 @@ class MainApplication: Application() {
         
         SuperTokens.Builder(this, "...")
             // highlight-next-line
-            .sessionTokenBackendDomain("example.com") // or ".example.com" (they both work)
+            .sessionTokenBackendDomain(".example.com")
             .build()
     }
 }
@@ -344,7 +344,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
             try SuperTokens.initialize(
                 apiDomain: "...",
                 // highlight-next-line
-                sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+                sessionTokenBackendDomain: ".example.com"
             )
         } catch SuperTokensError.initError(let message) {
             // TODO: Handle initialization error
@@ -368,7 +368,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
+        sessionTokenBackendDomain: ".example.com",
     );
 }
 ```

--- a/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/session/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -24,7 +24,7 @@ Sharing sessions across multiple sub domains in SuperTokens can be configured by
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
- - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `example.com` or `.example.com`.
+ - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `.example.com`.
 
 
 <PreBuiltOrCustomUISwitcher>
@@ -50,7 +50,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionTokenFrontendDomain: "example.com" // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
         })
     ]
 });
@@ -97,7 +97,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-start
-            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
             // highlight-end 
         }),
     ],
@@ -119,7 +119,7 @@ supertokens.init({
         supertokensSession.init({
             // ...
             // highlight-start
-            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
             // highlight-end
         })
     ],

--- a/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdparty/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -30,7 +30,7 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 
 ## Step 1) Set Cookie Domain in the Backend Config (only applicable for cookie based auth)
 
-You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is NOT important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -51,7 +51,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: "example.com", // or ".example.com" (they both work)
+            cookieDomain: ".example.com",
         })
     ]
 });
@@ -68,7 +68,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := "example.com" // or ".example.com" (they both work)
+	cookieDomain := ".example.com"
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
@@ -94,7 +94,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='example.com' # or ".example.com" (they both work)
+            cookie_domain='.example.com'
             # highlight-end
         )
     ]
@@ -135,7 +135,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: "example.com", // or ".example.com" (they both work)
+            cookieDomain: ".example.com",
             // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
@@ -154,7 +154,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := "example.com"  // or ".example.com" (they both work)
+	cookieDomain := ".example.com"
 	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
@@ -183,7 +183,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='example.com',  # or ".example.com" (they both work)
+            cookie_domain='.example.com',
             older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
@@ -233,7 +233,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line 
-            sessionTokenBackendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com"
         })
     ]
 });
@@ -264,7 +264,7 @@ SuperTokens.init({
     },
     recipeList: [
         Session.init({
-            sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com"
         }),
     ],
 });
@@ -283,7 +283,7 @@ supertokens.init({
     },
     recipeList: [
         supertokensSession.init({
-            sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com",
         })
     ],
 });
@@ -305,7 +305,7 @@ import SuperTokens from 'supertokens-react-native';
 
 SuperTokens.init({
     apiDomain: "...",
-    sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+    sessionTokenBackendDomain: ".example.com"
 });
 ```
 
@@ -323,7 +323,7 @@ class MainApplication: Application() {
         
         SuperTokens.Builder(this, "...")
             // highlight-next-line
-            .sessionTokenBackendDomain("example.com") // or ".example.com" (they both work)
+            .sessionTokenBackendDomain(".example.com")
             .build()
     }
 }
@@ -344,7 +344,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
             try SuperTokens.initialize(
                 apiDomain: "...",
                 // highlight-next-line
-                sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+                sessionTokenBackendDomain: ".example.com"
             )
         } catch SuperTokensError.initError(let message) {
             // TODO: Handle initialization error
@@ -368,7 +368,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
+        sessionTokenBackendDomain: ".example.com",
     );
 }
 ```

--- a/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdparty/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -24,7 +24,7 @@ Sharing sessions across multiple sub domains in SuperTokens can be configured by
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
- - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `example.com` or `.example.com`.
+ - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `.example.com`.
 
 
 <PreBuiltOrCustomUISwitcher>
@@ -50,7 +50,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionTokenFrontendDomain: "example.com" // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
         })
     ]
 });
@@ -97,7 +97,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-start
-            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
             // highlight-end 
         }),
     ],
@@ -119,7 +119,7 @@ supertokens.init({
         supertokensSession.init({
             // ...
             // highlight-start
-            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
             // highlight-end
         })
     ],

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -30,7 +30,7 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 
 ## Step 1) Set Cookie Domain in the Backend Config (only applicable for cookie based auth)
 
-You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is NOT important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -51,7 +51,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: "example.com", // or ".example.com" (they both work)
+            cookieDomain: ".example.com",
         })
     ]
 });
@@ -68,7 +68,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := "example.com" // or ".example.com" (they both work)
+	cookieDomain := ".example.com"
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
@@ -94,7 +94,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='example.com' # or ".example.com" (they both work)
+            cookie_domain='.example.com'
             # highlight-end
         )
     ]
@@ -135,7 +135,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: "example.com", // or ".example.com" (they both work)
+            cookieDomain: ".example.com",
             // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
@@ -154,7 +154,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := "example.com"  // or ".example.com" (they both work)
+	cookieDomain := ".example.com"
 	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
@@ -183,7 +183,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='example.com',  # or ".example.com" (they both work)
+            cookie_domain='.example.com',
             older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
@@ -233,7 +233,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line 
-            sessionTokenBackendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com"
         })
     ]
 });
@@ -264,7 +264,7 @@ SuperTokens.init({
     },
     recipeList: [
         Session.init({
-            sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com"
         }),
     ],
 });
@@ -283,7 +283,7 @@ supertokens.init({
     },
     recipeList: [
         supertokensSession.init({
-            sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com",
         })
     ],
 });
@@ -305,7 +305,7 @@ import SuperTokens from 'supertokens-react-native';
 
 SuperTokens.init({
     apiDomain: "...",
-    sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+    sessionTokenBackendDomain: ".example.com"
 });
 ```
 
@@ -323,7 +323,7 @@ class MainApplication: Application() {
         
         SuperTokens.Builder(this, "...")
             // highlight-next-line
-            .sessionTokenBackendDomain("example.com") // or ".example.com" (they both work)
+            .sessionTokenBackendDomain(".example.com")
             .build()
     }
 }
@@ -344,7 +344,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
             try SuperTokens.initialize(
                 apiDomain: "...",
                 // highlight-next-line
-                sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+                sessionTokenBackendDomain: ".example.com"
             )
         } catch SuperTokensError.initError(let message) {
             // TODO: Handle initialization error
@@ -368,7 +368,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
+        sessionTokenBackendDomain: ".example.com",
     );
 }
 ```

--- a/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -24,7 +24,7 @@ Sharing sessions across multiple sub domains in SuperTokens can be configured by
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
- - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `example.com` or `.example.com`.
+ - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `.example.com`.
 
 
 <PreBuiltOrCustomUISwitcher>
@@ -50,7 +50,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionTokenFrontendDomain: "example.com" // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
         })
     ]
 });
@@ -97,7 +97,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-start
-            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
             // highlight-end 
         }),
     ],
@@ -119,7 +119,7 @@ supertokens.init({
         supertokensSession.init({
             // ...
             // highlight-start
-            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
             // highlight-end
         })
     ],

--- a/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/multiple-api-endpoints.mdx
@@ -30,7 +30,7 @@ To enable use of sessions for multiple API endpoints, you need to use the `sessi
 
 ## Step 1) Set Cookie Domain in the Backend Config (only applicable for cookie based auth)
 
-You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is NOT important). So you would need to set the following:
+You need to set the `cookieDomain` value to be the common top level domain. For example, if your API endpoints are `{"api.example.com", "api2.example.com", "api3.example.com"}`, the common portion of these endpoints is `".example.com"` (The dot is important). So you would need to set the following:
 
 <BackendSDKTabs>
 <TabItem value="nodejs">
@@ -51,7 +51,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: "example.com", // or ".example.com" (they both work)
+            cookieDomain: ".example.com",
         })
     ]
 });
@@ -68,7 +68,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := "example.com" // or ".example.com" (they both work)
+	cookieDomain := ".example.com"
 
 	supertokens.Init(supertokens.TypeInput{
 		RecipeList: []supertokens.Recipe{
@@ -94,7 +94,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='example.com' # or ".example.com" (they both work)
+            cookie_domain='.example.com'
             # highlight-end
         )
     ]
@@ -135,7 +135,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            cookieDomain: "example.com", // or ".example.com" (they both work)
+            cookieDomain: ".example.com",
             // highlight-next-line
             olderCookieDomain: "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
         })
@@ -154,7 +154,7 @@ import (
 
 func main() {
 	// highlight-next-line
-	cookieDomain := "example.com"  // or ".example.com" (they both work)
+	cookieDomain := ".example.com"
 	olderCookieDomain := "" // Set to an empty string if your previous cookieDomain was unset. Otherwise, use your old cookieDomain value.
 
 	supertokens.Init(supertokens.TypeInput{
@@ -183,7 +183,7 @@ init(
     recipe_list=[
         session.init(
             # highlight-start
-            cookie_domain='example.com',  # or ".example.com" (they both work)
+            cookie_domain='.example.com',
             older_cookie_domain='' # Set to an empty string if your previous cookie_domain was unset. Otherwise, use your old cookie_domain value.
             # highlight-end
         )
@@ -233,7 +233,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line 
-            sessionTokenBackendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com"
         })
     ]
 });
@@ -264,7 +264,7 @@ SuperTokens.init({
     },
     recipeList: [
         Session.init({
-            sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com"
         }),
     ],
 });
@@ -283,7 +283,7 @@ supertokens.init({
     },
     recipeList: [
         supertokensSession.init({
-            sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
+            sessionTokenBackendDomain: ".example.com",
         })
     ],
 });
@@ -305,7 +305,7 @@ import SuperTokens from 'supertokens-react-native';
 
 SuperTokens.init({
     apiDomain: "...",
-    sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+    sessionTokenBackendDomain: ".example.com"
 });
 ```
 
@@ -323,7 +323,7 @@ class MainApplication: Application() {
         
         SuperTokens.Builder(this, "...")
             // highlight-next-line
-            .sessionTokenBackendDomain("example.com") // or ".example.com" (they both work)
+            .sessionTokenBackendDomain(".example.com")
             .build()
     }
 }
@@ -344,7 +344,7 @@ fileprivate class ApplicationDelegate: UIResponder, UIApplicationDelegate {
             try SuperTokens.initialize(
                 apiDomain: "...",
                 // highlight-next-line
-                sessionTokenBackendDomain: "example.com" // or ".example.com" (they both work)
+                sessionTokenBackendDomain: ".example.com"
             )
         } catch SuperTokensError.initError(let message) {
             // TODO: Handle initialization error
@@ -368,7 +368,7 @@ import 'package:supertokens_flutter/supertokens.dart';
 void initialiseSuperTokens() {
     SuperTokens.init(
         apiDomain: "...",
-        sessionTokenBackendDomain: "example.com", // or ".example.com" (they both work)
+        sessionTokenBackendDomain: ".example.com",
     );
 }
 ```

--- a/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/sessions/share-session-across-sub-domains.mdx
@@ -24,7 +24,7 @@ Sharing sessions across multiple sub domains in SuperTokens can be configured by
 
 Example:
  - Your app has two subdomains `abc.example.com` and `xyz.example.com`. We assume that the user logs in via `example.com`
- - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `example.com` or `.example.com`.
+ - To enable sharing sessions across `example.com`, `abc.example.com` and `xyz.example.com` the `sessionTokenFrontendDomain` attribute must be set to `.example.com`.
 
 
 <PreBuiltOrCustomUISwitcher>
@@ -50,7 +50,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-next-line
-            sessionTokenFrontendDomain: "example.com" // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
         })
     ]
 });
@@ -97,7 +97,7 @@ SuperTokens.init({
     recipeList: [
         Session.init({
             // highlight-start
-            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
             // highlight-end 
         }),
     ],
@@ -119,7 +119,7 @@ supertokens.init({
         supertokensSession.init({
             // ...
             // highlight-start
-            sessionTokenFrontendDomain: "example.com"  // or ".example.com" (they both work)
+            sessionTokenFrontendDomain: ".example.com"
             // highlight-end
         })
     ],


### PR DESCRIPTION
## Summary of change

We found that browsers don't add a leading dot if `sessionTokenFrontendDomain` lacks one, preventing cookies from being shared across subdomains. To ensure consistency, we now add a leading dot to all cookie domain configurations by default.

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
