### PR TITLE
feat: add error handling details in custom send email method

### DIFF
--- a/docs/platform-configuration/email-delivery.mdx
+++ b/docs/platform-configuration/email-delivery.mdx
@@ -402,7 +402,7 @@ If you call the original implementation function for `sendEmail`, it uses the se
 Using this method, you can, for example, have your custom way of sending email verification emails, but use the default or SMTP service to send the reset password emails.
 
 :::important
-There is an upper level error handler that will catch any errors that are thrown from the `sendEmail` function. It is recommended to throw an error from the `sendEmail` function in case of failures or other issues so that the error can be accordingly handled and returned to the client.
+It is recommended to throw an error from the `sendEmail` function in case of failures or other issues so that the error can be accordingly handled and returned to the client. SuperTokens has an upper level error handler that will catch any errors that are thrown from the `sendEmail` function. 
 :::
 
 ---

--- a/docs/platform-configuration/email-delivery.mdx
+++ b/docs/platform-configuration/email-delivery.mdx
@@ -401,8 +401,8 @@ If you call the original implementation function for `sendEmail`, it uses the se
 
 Using this method, you can, for example, have your custom way of sending email verification emails, but use the default or SMTP service to send the reset password emails.
 
-:::important
-It is recommended to throw an error from the `sendEmail` function in case of failures or other issues so that the error can be accordingly handled and returned to the client. SuperTokens has an upper level error handler that will catch any errors that are thrown from the `sendEmail` function. 
+:::important Error Management
+To handle failures and other types of issues in the `sendEmail` function just throw an error. The SDK catches any exception through an upper level error handler. This error is then propagated if this is through an API call or otherwise logged.
 :::
 
 ---

--- a/docs/platform-configuration/email-delivery.mdx
+++ b/docs/platform-configuration/email-delivery.mdx
@@ -401,6 +401,10 @@ If you call the original implementation function for `sendEmail`, it uses the se
 
 Using this method, you can, for example, have your custom way of sending email verification emails, but use the default or SMTP service to send the reset password emails.
 
+:::important
+There is an upper level error handler that will catch any errors that are thrown from the `sendEmail` function. It is recommended to throw an error from the `sendEmail` function in case of failures or other issues so that the error can be accordingly handled and returned to the client.
+:::
+
 ---
 
 ## Email content customization

--- a/docs/platform-configuration/sms-delivery.mdx
+++ b/docs/platform-configuration/sms-delivery.mdx
@@ -414,6 +414,10 @@ If you call the original implementation function for `sendSms`, it uses the serv
 When using this callback, you must manage sending the SMS yourself.
 :::
 
+:::important
+There is an upper level error handler that will catch any errors that are thrown from the `sendSms` function. It is recommended to throw an error from the `sendSms` function in case of failures or other issues so that the error can be accordingly handled and returned to the client.
+:::
+
 ## SMS Customization
 
 You can see the default SMS content:

--- a/docs/platform-configuration/sms-delivery.mdx
+++ b/docs/platform-configuration/sms-delivery.mdx
@@ -414,8 +414,8 @@ If you call the original implementation function for `sendSms`, it uses the serv
 When using this callback, you must manage sending the SMS yourself.
 :::
 
-:::important
-It is recommended to throw an error from the `sendSms` function in case of failures or other issues so that the error can be accordingly handled and returned to the client. SuperTokens has an upper level error handler that will catch any errors that are thrown from the `sendSms` function. 
+:::important Error Management
+To handle failures and other types of issues in the `sendSms` function just throw an error. The SDK catches any exception through an upper level error handler. This error is then propagated if this is through an API call or otherwise logged.
 :::
 
 ## SMS Customization

--- a/docs/platform-configuration/sms-delivery.mdx
+++ b/docs/platform-configuration/sms-delivery.mdx
@@ -415,7 +415,7 @@ When using this callback, you must manage sending the SMS yourself.
 :::
 
 :::important
-There is an upper level error handler that will catch any errors that are thrown from the `sendSms` function. It is recommended to throw an error from the `sendSms` function in case of failures or other issues so that the error can be accordingly handled and returned to the client.
+It is recommended to throw an error from the `sendSms` function in case of failures or other issues so that the error can be accordingly handled and returned to the client. SuperTokens has an upper level error handler that will catch any errors that are thrown from the `sendSms` function. 
 :::
 
 ## SMS Customization


### PR DESCRIPTION
## Summary of change

This PR adds some details about error handling in custom sendEmail and sendSMS methods and encourages to throw errors so that they are handled accordingly.

**[Link to change](https://docs-git-feat-add-error-handling-details-in-5a85e8-supertokens.vercel.app/docs/platform-configuration/email-delivery#custom-method)**

## Related issues

## Checklist

- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v3 && npm run build`)
- [ ] Changes required to the demo apps corresponding to the docs?

