### PR TITLE
Use stable version of @docsearch/react

### DIFF
--- a/v2/package-lock.json
+++ b/v2/package-lock.json
@@ -8,6 +8,7 @@
       "name": "change-me",
       "version": "0.0.0",
       "dependencies": {
+        "@docsearch/react": "^3.0.0",
         "@docusaurus/core": "2.0.0-beta.3",
         "@docusaurus/preset-classic": "2.0.0-beta.3",
         "@mdx-js/react": "^1.6.21",
@@ -28,19 +29,19 @@
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.2.1.tgz",
-      "integrity": "sha512-/SLS6636Wpl7eFiX7eEy0E3wBo60sUm1qRYybJBDt1fs8reiJ1+OSy+dZgrLBfLL4mSFqRIIUHXbVp25QdZ+iw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.5.2.tgz",
+      "integrity": "sha512-DY0bhyczFSS1b/CqJlTE/nQRtnTAHl6IemIkBy0nEWnhDzRDdtdx4p5Uuk3vwAFxwEEgi1WqKwgSSMx6DpNL4A==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.2.1"
+        "@algolia/autocomplete-shared": "1.5.2"
       }
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.2.1.tgz",
-      "integrity": "sha512-Lf4PpPVgHNXm1ytrnVdrZYV7hAYSCpAI/TrebF8UC6xflPY6sKb1RL/2OfrO9On7SDjPBtNd+6MArSar5JmK0g==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.5.2.tgz",
+      "integrity": "sha512-3MRYnYQFJyovANzSX2CToS6/5cfVjbLLqFsZTKcvF3abhQzxbqwwaMBlJtt620uBUOeMzhdfasKhCc40+RHiZw==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.2.1"
+        "@algolia/autocomplete-shared": "1.5.2"
       },
       "peerDependencies": {
         "@algolia/client-search": "^4.9.1",
@@ -48,9 +49,9 @@
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.2.1.tgz",
-      "integrity": "sha512-RHCwcXAYFwDXTlomstjWRFIzOfyxtQ9KmViacPE5P5hxUSSjkmG3dAb77xdydift1PaZNbho5TNTCi5UZe0RpA=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.5.2.tgz",
+      "integrity": "sha512-ylQAYv5H0YKMfHgVWX0j0NmL8XBcAeeeVQUmppnnMtzDbDnca6CzhKj3Q8eF9cHCgcdTDdb5K+3aKyGWA0obug=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
       "version": "4.10.3",
@@ -1855,18 +1856,18 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0-alpha.37.tgz",
-      "integrity": "sha512-EUr2AhvFw+TYPrkfePjDWh3NqpJgpwM8v6n8Mf0rUnL/ThxXKsdamzfBqWCWAh+N1o+eeGqypvy+p8Fp8dZXhQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-1kkV7tkAsiuEd0shunYRByKJe3xQDG2q7wYg24SOw1nV9/2lwEd4WrUYRJC/ukGTl2/kHeFxsaUvtiOy0y6fFA=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0-alpha.37.tgz",
-      "integrity": "sha512-W/O3OfL+LLQTlGXrT8/d7ztBYKgZmDWweu9f0O/41zV6Hirzo/qZEWzr25ky8utFUcMwj1pfTHLOp1F9UCtLAQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0.tgz",
+      "integrity": "sha512-yhMacqS6TVQYoBh/o603zszIb5Bl8MIXuOc6Vy617I74pirisDzzcNh0NEaYQt50fVVR3khUbeEhUEWEWipESg==",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.2.1",
-        "@algolia/autocomplete-preset-algolia": "1.2.1",
-        "@docsearch/css": "3.0.0-alpha.37",
+        "@algolia/autocomplete-core": "1.5.2",
+        "@algolia/autocomplete-preset-algolia": "1.5.2",
+        "@docsearch/css": "3.0.0",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
@@ -14646,25 +14647,25 @@
   },
   "dependencies": {
     "@algolia/autocomplete-core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.2.1.tgz",
-      "integrity": "sha512-/SLS6636Wpl7eFiX7eEy0E3wBo60sUm1qRYybJBDt1fs8reiJ1+OSy+dZgrLBfLL4mSFqRIIUHXbVp25QdZ+iw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.5.2.tgz",
+      "integrity": "sha512-DY0bhyczFSS1b/CqJlTE/nQRtnTAHl6IemIkBy0nEWnhDzRDdtdx4p5Uuk3vwAFxwEEgi1WqKwgSSMx6DpNL4A==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.2.1"
+        "@algolia/autocomplete-shared": "1.5.2"
       }
     },
     "@algolia/autocomplete-preset-algolia": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.2.1.tgz",
-      "integrity": "sha512-Lf4PpPVgHNXm1ytrnVdrZYV7hAYSCpAI/TrebF8UC6xflPY6sKb1RL/2OfrO9On7SDjPBtNd+6MArSar5JmK0g==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.5.2.tgz",
+      "integrity": "sha512-3MRYnYQFJyovANzSX2CToS6/5cfVjbLLqFsZTKcvF3abhQzxbqwwaMBlJtt620uBUOeMzhdfasKhCc40+RHiZw==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.2.1"
+        "@algolia/autocomplete-shared": "1.5.2"
       }
     },
     "@algolia/autocomplete-shared": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.2.1.tgz",
-      "integrity": "sha512-RHCwcXAYFwDXTlomstjWRFIzOfyxtQ9KmViacPE5P5hxUSSjkmG3dAb77xdydift1PaZNbho5TNTCi5UZe0RpA=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.5.2.tgz",
+      "integrity": "sha512-ylQAYv5H0YKMfHgVWX0j0NmL8XBcAeeeVQUmppnnMtzDbDnca6CzhKj3Q8eF9cHCgcdTDdb5K+3aKyGWA0obug=="
     },
     "@algolia/cache-browser-local-storage": {
       "version": "4.10.3",
@@ -15934,18 +15935,18 @@
       }
     },
     "@docsearch/css": {
-      "version": "3.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0-alpha.37.tgz",
-      "integrity": "sha512-EUr2AhvFw+TYPrkfePjDWh3NqpJgpwM8v6n8Mf0rUnL/ThxXKsdamzfBqWCWAh+N1o+eeGqypvy+p8Fp8dZXhQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-1kkV7tkAsiuEd0shunYRByKJe3xQDG2q7wYg24SOw1nV9/2lwEd4WrUYRJC/ukGTl2/kHeFxsaUvtiOy0y6fFA=="
     },
     "@docsearch/react": {
-      "version": "3.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0-alpha.37.tgz",
-      "integrity": "sha512-W/O3OfL+LLQTlGXrT8/d7ztBYKgZmDWweu9f0O/41zV6Hirzo/qZEWzr25ky8utFUcMwj1pfTHLOp1F9UCtLAQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0.tgz",
+      "integrity": "sha512-yhMacqS6TVQYoBh/o603zszIb5Bl8MIXuOc6Vy617I74pirisDzzcNh0NEaYQt50fVVR3khUbeEhUEWEWipESg==",
       "requires": {
-        "@algolia/autocomplete-core": "1.2.1",
-        "@algolia/autocomplete-preset-algolia": "1.2.1",
-        "@docsearch/css": "3.0.0-alpha.37",
+        "@algolia/autocomplete-core": "1.5.2",
+        "@algolia/autocomplete-preset-algolia": "1.5.2",
+        "@docsearch/css": "3.0.0",
         "algoliasearch": "^4.0.0"
       }
     },

--- a/v2/package.json
+++ b/v2/package.json
@@ -17,6 +17,7 @@
     "set-up-hooks": "cp ../hooks/pre-commit ../.git/hooks/pre-commit && chmod +x ../.git/hooks/pre-commit"
   },
   "dependencies": {
+    "@docsearch/react": "^3.0.0",
     "@docusaurus/core": "2.0.0-beta.3",
     "@docusaurus/preset-classic": "2.0.0-beta.3",
     "@mdx-js/react": "^1.6.21",

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -34,6 +34,7 @@ html[data-theme="dark"] .docusaurus-highlight-code-line {
 }
 
 /* custom styles below */
+
 /* Navbar discord icon*/
 .navbar__item_discord>span>svg {
   display: none;

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -32,6 +32,7 @@
 html[data-theme="dark"] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }
+
 /* custom styles below */
 
 /* Navbar discord icon*/

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -32,7 +32,6 @@
 html[data-theme="dark"] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }
-
 /* custom styles below */
 
 /* Navbar discord icon*/

--- a/v2/src/css/custom.css
+++ b/v2/src/css/custom.css
@@ -34,7 +34,6 @@ html[data-theme="dark"] .docusaurus-highlight-code-line {
 }
 
 /* custom styles below */
-
 /* Navbar discord icon*/
 .navbar__item_discord>span>svg {
   display: none;

--- a/v2/src/theme/SearchBar/index.js
+++ b/v2/src/theme/SearchBar/index.js
@@ -22,7 +22,6 @@ import {
   useActiveDocContext,
 } from '@theme/hooks/useDocs';
 
-// trigger tests
 
 let DocSearchModal = null;
 

--- a/v2/src/theme/SearchBar/index.js
+++ b/v2/src/theme/SearchBar/index.js
@@ -22,6 +22,8 @@ import {
   useActiveDocContext,
 } from '@theme/hooks/useDocs';
 
+// trigger tests
+
 let DocSearchModal = null;
 
 function Hit({ hit, children }) {

--- a/v2/yarn.lock
+++ b/v2/yarn.lock
@@ -2,24 +2,24 @@
 # yarn lockfile v1
 
 
-"@algolia/autocomplete-core@1.2.1":
-  "integrity" "sha512-/SLS6636Wpl7eFiX7eEy0E3wBo60sUm1qRYybJBDt1fs8reiJ1+OSy+dZgrLBfLL4mSFqRIIUHXbVp25QdZ+iw=="
-  "resolved" "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.2.1.tgz"
-  "version" "1.2.1"
+"@algolia/autocomplete-core@1.5.2":
+  "integrity" "sha512-DY0bhyczFSS1b/CqJlTE/nQRtnTAHl6IemIkBy0nEWnhDzRDdtdx4p5Uuk3vwAFxwEEgi1WqKwgSSMx6DpNL4A=="
+  "resolved" "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.5.2.tgz"
+  "version" "1.5.2"
   dependencies:
-    "@algolia/autocomplete-shared" "1.2.1"
+    "@algolia/autocomplete-shared" "1.5.2"
 
-"@algolia/autocomplete-preset-algolia@1.2.1":
-  "integrity" "sha512-Lf4PpPVgHNXm1ytrnVdrZYV7hAYSCpAI/TrebF8UC6xflPY6sKb1RL/2OfrO9On7SDjPBtNd+6MArSar5JmK0g=="
-  "resolved" "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.2.1.tgz"
-  "version" "1.2.1"
+"@algolia/autocomplete-preset-algolia@1.5.2":
+  "integrity" "sha512-3MRYnYQFJyovANzSX2CToS6/5cfVjbLLqFsZTKcvF3abhQzxbqwwaMBlJtt620uBUOeMzhdfasKhCc40+RHiZw=="
+  "resolved" "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.5.2.tgz"
+  "version" "1.5.2"
   dependencies:
-    "@algolia/autocomplete-shared" "1.2.1"
+    "@algolia/autocomplete-shared" "1.5.2"
 
-"@algolia/autocomplete-shared@1.2.1":
-  "integrity" "sha512-RHCwcXAYFwDXTlomstjWRFIzOfyxtQ9KmViacPE5P5hxUSSjkmG3dAb77xdydift1PaZNbho5TNTCi5UZe0RpA=="
-  "resolved" "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.2.1.tgz"
-  "version" "1.2.1"
+"@algolia/autocomplete-shared@1.5.2":
+  "integrity" "sha512-ylQAYv5H0YKMfHgVWX0j0NmL8XBcAeeeVQUmppnnMtzDbDnca6CzhKj3Q8eF9cHCgcdTDdb5K+3aKyGWA0obug=="
+  "resolved" "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.5.2.tgz"
+  "version" "1.5.2"
 
 "@algolia/cache-browser-local-storage@4.10.3":
   "integrity" "sha512-TD1N7zg5lb56/PLjjD4bBl2eccEvVHhC7yfgFu2r9k5tf+gvbGxEZ3NhRZVKu2MObUIcEy2VR4LVLxOQu45Hlg=="
@@ -1145,19 +1145,19 @@
     "@babel/helper-validator-identifier" "^7.14.5"
     "to-fast-properties" "^2.0.0"
 
-"@docsearch/css@3.0.0-alpha.37":
-  "integrity" "sha512-EUr2AhvFw+TYPrkfePjDWh3NqpJgpwM8v6n8Mf0rUnL/ThxXKsdamzfBqWCWAh+N1o+eeGqypvy+p8Fp8dZXhQ=="
-  "resolved" "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0-alpha.37.tgz"
-  "version" "3.0.0-alpha.37"
+"@docsearch/css@3.0.0":
+  "integrity" "sha512-1kkV7tkAsiuEd0shunYRByKJe3xQDG2q7wYg24SOw1nV9/2lwEd4WrUYRJC/ukGTl2/kHeFxsaUvtiOy0y6fFA=="
+  "resolved" "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0.tgz"
+  "version" "3.0.0"
 
-"@docsearch/react@^3.0.0-alpha.36":
-  "integrity" "sha512-W/O3OfL+LLQTlGXrT8/d7ztBYKgZmDWweu9f0O/41zV6Hirzo/qZEWzr25ky8utFUcMwj1pfTHLOp1F9UCtLAQ=="
-  "resolved" "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0-alpha.37.tgz"
-  "version" "3.0.0-alpha.37"
+"@docsearch/react@^3.0.0", "@docsearch/react@^3.0.0-alpha.36":
+  "integrity" "sha512-yhMacqS6TVQYoBh/o603zszIb5Bl8MIXuOc6Vy617I74pirisDzzcNh0NEaYQt50fVVR3khUbeEhUEWEWipESg=="
+  "resolved" "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0.tgz"
+  "version" "3.0.0"
   dependencies:
-    "@algolia/autocomplete-core" "1.2.1"
-    "@algolia/autocomplete-preset-algolia" "1.2.1"
-    "@docsearch/css" "3.0.0-alpha.37"
+    "@algolia/autocomplete-core" "1.5.2"
+    "@algolia/autocomplete-preset-algolia" "1.5.2"
+    "@docsearch/css" "3.0.0"
     "algoliasearch" "^4.0.0"
 
 "@docusaurus/core@2.0.0-beta.3":


### PR DESCRIPTION
## Summary of change

The alpha version of @docsearch/react is unstable. This has been updated to a more stable version

https://www.loom.com/share/1d09115fff904bfeb5549227a27f6703


## Possible improvement

Update all Beta + Alpha dependencies

## Related issues
- Link to issue1 here
- Link to issue1 here

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2