### PR TITLE
Remove duplicate code snippet in angular docs

### DIFF
--- a/docs/quickstart/frontend-setup.mdx
+++ b/docs/quickstart/frontend-setup.mdx
@@ -22,7 +22,6 @@ import ReactSDKInit from "./_blocks/react-sdk-init.mdx";
 import ReactRouterV6 from "./_blocks/react-router-v6.mdx";
 import ReactNoRouter from "./_blocks/react-no-router.mdx";
 import AngularAuthComponent from "./_blocks/angular-auth-component.mdx";
-import AngularAppComponent from "./_blocks/angular-auth-component.mdx";
 import AngularRouting from "./_blocks/angular-routing.mdx";
 import VueAuthView from "./_blocks/vue-auth-view.mdx";
 import VueMainFile from "./_blocks/vue-main-file.mdx";
@@ -167,7 +166,6 @@ Run the following command in your terminal to install the package.
 
     - Initialize the `supertokens-web-js` SDK in your angular app's root component. This will provide session management across your entire application.
 
-    <AngularAppComponent />
   </FrontendPrebuiltUITabs.TabItem>
   <FrontendPrebuiltUITabs.TabItem value="vue">
     Before we initialize the `supertokens-web-js` SDK let's see how we will use it in our Vue app


### PR DESCRIPTION
## Summary of change

For the [angular docs](https://supertokens.com/docs/quickstart/frontend-setup) there's a duplicate code snippet, looking at the code it's being reimported under a different name.

## Checklist

- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v3 && npm run build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2

