### PR TITLE
docs: remove references to Rubik and font loading

### DIFF
--- a/v2/emailpassword/common-customizations/email-verification/changing-style.mdx
+++ b/v2/emailpassword/common-customizations/email-verification/changing-style.mdx
@@ -70,7 +70,7 @@ The above will result in:
 
 ### Changing fonts
 
-By default, SuperTokens loads and uses the ['Rubik'](https://fonts.google.com/specimen/Rubik) font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration. Adding `font-family` or `font` to the styles will disable the default font loading.
+By default, SuperTokens uses the Arial font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/emailpassword/common-customizations/styling/changing-style.mdx
+++ b/v2/emailpassword/common-customizations/styling/changing-style.mdx
@@ -63,7 +63,7 @@ The above will result in:
 
 ### Changing fonts
 
-By default, SuperTokens loads and uses the ['Rubik'](https://fonts.google.com/specimen/Rubik) font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration. Adding `font-family` or `font` to the styles will disable the default font loading.
+By default, SuperTokens uses the Arial font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/passwordless/common-customizations/email-verification/changing-style.mdx
+++ b/v2/passwordless/common-customizations/email-verification/changing-style.mdx
@@ -70,7 +70,7 @@ The above will result in:
 
 ### Changing fonts
 
-By default, SuperTokens loads and uses the ['Rubik'](https://fonts.google.com/specimen/Rubik) font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration. Adding `font-family` or `font` to the styles will disable the default font loading.
+By default, SuperTokens uses the Arial font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/passwordless/common-customizations/styling/changing-style.mdx
+++ b/v2/passwordless/common-customizations/styling/changing-style.mdx
@@ -62,7 +62,7 @@ The above will result in:
 
 ### Changing fonts
 
-By default, SuperTokens loads and uses the ['Rubik'](https://fonts.google.com/specimen/Rubik) font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration. Adding `font-family` or `font` to the styles will disable the default font loading.
+By default, SuperTokens uses the Arial font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/thirdparty/common-customizations/email-verification/changing-style.mdx
+++ b/v2/thirdparty/common-customizations/email-verification/changing-style.mdx
@@ -70,7 +70,7 @@ The above will result in:
 
 ### Changing fonts
 
-By default, SuperTokens loads and uses the ['Rubik'](https://fonts.google.com/specimen/Rubik) font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration. Adding `font-family` or `font` to the styles will disable the default font loading.
+By default, SuperTokens uses the Arial font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/thirdparty/common-customizations/styling/changing-style.mdx
+++ b/v2/thirdparty/common-customizations/styling/changing-style.mdx
@@ -66,7 +66,7 @@ The above will result in:
 
 ### Changing fonts
 
-By default, SuperTokens loads and uses the ['Rubik'](https://fonts.google.com/specimen/Rubik) font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration. Adding `font-family` or `font` to the styles will disable the default font loading.
+By default, SuperTokens uses the Arial font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/thirdpartyemailpassword/common-customizations/email-verification/changing-style.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/email-verification/changing-style.mdx
@@ -70,7 +70,7 @@ The above will result in:
 
 ### Changing fonts
 
-By default, SuperTokens loads and uses the ['Rubik'](https://fonts.google.com/specimen/Rubik) font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration. Adding `font-family` or `font` to the styles will disable the default font loading.
+By default, SuperTokens uses the Arial font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/thirdpartyemailpassword/common-customizations/styling/changing-style.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/styling/changing-style.mdx
@@ -61,7 +61,7 @@ The above will result in:
 
 ### Changing fonts
 
-By default, SuperTokens loads and uses the ['Rubik'](https://fonts.google.com/specimen/Rubik) font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration. Adding `font-family` or `font` to the styles will disable the default font loading.
+By default, SuperTokens uses the Arial font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/thirdpartypasswordless/common-customizations/email-verification/changing-style.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/email-verification/changing-style.mdx
@@ -70,7 +70,7 @@ The above will result in:
 
 ### Changing fonts
 
-By default, SuperTokens loads and uses the ['Rubik'](https://fonts.google.com/specimen/Rubik) font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration. Adding `font-family` or `font` to the styles will disable the default font loading.
+By default, SuperTokens uses the Arial font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">

--- a/v2/thirdpartypasswordless/common-customizations/styling/changing-style.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/styling/changing-style.mdx
@@ -61,7 +61,7 @@ The above will result in:
 
 ### Changing fonts
 
-By default, SuperTokens loads and uses the ['Rubik'](https://fonts.google.com/specimen/Rubik) font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration. Adding `font-family` or `font` to the styles will disable the default font loading.
+By default, SuperTokens uses the Arial font. The best way to override this is to add a `font-family` styling to the `container` component in the recipe configuration.
 
 <FrontendSDKTabs>
 <TabItem value="reactjs">


### PR DESCRIPTION
## Summary of change
docs: remove references to Rubik and font loading

## Related issues
- https://github.com/supertokens/supertokens-auth-react/pull/840

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?
