### PR TITLE
Fix Go option on example app generation form

### DIFF
--- a/v3/src/components/Forms/ExampleAppForm.tsx
+++ b/v3/src/components/Forms/ExampleAppForm.tsx
@@ -150,7 +150,7 @@ function ExampleAppFormRoot() {
                     <Select.Trigger />
                     <Select.Content>
                       <Select.Item value="node">NodeJS</Select.Item>
-                      <Select.Item value="go">Go</Select.Item>
+                      <Select.Item value="go-http">Go</Select.Item>
                       <Select.Item value="python">Python</Select.Item>
                     </Select.Content>
                   </Select.Root>


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)
Updates the auto-generated value when selected `Go` as the backend, to match the value required in the `npx create-supertokens-app` command on https://supertokens.com/docs/quickstart/example-apps/generate-example-app.

## Related issues

After generating with the existing value for Go (`go`), the following error occurs on running the command:

![image](https://github.com/user-attachments/assets/539cf9e3-93d8-4a9c-bc95-ea58bf67d22a)

Example command: 
```
npx create-supertokens-app --appname=example --recipe=emailpassword --frontend=vue --backend=go
```

Re-running after changing `go` to `go-http` fixes the issue on the command, so this change updates the form to reflect this.

ie.
```
npx create-supertokens-app --appname=example --recipe=emailpassword --frontend=vue --backend=go-http
```

## Checklist

- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v3 && npm run build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR

