### PR TITLE
Update frontend.mdx to be compatible with React Router latest version

### DIFF
--- a/v2/thirdpartyemailpassword/pre-built-ui/setup/frontend.mdx
+++ b/v2/thirdpartyemailpassword/pre-built-ui/setup/frontend.mdx
@@ -495,22 +495,17 @@ import { getSuperTokensRoutesForReactRouterDom } from "supertokens-auth-react/ui
 ^{prebuiltuiimport}
 import * as reactRouterDom from "react-router-dom";
 
-class App extends React.Component {
-    render() {
-        return (
-            <SuperTokensWrapper>
-                <BrowserRouter>
-                    <Routes>
-                        {/*This renders the login UI on the ^{form_websiteBasePath} route*/}
-                        // highlight-next-line
-                        {getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}])}
-                        {/*Your app routes*/}
-                    </Routes>
-                </BrowserRouter>
-            </SuperTokensWrapper>
-        );
-    }
-}
+createRoot(document.getElementById('root')!).render(
+    <SuperTokensWrapper>
+      <BrowserRouter>
+        <Routes>
+        {getSuperTokensRoutesForReactRouterDom(reactRouterDom, [ThirdPartyPreBuiltUI, EmailPasswordPreBuiltUI])}
+        <Route path="/" element={<Root />} />  {/*or other routes*/}
+        </Routes>
+      </BrowserRouter>
+    </SuperTokensWrapper>
+,
+)
 ```
 
 </TabItem>


### PR DESCRIPTION
updated the docs example code to be compatible with React, React Router and Supertokens latest versions

"react": "^18.3.1",
"react-dom": "^18.3.1",
"react-router-dom": "^6.27.0",
"supertokens-auth-react": "^0.47.1"

all latest versions, as the provided example doesn't work according to supertokens/supertokens-auth-react#817 and supertokens/supertokens-auth-react#581 
