### PR TITLE
fix: Resolve the potential panic error in the Go version example in implementing-deduplication.mdx.

### DIFF
--- a/v2/thirdparty/common-customizations/deduplication/implementing-deduplication.mdx
+++ b/v2/thirdparty/common-customizations/deduplication/implementing-deduplication.mdx
@@ -129,7 +129,7 @@ func main() {
 
 					resp, err := originalSignInUpPOST(provider, input, tenantId, options, userContext)
 
-					if err.Error() == "Cannot sign up as email already exists" {
+					if err != nil && err.Error() == "Cannot sign up as email already exists" {
 						// this error was thrown from our function override above.
 						// so we send a useful message to the user
 						return tpmodels.SignInUpPOSTResponse{

--- a/v2/thirdpartyemailpassword/common-customizations/deduplication/implementing-deduplication.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/deduplication/implementing-deduplication.mdx
@@ -193,7 +193,7 @@ func main() {
 
 						resp, err := originalSignInUpPOST(provider, input, tenantId, options, userContext)
 
-						if err.Error() == "Cannot sign up as email already exists" {
+						if err != nil && err.Error() == "Cannot sign up as email already exists" {
 							// this error was thrown from our function override above.
 							// so we send a useful message to the user
 							return tpmodels.SignInUpPOSTResponse{

--- a/v2/thirdpartypasswordless/common-customizations/deduplication/implementing-deduplication.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/deduplication/implementing-deduplication.mdx
@@ -205,7 +205,7 @@ func main() {
 
 						resp, err := originalSignInUpPOST(provider, input, tenantId, options, userContext)
 
-						if err.Error() == "Cannot sign up as email already exists" {
+						if err != nil && err.Error() == "Cannot sign up as email already exists" {
 							// this error was thrown from our function override above.
 							// so we send a useful message to the user
 							return tpmodels.SignInUpPOSTResponse{


### PR DESCRIPTION
## Summary of change
If we don't check the error is nil, the code will panic if there's no error in it.

```
2024/07/06 21:10:34 [Recovery] 2024/07/06 - 21:10:34 panic recovered:
runtime error: invalid memory address or nil pointer dereference
/usr/local/go/src/runtime/panic.go:261 (0x100495407)
	panicmem: panic(memoryError)
/usr/local/go/src/runtime/signal_unix.go:881 (0x1004953d4)
	sigpanic: panicmem()
/Users/da/github/xxx/server/supertokens.go:161 (0x100d09604)
	InitSuperToken.thirdPartyAPIOverride.func3.1: if err.Error() == "Cannot sign up as email already exists" {
/Users/da/go/pkg/mod/github.com/supertokens/supertokens-golang@v0.22.0/recipe/thirdparty/api/signinup.go:82 (0x100bc09bb)
	SignInUpAPI: result, err := (*apiImplementation.SignInUpPOST)(provider, input, tenantId, options, userContext)
/Users/da/go/pkg/mod/github.com/supertokens/supertokens-golang@v0.22.0/recipe/thirdparty/recipe.go:147 (0x100bc2357)
	(*Recipe).handleAPIRequest: return api.SignInUpAPI(r.APIImpl, tenantId, options, userContext)
/Users/da/go/pkg/mod/github.com/supertokens/supertokens-golang@v0.22.0/supertokens/supertokens.go:261 (0x100a4241f)
	(*superTokens).middleware.func2: apiErr := finalMatchedRecipe.HandleAPIRequest(*id, tenantId, r, dw, theirHandler.ServeHTTP, path, method, userContext)
/usr/local/go/src/net/http/server.go:2166 (0x10073db07)
	HandlerFunc.ServeHTTP: f(w, r)
```

## Related issues
N/A

## Checklist
- [x] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [x] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [x] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
N/A