### PR TITLE
Fix typo in rate limiting description.

### DIFF
--- a/v2/thirdpartyemailpassword/rate-limits.mdx
+++ b/v2/thirdpartyemailpassword/rate-limits.mdx
@@ -13,7 +13,7 @@ import CustomAdmonition from "/src/components/customAdmonition"
 
 ## For managed service
 
-The SuperTokens core is rate limited on a per app and per IP address basis. This means that if query the core for app1 using the same IP address very quickly, the rate limit will kick in and you will get a `429` status code back from the core. However, if you query the core using different IP addresses or for a different app, the rate limit of that won't interfere with the previous requests (that had another IP or was for another app).
+The SuperTokens core is rate limited on a per app and per IP address basis. This means that if you query the core for app1 using the same IP address very quickly, the rate limit will kick in and you will get a `429` status code back from the core. However, if you query the core using different IP addresses or for a different app, the rate limit of that won't interfere with the previous requests (that had another IP or was for another app).
 
 :::note
 To know more about rps and bursts, please [this nginx document](https://www.nginx.com/blog/rate-limiting-nginx/).


### PR DESCRIPTION
## Summary of change
Fixing a typo in the rate limiting docs.

## Checklist
- [x] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [x] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [x] Changes required to the demo apps corresponding to the docs?