### PR TITLE
fix(#871): add pnpm command for mannual setup steps

### DIFF
--- a/v2/emailpassword/pre-built-ui/setup/frontend.mdx
+++ b/v2/emailpassword/pre-built-ui/setup/frontend.mdx
@@ -65,6 +65,13 @@ yarn add supertokens-auth-react supertokens-web-js
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add supertokens-auth-react supertokens-web-js
+```
+
+</TabItem>
 </NpmVersionOrYarnSubTabs>
 </TabItem>
 
@@ -96,6 +103,16 @@ Start by installing the SuperTokens Web SDK:
 
 ```bash
 yarn add supertokens-web-js
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+
+Start by installing the SuperTokens Web SDK:
+
+```bash
+pnpm add supertokens-web-js
 ```
 
 </TabItem>
@@ -132,6 +149,16 @@ Start by installing the SuperTokens web SDK:
 
 ```bash
 yarn add supertokens-web-js
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+
+Start by installing the SuperTokens web SDK:
+
+```bash
+pnpm add supertokens-web-js
 ```
 
 </TabItem>

--- a/v2/passwordless/pre-built-ui/setup/frontend.mdx
+++ b/v2/passwordless/pre-built-ui/setup/frontend.mdx
@@ -66,6 +66,13 @@ yarn add supertokens-auth-react supertokens-web-js
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add supertokens-auth-react supertokens-web-js
+```
+
+</TabItem>
 </NpmVersionOrYarnSubTabs>
 </TabItem>
 
@@ -97,6 +104,16 @@ Start by installing the SuperTokens Web SDK:
 
 ```bash
 yarn add supertokens-web-js
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+
+Start by installing the SuperTokens Web SDK:
+
+```bash
+pnpm add supertokens-web-js
 ```
 
 </TabItem>
@@ -133,6 +150,16 @@ Start by installing the SuperTokens web SDK:
 
 ```bash
 yarn add supertokens-web-js
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+
+Start by installing the SuperTokens web SDK:
+
+```bash
+pnpm add supertokens-web-js
 ```
 
 </TabItem>

--- a/v2/src/components/tabs/NpmVersionOrYarnSubTabs.tsx
+++ b/v2/src/components/tabs/NpmVersionOrYarnSubTabs.tsx
@@ -11,6 +11,7 @@ export default function NpmVersionOrYarnSubTabs(props: any) {
                 { label: 'Via NPM>=7', value: 'npm7+' },
                 { label: 'Via NPM6', value: 'npm6' },
                 { label: 'Via Yarn', value: 'yarn' },
+                { label: 'Via Pnpm', value: 'pnpm' },
             ]}>
             {props.children}
         </Tabs>

--- a/v2/thirdparty/pre-built-ui/setup/frontend.mdx
+++ b/v2/thirdparty/pre-built-ui/setup/frontend.mdx
@@ -64,6 +64,13 @@ yarn add supertokens-auth-react supertokens-web-js
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add supertokens-auth-react supertokens-web-js
+```
+
+</TabItem>
 </NpmVersionOrYarnSubTabs>
 </TabItem>
 
@@ -95,6 +102,16 @@ Start by installing the SuperTokens Web SDK:
 
 ```bash
 yarn add supertokens-web-js
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+
+Start by installing the SuperTokens Web SDK:
+
+```bash
+pnpm add supertokens-web-js
 ```
 
 </TabItem>
@@ -131,6 +148,16 @@ Start by installing the SuperTokens web SDK:
 
 ```bash
 yarn add supertokens-web-js
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+
+Start by installing the SuperTokens web SDK:
+
+```bash
+pnpm add supertokens-web-js
 ```
 
 </TabItem>

--- a/v2/thirdpartyemailpassword/pre-built-ui/setup/frontend.mdx
+++ b/v2/thirdpartyemailpassword/pre-built-ui/setup/frontend.mdx
@@ -64,6 +64,13 @@ yarn add supertokens-auth-react supertokens-web-js
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add supertokens-auth-react supertokens-web-js
+```
+
+</TabItem>
 </NpmVersionOrYarnSubTabs>
 </TabItem>
 
@@ -95,6 +102,16 @@ Start by installing the SuperTokens Web SDK:
 
 ```bash
 yarn add supertokens-web-js
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+
+Start by installing the SuperTokens Web SDK:
+
+```bash
+pnpm add supertokens-web-js
 ```
 
 </TabItem>
@@ -131,6 +148,16 @@ Start by installing the SuperTokens web SDK:
 
 ```bash
 yarn add supertokens-web-js
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+
+Start by installing the SuperTokens web SDK:
+
+```bash
+pnpm add supertokens-web-js
 ```
 
 </TabItem>

--- a/v2/thirdpartypasswordless/pre-built-ui/setup/frontend.mdx
+++ b/v2/thirdpartypasswordless/pre-built-ui/setup/frontend.mdx
@@ -67,6 +67,13 @@ yarn add supertokens-auth-react supertokens-web-js
 ```
 
 </TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add supertokens-auth-react supertokens-web-js
+```
+
+</TabItem>
 </NpmVersionOrYarnSubTabs>
 </TabItem>
 
@@ -98,6 +105,16 @@ Start by installing the SuperTokens Web SDK:
 
 ```bash
 yarn add supertokens-web-js
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+
+Start by installing the SuperTokens Web SDK:
+
+```bash
+pnpm add supertokens-web-js
 ```
 
 </TabItem>
@@ -134,6 +151,16 @@ Start by installing the SuperTokens web SDK:
 
 ```bash
 yarn add supertokens-web-js
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+
+Start by installing the SuperTokens web SDK:
+
+```bash
+pnpm add supertokens-web-js
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary of change
This PR adds the pnpm command for manual setup docs.

<img width="784" alt="image" src="https://github.com/user-attachments/assets/b583e26a-6ec9-4870-8f81-aa9852b1ecdd">


## Related issues
Fixes #871 

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2