### PR TITLE
Chore: Send logs

### DIFF
--- a/v2/src/components/httpNetworking.ts
+++ b/v2/src/components/httpNetworking.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getAnalytics } from "./utils";
+import { getAnalytics, sendSDKLogsToBackend } from "./utils";
 
 export enum HTTP_REQUEST_ERROR {
     SESSION_EXPIRED,
@@ -105,7 +105,7 @@ export async function simpleGETRequest(url: string, userConfig: any = {}, versio
     let response = await axios.get(url, userConfig);
     let data = await response.data;
     let headers = response.headers;
-    sendAnalyticsIfFrontTokenRemoved(url, frontTokenExists, headers);
+    await sendAnalyticsIfFrontTokenRemoved(url, frontTokenExists, headers);
     return { data, headers };
 }
 
@@ -125,7 +125,7 @@ export async function simplePOSTRequest(url: string, data: any, userConfig: POST
     let response = await axios.post(url, data, userConfig);
     let responseData = response.data;
     let headers = response.headers;
-    sendAnalyticsIfFrontTokenRemoved(url, frontTokenExists, headers);
+    await sendAnalyticsIfFrontTokenRemoved(url, frontTokenExists, headers);
     return { data: responseData, headers, status: response.status, statusText: response.statusText };
 }
 
@@ -145,7 +145,7 @@ export async function simplePATCHRequest(url: string, data: any, userConfig: PAT
     let response = await axios.patch(url, data, userConfig);
     let responseData = response.data;
     let headers = response.headers;
-    sendAnalyticsIfFrontTokenRemoved(url, frontTokenExists, headers);
+    await sendAnalyticsIfFrontTokenRemoved(url, frontTokenExists, headers);
     return { data: responseData, headers };
 }
 
@@ -165,7 +165,7 @@ export async function simplePUTRequest(url: string, data: any, userConfig: POSTR
     let response = await axios.put(url, data, userConfig);
     let responseData = response.data;
     let headers = response.headers;
-    sendAnalyticsIfFrontTokenRemoved(url, frontTokenExists, headers);
+    await sendAnalyticsIfFrontTokenRemoved(url, frontTokenExists, headers);
     return { data: responseData, headers };
 }
 
@@ -189,11 +189,11 @@ export async function simpleDELETERequest(url: string, userConfig: DELETERequest
     let response = await axios.delete(url, userConfig);
     let data = await response.data;
     let headers = response.headers;
-    sendAnalyticsIfFrontTokenRemoved(url, frontTokenExists, headers);
+    await sendAnalyticsIfFrontTokenRemoved(url, frontTokenExists, headers);
     return { data, headers };
 }
 
-function sendAnalyticsIfFrontTokenRemoved(url: string, frontTokenExists: boolean, headers: any) {
+async function sendAnalyticsIfFrontTokenRemoved(url: string, frontTokenExists: boolean, headers: any) {
     if (!frontTokenExists) {
         return;
     }
@@ -205,6 +205,7 @@ function sendAnalyticsIfFrontTokenRemoved(url: string, frontTokenExists: boolean
             url,
             headers
         });
+        await sendSDKLogsToBackend()
     }
 }
 

--- a/v2/src/theme/Layout/index.js
+++ b/v2/src/theme/Layout/index.js
@@ -18,6 +18,7 @@ import Head from '@docusaurus/Head';
 import { useLocation } from '@docusaurus/router';
 import './styles.css';
 import supertokens from "supertokens-website";
+import {overrideConsoleImplementation,saveSDKLogsConsoleOverride} from '../../components/utils'
 import styles from "./styles.module.css";
 
 
@@ -31,11 +32,12 @@ if (typeof window !== 'undefined') {
     API_DOMAIN = "https://dev.api.supertokens.com"
     API_BASE_PATH = "/0/auth"
   }
-
+  overrideConsoleImplementation(saveSDKLogsConsoleOverride);
   let sessionExpiredStatusCode = 401;
   supertokens.init({
     apiDomain: API_DOMAIN,
     apiBasePath: API_BASE_PATH,
+    enableDebugLogs:true,
     sessionExpiredStatusCode,
     preAPIHook: async (context) => {
       return {


### PR DESCRIPTION
## Summary of goal
Send sdk logs to the server when auth error occurs (either front_token_removed or auth_error).

## Summary of solution
Override the native console implementation

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2