### PR TITLE
fix: bump flutter SDK version based on updated docs

### DIFF
--- a/v2/emailpassword/troubleshooting/how-to-troubleshoot.mdx
+++ b/v2/emailpassword/troubleshooting/how-to-troubleshoot.mdx
@@ -273,7 +273,7 @@ Debug logs feature not yet available for iOS
 import 'package:supertokens_flutter/supertokens.dart';
 
 void main() {
-  SuperTokens.init(apiDomain: apiDomain, enableDebugLogs: true);
+  SuperTokens.init(apiDomain: "...", enableDebugLogs: true);
 }
 ```
 

--- a/v2/passwordless/troubleshooting/how-to-troubleshoot.mdx
+++ b/v2/passwordless/troubleshooting/how-to-troubleshoot.mdx
@@ -273,7 +273,7 @@ Debug logs feature not yet available for iOS
 import 'package:supertokens_flutter/supertokens.dart';
 
 void main() {
-  SuperTokens.init(apiDomain: apiDomain, enableDebugLogs: true);
+  SuperTokens.init(apiDomain: "...", enableDebugLogs: true);
 }
 ```
 

--- a/v2/session/troubleshooting/how-to-troubleshoot.mdx
+++ b/v2/session/troubleshooting/how-to-troubleshoot.mdx
@@ -273,7 +273,7 @@ Debug logs feature not yet available for iOS
 import 'package:supertokens_flutter/supertokens.dart';
 
 void main() {
-  SuperTokens.init(apiDomain: apiDomain, enableDebugLogs: true);
+  SuperTokens.init(apiDomain: "...", enableDebugLogs: true);
 }
 ```
 

--- a/v2/src/plugins/codeTypeChecking/dart_env/pubspec.lock
+++ b/v2/src/plugins/codeTypeChecking/dart_env/pubspec.lock
@@ -180,18 +180,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -220,18 +220,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mutex:
     dependency: transitive
     description:
@@ -425,10 +425,10 @@ packages:
     dependency: "direct main"
     description:
       name: supertokens_flutter
-      sha256: "0a5100c86cec0a64a3970cbbd86375ba81ffa228bf8c836261cc9889067a69cd"
+      sha256: "9ce32f3353b27a0475046c809ba8564a91cc41b5132f9d8a9c28440f02b67775"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.2"
   term_glyph:
     dependency: transitive
     description:
@@ -441,10 +441,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -465,10 +465,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: e7d5ecd604e499358c5fe35ee828c0298a320d54455e791e9dcf73486bc8d9f0
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.1.0"
+    version: "14.2.5"
   win32:
     dependency: transitive
     description:

--- a/v2/src/plugins/codeTypeChecking/dart_env/pubspec.yaml
+++ b/v2/src/plugins/codeTypeChecking/dart_env/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  supertokens_flutter: ^0.5.1
+  supertokens_flutter: ^0.6.2
   google_sign_in: ^6.1.4
   sign_in_with_apple: ^5.0.0
   dio: ^5.3.3

--- a/v2/thirdparty/troubleshooting/how-to-troubleshoot.mdx
+++ b/v2/thirdparty/troubleshooting/how-to-troubleshoot.mdx
@@ -273,7 +273,7 @@ Debug logs feature not yet available for iOS
 import 'package:supertokens_flutter/supertokens.dart';
 
 void main() {
-  SuperTokens.init(apiDomain: apiDomain, enableDebugLogs: true);
+  SuperTokens.init(apiDomain: "...", enableDebugLogs: true);
 }
 ```
 

--- a/v2/thirdpartyemailpassword/troubleshooting/how-to-troubleshoot.mdx
+++ b/v2/thirdpartyemailpassword/troubleshooting/how-to-troubleshoot.mdx
@@ -273,7 +273,7 @@ Debug logs feature not yet available for iOS
 import 'package:supertokens_flutter/supertokens.dart';
 
 void main() {
-  SuperTokens.init(apiDomain: apiDomain, enableDebugLogs: true);
+  SuperTokens.init(apiDomain: "...", enableDebugLogs: true);
 }
 ```
 

--- a/v2/thirdpartypasswordless/troubleshooting/how-to-troubleshoot.mdx
+++ b/v2/thirdpartypasswordless/troubleshooting/how-to-troubleshoot.mdx
@@ -273,7 +273,7 @@ Debug logs feature not yet available for iOS
 import 'package:supertokens_flutter/supertokens.dart';
 
 void main() {
-  SuperTokens.init(apiDomain: apiDomain, enableDebugLogs: true);
+  SuperTokens.init(apiDomain: "...", enableDebugLogs: true);
 }
 ```
 


### PR DESCRIPTION
## Summary of change

Updates the flutter SDK version to ensure that the docs pass code type check for `dart`.

## Related issues

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR