### PR TITLE
Docker images should use `:tag` not `@tag`

### DIFF
--- a/docs/deployment/self-host-supertokens.mdx
+++ b/docs/deployment/self-host-supertokens.mdx
@@ -45,7 +45,7 @@ If you want to reference the old documentation, please [open this page](/docs/le
 
 
 ```bash
-docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql@latest
+docker run -p 3567:3567 -d registry.supertokens.io/supertokens/supertokens-postgresql:latest
 ```
 
 - To see all the environment variables available, please see [the README file](https://github.com/supertokens/supertokens-docker-postgresql/blob/master/README.md).
@@ -909,7 +909,7 @@ services:
       retries: 5
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql@latest
+    image: registry.supertokens.io/supertokens/supertokens-postgresql:latest
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary of change

This PR replaces `@` with `:` for Docker images; you can see examples of this syntax on https://docs.docker.com/reference/cli/docker/image/tag/

## Related issues

N/A

## Checklist

- [ ] Algolia search needs to be updated? (If there is a new sub docs project, then yes)
- [ ] Sitemap needs to be updated? (If there is a new sub docs project, then yes)
- [x] Checked for broken links? (Run `cd v3 && npm run build`)
- [ ] Changes required to the demo apps corresponding to the docs?

## Remaining TODOs for this PR

N/A

