### PR TITLE
docs: Add documentation for app deletion in multi-tenancy

### DIFF
--- a/v3/docs/multi-tenancy/delete-app.mdx
+++ b/v3/docs/multi-tenancy/delete-app.mdx
@@ -18,7 +18,7 @@ Before you delete an app you need to make sure that the following requirements a
 
 ## Deleting an app using the API
 
-:::warning
+:::danger
 This operation cannot be undone. Make sure you have backed up any important data before proceeding.
 :::
 

--- a/v3/docs/multi-tenancy/delete-app.mdx
+++ b/v3/docs/multi-tenancy/delete-app.mdx
@@ -8,17 +8,17 @@ import { BackendTabs } from "/src/components/Tabs";
 
 # Delete an app from SuperTokens core
 
-You can delete an app from your SuperTokens core. This operation is irreversible and will delete all user data associated with the app.
+The following guide will show you how to delete an app from a SuperTokens Core instance. This operation is irreversible and will delete all user data associated with the app.
 
-## Requirements
+## Before you start
 
-Before deleting an app:
+Before you delete an app you need to make sure that the following requirements are met:
 - The request must originate from the public app and tenant
 - The app must not have any tenants other than the public tenant. You'll need to delete other tenants first.
 
 ## Deleting an app using the API
 
-:::caution
+:::warning
 This operation cannot be undone. Make sure you have backed up any important data before proceeding.
 :::
 

--- a/v3/docs/multi-tenancy/delete-app.mdx
+++ b/v3/docs/multi-tenancy/delete-app.mdx
@@ -1,0 +1,42 @@
+---
+title: Deleting an app
+hide_title: true
+sidebar_position: 5
+---
+
+import { BackendTabs } from "/src/components/Tabs";
+
+# Delete an app from SuperTokens core
+
+You can delete an app from your SuperTokens core. This operation is irreversible and will delete all user data associated with the app.
+
+## Requirements
+
+Before deleting an app:
+- The request must originate from the public app and tenant
+- The app must not have any tenants other than the public tenant. You'll need to delete other tenants first.
+
+## Deleting an app using the API
+
+:::caution
+This operation cannot be undone. Make sure you have backed up any important data before proceeding.
+:::
+
+To delete an app from the SuperTokens core, you can use the following cURL command:
+
+```bash
+curl --location --request POST '^{coreInfo.uri}/recipe/multitenancy/app/remove' \
+--header 'api-key: ^{coreInfo.key}' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "appId": "app1"
+}'
+```
+
+- The above command will delete the app with the appId of `app1` and all its associated tenants.
+- All user data, configuration, and tenant information associated with this app will be permanently deleted.
+- The API key used must have the necessary permissions to delete apps.
+
+:::important
+After deleting an app, make sure to update any backend services that were configured to use this app ID to prevent unexpected errors.
+:::


### PR DESCRIPTION
## Deploy Preview

https://deploy-preview-904--starlit-elf-06ee1a.netlify.app/docs/multi-tenancy/delete-app

## Issue

Fixes https://github.com/supertokens/docs/issues/892

## Summary of change

This PR adds documentation explaining how to delete an app in a multi-tenant setup.

Key additions:
- New file `docs/multi-tenancy/delete-app.mdx`
- Documents the requirements for app deletion:
  - Request must come from public app and tenant
  - App must not have any non-public tenants
- Includes cURL example for the deletion API endpoint
- Added relevant warnings about the irreversible nature of deletion

This complements the existing app creation documentation and provides users with the complete lifecycle management of apps in SuperTokens.

## Related issues

- Link to issue1 here
- Link to issue1 here

## Checklist

- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v3 && npm run build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2

