### PR TITLE
fix: Add note for using react-router function with hooks

### DIFF
--- a/v2/emailpassword/common-customizations/email-verification/about.mdx
+++ b/v2/emailpassword/common-customizations/email-verification/about.mdx
@@ -172,6 +172,18 @@ function App() {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </Answer>
 
 <Answer title="No">

--- a/v2/emailpassword/common-customizations/email-verification/about.mdx
+++ b/v2/emailpassword/common-customizations/email-verification/about.mdx
@@ -175,7 +175,7 @@ function App() {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [/* Other pre built UI */ EmailVerificationPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),

--- a/v2/emailpassword/common-customizations/email-verification/about.mdx
+++ b/v2/emailpassword/common-customizations/email-verification/about.mdx
@@ -173,7 +173,7 @@ function App() {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/emailpassword/quickstart/frontend-setup.mdx
+++ b/v2/emailpassword/quickstart/frontend-setup.mdx
@@ -407,7 +407,7 @@ class App extends React.Component {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/emailpassword/quickstart/frontend-setup.mdx
+++ b/v2/emailpassword/quickstart/frontend-setup.mdx
@@ -406,6 +406,18 @@ class App extends React.Component {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </TabItem>
 
 <TabItem value="v5">

--- a/v2/mfa/email-sms-otp/otp-for-all-users.mdx
+++ b/v2/mfa/email-sms-otp/otp-for-all-users.mdx
@@ -405,7 +405,7 @@ function App() {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way
@@ -1069,7 +1069,7 @@ function App() {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/mfa/email-sms-otp/otp-for-all-users.mdx
+++ b/v2/mfa/email-sms-otp/otp-for-all-users.mdx
@@ -404,6 +404,18 @@ function App() {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </Answer>
 
 <Answer title="No">
@@ -1055,6 +1067,18 @@ function App() {
   );
 }
 ```
+
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
 
 </Answer>
 

--- a/v2/mfa/email-sms-otp/otp-for-all-users.mdx
+++ b/v2/mfa/email-sms-otp/otp-for-all-users.mdx
@@ -407,7 +407,7 @@ function App() {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [EmailPasswordPreBuiltUI, ThirdPartyPreBuiltUI, PasswordlessPreBuiltUI, MultiFactorAuthPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),
@@ -1071,7 +1071,7 @@ function App() {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [EmailPasswordPreBuiltUI, ThirdPartyPreBuiltUI, PasswordlessPreBuiltUI, MultiFactorAuthPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),

--- a/v2/mfa/legacy-method/pre-built-ui/protecting-routes.mdx
+++ b/v2/mfa/legacy-method/pre-built-ui/protecting-routes.mdx
@@ -67,3 +67,15 @@ function App() {
     );
 }
 ```
+
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::

--- a/v2/mfa/legacy-method/pre-built-ui/protecting-routes.mdx
+++ b/v2/mfa/legacy-method/pre-built-ui/protecting-routes.mdx
@@ -69,7 +69,7 @@ function App() {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/mfa/legacy-method/pre-built-ui/protecting-routes.mdx
+++ b/v2/mfa/legacy-method/pre-built-ui/protecting-routes.mdx
@@ -71,7 +71,7 @@ function App() {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [ThirdPartyPreBuiltUI, EmailPasswordPreBuiltUI, PasswordlessPreBuiltUI, MultiFactorAuthPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),

--- a/v2/mfa/legacy-method/pre-built-ui/showing-login-ui.mdx
+++ b/v2/mfa/legacy-method/pre-built-ui/showing-login-ui.mdx
@@ -205,7 +205,7 @@ function App() {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/mfa/legacy-method/pre-built-ui/showing-login-ui.mdx
+++ b/v2/mfa/legacy-method/pre-built-ui/showing-login-ui.mdx
@@ -204,3 +204,15 @@ function App() {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+

--- a/v2/mfa/legacy-method/pre-built-ui/showing-login-ui.mdx
+++ b/v2/mfa/legacy-method/pre-built-ui/showing-login-ui.mdx
@@ -207,7 +207,7 @@ function App() {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [ThirdPartyPreBuiltUI, EmailPasswordPreBuiltUI, PasswordlessPreBuiltUI, MultiFactorAuthPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),

--- a/v2/mfa/totp/totp-for-all-users.mdx
+++ b/v2/mfa/totp/totp-for-all-users.mdx
@@ -327,6 +327,18 @@ function App() {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </Answer>
 
 <Answer title="No">
@@ -1265,6 +1277,18 @@ function App() {
   );
 }
 ```
+
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
 
 </Answer>
 

--- a/v2/mfa/totp/totp-for-all-users.mdx
+++ b/v2/mfa/totp/totp-for-all-users.mdx
@@ -330,7 +330,7 @@ function App() {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDOM, [/* ... */ TOTPPreBuiltUI, MultiFactorAuthPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),
@@ -1281,7 +1281,7 @@ function App() {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDOM, [/* ... */ TOTPPreBuiltUI, MultiFactorAuthPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),

--- a/v2/mfa/totp/totp-for-all-users.mdx
+++ b/v2/mfa/totp/totp-for-all-users.mdx
@@ -328,7 +328,7 @@ function App() {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way
@@ -1279,7 +1279,7 @@ function App() {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/passwordless/common-customizations/email-verification/about.mdx
+++ b/v2/passwordless/common-customizations/email-verification/about.mdx
@@ -172,6 +172,18 @@ function App() {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </Answer>
 
 <Answer title="No">

--- a/v2/passwordless/common-customizations/email-verification/about.mdx
+++ b/v2/passwordless/common-customizations/email-verification/about.mdx
@@ -175,7 +175,7 @@ function App() {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDOM, [/* Other pre built UI */ EmailVerificationPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),

--- a/v2/passwordless/common-customizations/email-verification/about.mdx
+++ b/v2/passwordless/common-customizations/email-verification/about.mdx
@@ -173,7 +173,7 @@ function App() {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/passwordless/quickstart/frontend-setup.mdx
+++ b/v2/passwordless/quickstart/frontend-setup.mdx
@@ -432,6 +432,18 @@ class App extends React.Component {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </TabItem>
 
 <TabItem value="v5">

--- a/v2/passwordless/quickstart/frontend-setup.mdx
+++ b/v2/passwordless/quickstart/frontend-setup.mdx
@@ -433,7 +433,7 @@ class App extends React.Component {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/src/components/reusableSnippets/angularUIImplementation.tsx
+++ b/v2/src/components/reusableSnippets/angularUIImplementation.tsx
@@ -5,7 +5,6 @@ export default function AngularUIImplementation(props: PropsWithChildren<{}>) {
   return (
     <Question
       question="What type of UI are you using?"
-      persistentId="angular-ui"
     >
     {props.children}
     </Question>

--- a/v2/src/components/reusableSnippets/vueUIImplementation.tsx
+++ b/v2/src/components/reusableSnippets/vueUIImplementation.tsx
@@ -5,7 +5,6 @@ export default function VueUIImplementation(props: PropsWithChildren<{}>) {
   return (
     <Question
       question="What type of UI are you using?"
-      persistentId="vue-ui"
     >
     {props.children}
     </Question>

--- a/v2/thirdparty/common-customizations/email-verification/about.mdx
+++ b/v2/thirdparty/common-customizations/email-verification/about.mdx
@@ -172,7 +172,7 @@ function App() {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDOM, [/* Other pre built UI */ EmailVerificationPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),

--- a/v2/thirdparty/common-customizations/email-verification/about.mdx
+++ b/v2/thirdparty/common-customizations/email-verification/about.mdx
@@ -169,6 +169,18 @@ function App() {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </Answer>
 
 <Answer title="No">

--- a/v2/thirdparty/common-customizations/email-verification/about.mdx
+++ b/v2/thirdparty/common-customizations/email-verification/about.mdx
@@ -170,7 +170,7 @@ function App() {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/thirdparty/quickstart/frontend-setup.mdx
+++ b/v2/thirdparty/quickstart/frontend-setup.mdx
@@ -432,7 +432,7 @@ class App extends React.Component {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/thirdparty/quickstart/frontend-setup.mdx
+++ b/v2/thirdparty/quickstart/frontend-setup.mdx
@@ -431,6 +431,18 @@ class App extends React.Component {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </TabItem>
 
 <TabItem value="v5">

--- a/v2/thirdpartyemailpassword/common-customizations/email-verification/about.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/email-verification/about.mdx
@@ -172,7 +172,7 @@ function App() {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDOM, [/* Other pre built UI */ EmailVerificationPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),

--- a/v2/thirdpartyemailpassword/common-customizations/email-verification/about.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/email-verification/about.mdx
@@ -169,6 +169,18 @@ function App() {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </Answer>
 
 <Answer title="No">

--- a/v2/thirdpartyemailpassword/common-customizations/email-verification/about.mdx
+++ b/v2/thirdpartyemailpassword/common-customizations/email-verification/about.mdx
@@ -170,7 +170,7 @@ function App() {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/thirdpartyemailpassword/quickstart/frontend-setup.mdx
+++ b/v2/thirdpartyemailpassword/quickstart/frontend-setup.mdx
@@ -439,7 +439,7 @@ class App extends React.Component {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/thirdpartyemailpassword/quickstart/frontend-setup.mdx
+++ b/v2/thirdpartyemailpassword/quickstart/frontend-setup.mdx
@@ -438,6 +438,18 @@ class App extends React.Component {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </TabItem>
 
 <TabItem value="v5">

--- a/v2/thirdpartypasswordless/common-customizations/email-verification/about.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/email-verification/about.mdx
@@ -172,7 +172,7 @@ function App() {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDOM, [/* Other pre built UI */ EmailVerificationPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),

--- a/v2/thirdpartypasswordless/common-customizations/email-verification/about.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/email-verification/about.mdx
@@ -169,6 +169,18 @@ function App() {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </Answer>
 
 <Answer title="No">

--- a/v2/thirdpartypasswordless/common-customizations/email-verification/about.mdx
+++ b/v2/thirdpartypasswordless/common-customizations/email-verification/about.mdx
@@ -170,7 +170,7 @@ function App() {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/thirdpartypasswordless/quickstart/frontend-setup.mdx
+++ b/v2/thirdpartypasswordless/quickstart/frontend-setup.mdx
@@ -479,6 +479,18 @@ class App extends React.Component {
 }
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </TabItem>
 
 <TabItem value="v5">

--- a/v2/thirdpartypasswordless/quickstart/frontend-setup.mdx
+++ b/v2/thirdpartypasswordless/quickstart/frontend-setup.mdx
@@ -480,7 +480,7 @@ class App extends React.Component {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/unified-login/multiple-frontends-with-a-single-backend.mdx
+++ b/v2/unified-login/multiple-frontends-with-a-single-backend.mdx
@@ -469,7 +469,7 @@ class App extends React.Component {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [OAuth2ProviderPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),

--- a/v2/unified-login/multiple-frontends-with-a-single-backend.mdx
+++ b/v2/unified-login/multiple-frontends-with-a-single-backend.mdx
@@ -466,6 +466,18 @@ class App extends React.Component {
 
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </Answer>
 
 <Answer title="No">

--- a/v2/unified-login/multiple-frontends-with-a-single-backend.mdx
+++ b/v2/unified-login/multiple-frontends-with-a-single-backend.mdx
@@ -467,7 +467,7 @@ class App extends React.Component {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/unified-login/multiple-frontends-with-separate-backends.mdx
+++ b/v2/unified-login/multiple-frontends-with-separate-backends.mdx
@@ -306,7 +306,7 @@ class App extends React.Component {
 :::important
 If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
-const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [OAuth2ProviderPreBuiltUI]);
 // createBrowserRouter also works in the following way
 const router = useRoutes([
     ...routes.map(route => route.props),

--- a/v2/unified-login/multiple-frontends-with-separate-backends.mdx
+++ b/v2/unified-login/multiple-frontends-with-separate-backends.mdx
@@ -304,7 +304,7 @@ class App extends React.Component {
 ```
 
 :::important
-If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. Please see [this issue](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493) for further details.
 ```tsx
 const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
 // createBrowserRouter also works in the following way

--- a/v2/unified-login/multiple-frontends-with-separate-backends.mdx
+++ b/v2/unified-login/multiple-frontends-with-separate-backends.mdx
@@ -303,6 +303,18 @@ class App extends React.Component {
 
 ```
 
+:::important
+If you are using `useRoutes` or `createBrowserRouter` or have routes defined in a different file, use it in the following way. [Issue Reference](https://github.com/supertokens/supertokens-auth-react/issues/581#issuecomment-1246998493)
+```tsx
+const routes = getSuperTokensRoutesForReactRouterDom(reactRouterDom, [^{recipePreBuiltUINameCapitalLetters}]);
+// createBrowserRouter also works in the following way
+const router = useRoutes([
+    ...routes.map(route => route.props),
+    // Define more routes
+])
+```
+:::
+
 </Answer>
 
 <Answer title="No">


### PR DESCRIPTION
## Summary of change

This PR adds a note to all the relevant documentation that is using the `getSuperTokensRoutesForReactRouterDom` function to indicate how it can be used with hooks like `createBrowserRouter` etc.

![Screenshot 2024-12-03 at 11 32 40 AM](https://github.com/user-attachments/assets/4b3eecd6-db2c-4ae9-8d46-c0351229fa62)

## Related issues
- https://github.com/supertokens/supertokens-auth-react/issues/817
- https://github.com/supertokens/supertokens-auth-react/issues/581

## Checklist
- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v2 && MODE=production npx docusaurus build`)
- [ ] Changes required to the demo apps corresponding to the docs?