### PR TITLE
feat: Add caution about postgres scheme designator in self hosted doc

### DIFF
--- a/docs/deployment/self-host-supertokens.mdx
+++ b/docs/deployment/self-host-supertokens.mdx
@@ -302,6 +302,10 @@ You also need to make the database listen on all the IPs of the local machine.
 Edit the `postgresql.conf` configuration file and set the value of `listen_addresses` to `0.0.0.0`.
 :::
 
+:::caution
+It is important to use the `postgresql://` scheme designator in the PostgreSQL Connection URI. Using `postgres://` will lead to a startup error.
+:::
+
 ```bash
 
 docker run \
@@ -358,6 +362,11 @@ mysql_database_name: "supertokens"
   </DatabaseTabs.TabItem>
 
   <DatabaseTabs.TabItem value="postgresql">
+
+:::caution
+It is important to use the `postgresql://` scheme designator in the PostgreSQL Connection URI. Using `postgres://` will lead to a startup error.
+:::
+
 ```yaml
 # You need to add the following to the config.yaml file.
 # The file path can be found by running the "supertokens --help" command


### PR DESCRIPTION
## Summary of change

This PR updates the self hosted docs to indicate the necessity to use the correct postgresql scheme designator. This issue was reported on [discord](https://discord.com/channels/603466164219281420/1224328457589227540/threads/1360701880522510346)

## Checklist

- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Checked for broken links? (Run `cd v3 && npm run build`)
- [ ] Changes required to the demo apps corresponding to the docs?

